### PR TITLE
fix: cannot edit image or see link menu if editorState is uneditable

### DIFF
--- a/lib/src/render/image/image_node_builder.dart
+++ b/lib/src/render/image/image_node_builder.dart
@@ -22,6 +22,7 @@ class ImageNodeBuilder extends NodeWidgetBuilder<Node>
       node: context.node,
       src: src,
       width: width,
+      editable: context.editorState.editable,
       alignment: _textToAlignment(align),
       onResize: (width) {
         final transaction = context.editorState.transaction

--- a/lib/src/render/rich_text/flowy_rich_text.dart
+++ b/lib/src/render/rich_text/flowy_rich_text.dart
@@ -312,7 +312,7 @@ class _FlowyRichTextState extends State<FlowyRichText> with SelectableMixin {
         tapCount += 1;
         timer?.cancel();
 
-        if (tapCount == 2) {
+        if (tapCount == 2 || !widget.editorState.editable) {
           tapCount = 0;
           safeLaunchUrl(href);
           return;

--- a/lib/src/service/render_plugin_service.dart
+++ b/lib/src/service/render_plugin_service.dart
@@ -154,7 +154,7 @@ class AppFlowyRenderPlugin extends AppFlowyRenderPluginService {
 
   Widget _buildWithActions(
       NodeWidgetBuilder builder, NodeWidgetContext context) {
-    if (builder is ActionProvider) {
+    if (builder is ActionProvider && context.editorState.editable) {
       return ChangeNotifierProvider(
         create: (_) => ActionMenuState(context.node.path),
         child: ActionMenuOverlay(

--- a/test/infra/test_editor.dart
+++ b/test/infra/test_editor.dart
@@ -28,6 +28,7 @@ class EditorWidgetTester {
     Locale locale = const Locale('en'),
     bool shrinkWrap = false,
     bool autoFocus = false,
+    bool editable = true,
   }) async {
     final app = MaterialApp(
       localizationsDelegates: const [
@@ -43,6 +44,7 @@ class EditorWidgetTester {
           editorState: _editorState,
           shrinkWrap: shrinkWrap,
           autoFocus: autoFocus,
+          editable: editable,
         ),
       ),
     );

--- a/test/render/image/image_node_builder_test.dart
+++ b/test/render/image/image_node_builder_test.dart
@@ -1,4 +1,6 @@
+import 'package:appflowy_editor/src/infra/flowy_svg.dart';
 import 'package:appflowy_editor/src/service/editor_service.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:network_image_mock/network_image_mock.dart';
@@ -25,6 +27,64 @@ void main() async {
 
         expect(editor.documentLength, 3);
         expect(find.byType(Image), findsOneWidget);
+      });
+    });
+
+    testWidgets('cannot see action menu when not editable', (tester) async {
+      mockNetworkImagesFor(() async {
+        const text = 'Welcome to Appflowy 😁';
+        const src =
+            'https://images.unsplash.com/photo-1471897488648-5eae4ac6686b?ixlib=rb-1.2.1&dl=sarah-dorweiler-QeVmJxZOv3k-unsplash.jpg&w=640&q=80&fm=jpg&crop=entropy&cs=tinysrgb';
+        final editor = tester.editor
+          ..insertTextNode(text)
+          ..insertImageNode(src)
+          ..insertTextNode(text);
+
+        await editor.startTesting(editable: false);
+        await tester.pumpAndSettle();
+
+        expect(editor.documentLength, 3);
+        expect(find.byType(Image), findsOneWidget);
+
+        final gesture =
+            await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+
+        addTearDown(gesture.removePointer);
+
+        await gesture.moveTo(tester.getCenter(find.byType(Image)));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(FlowySvg), findsNothing);
+      });
+    });
+
+    testWidgets('can see action menu when editable', (tester) async {
+      mockNetworkImagesFor(() async {
+        const text = 'Welcome to Appflowy 😁';
+        const src =
+            'https://images.unsplash.com/photo-1471897488648-5eae4ac6686b?ixlib=rb-1.2.1&dl=sarah-dorweiler-QeVmJxZOv3k-unsplash.jpg&w=640&q=80&fm=jpg&crop=entropy&cs=tinysrgb';
+        final editor = tester.editor
+          ..insertTextNode(text)
+          ..insertImageNode(src)
+          ..insertTextNode(text);
+
+        await editor.startTesting();
+        await tester.pumpAndSettle();
+
+        expect(editor.documentLength, 3);
+        expect(find.byType(Image), findsOneWidget);
+
+        final gesture =
+            await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+
+        addTearDown(gesture.removePointer);
+
+        await gesture.moveTo(tester.getCenter(find.byType(Image)));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(FlowySvg), findsWidgets);
       });
     });
 

--- a/test/render/image/image_node_widget_test.dart
+++ b/test/render/image/image_node_widget_test.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/render/image/image_node_widget.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:network_image_mock/network_image_mock.dart';
@@ -20,6 +21,7 @@ void main() async {
         final widget = ImageNodeWidget(
           src: src,
           width: 100,
+          editable: true,
           node: Node(
             type: 'image',
             children: LinkedList(),
@@ -53,6 +55,140 @@ void main() async {
         expect(imageRect.width, 100);
         expect((imageNodeRect.left - imageRect.left).abs(),
             (imageNodeRect.right - imageRect.right).abs());
+      });
+    });
+
+    testWidgets('can see resize when editable', (tester) async {
+      final imageResizeFinder = find.descendant(
+        of: find.byType(Center),
+        matching: find.byType(Container),
+      );
+
+      mockNetworkImagesFor(() async {
+        const src =
+            'https://images.unsplash.com/photo-1471897488648-5eae4ac6686b?ixlib=rb-1.2.1&dl=sarah-dorweiler-QeVmJxZOv3k-unsplash.jpg&w=640&q=80&fm=jpg&crop=entropy&cs=tinysrgb';
+
+        final widget = ImageNodeWidget(
+          src: src,
+          width: 100,
+          editable: true,
+          node: Node(
+            type: 'image',
+            children: LinkedList(),
+            attributes: {
+              'image_src': src,
+              'align': 'center',
+            },
+          ),
+          alignment: Alignment.center,
+          onResize: (width) {},
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: widget,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final imageNodeFinder = find.byType(ImageNodeWidget);
+        expect(imageNodeFinder, findsOneWidget);
+
+        ImageNodeWidgetState nodeState = tester.state<ImageNodeWidgetState>(
+          find.byType(ImageNodeWidget),
+        );
+
+        expect(nodeState.onFocus, false);
+        expect(tester.widgetList(imageResizeFinder).length, 0);
+
+        final gesture =
+            await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+
+        addTearDown(gesture.removePointer);
+
+        await gesture.moveTo(
+          tester.getCenter(
+            find.byType(Image),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        nodeState = tester.state<ImageNodeWidgetState>(
+          find.byType(ImageNodeWidget),
+        );
+
+        expect(nodeState.onFocus, true);
+        expect(tester.widgetList(imageResizeFinder).length, 2);
+      });
+    });
+
+    testWidgets('cannot see resize when not editable', (tester) async {
+      final imageResizeFinder = find.descendant(
+        of: find.byType(Center),
+        matching: find.byType(Container),
+      );
+
+      mockNetworkImagesFor(() async {
+        const src =
+            'https://images.unsplash.com/photo-1471897488648-5eae4ac6686b?ixlib=rb-1.2.1&dl=sarah-dorweiler-QeVmJxZOv3k-unsplash.jpg&w=640&q=80&fm=jpg&crop=entropy&cs=tinysrgb';
+
+        final widget = ImageNodeWidget(
+          src: src,
+          width: 100,
+          editable: false,
+          node: Node(
+            type: 'image',
+            children: LinkedList(),
+            attributes: {
+              'image_src': src,
+              'align': 'center',
+            },
+          ),
+          alignment: Alignment.center,
+          onResize: (width) {},
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: widget,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final imageNodeFinder = find.byType(ImageNodeWidget);
+        expect(imageNodeFinder, findsOneWidget);
+
+        ImageNodeWidgetState nodeState = tester.state<ImageNodeWidgetState>(
+          find.byType(ImageNodeWidget),
+        );
+
+        expect(nodeState.onFocus, false);
+        expect(tester.widgetList(imageResizeFinder).length, 0);
+
+        final gesture =
+            await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+
+        addTearDown(gesture.removePointer);
+
+        await gesture.moveTo(
+          tester.getCenter(
+            find.byType(Image),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        nodeState = tester.state<ImageNodeWidgetState>(
+          find.byType(ImageNodeWidget),
+        );
+
+        expect(nodeState.onFocus, true);
+        expect(tester.widgetList(imageResizeFinder).length, 0);
       });
     });
   });

--- a/test/render/link_menu/link_menu_test.dart
+++ b/test/render/link_menu/link_menu_test.dart
@@ -71,5 +71,36 @@ void main() async {
       expect(linkMenu, findsOneWidget);
       expect(find.text(link, findRichText: true), findsNWidgets(2));
     });
+
+    testWidgets('test tap linked text when editor not editable',
+        (tester) async {
+      const link = 'appflowy.io';
+
+      // This is a link [appflowy.io](appflowy.io)
+      final editor = tester.editor
+        ..insertTextNode(
+          null,
+          delta: Delta()
+            ..insert(
+              link,
+              attributes: {
+                BuiltInAttributeKey.href: link,
+              },
+            ),
+        );
+      await editor.startTesting(editable: false);
+      await tester.pumpAndSettle();
+
+      final finder = find.text(link, findRichText: true);
+      expect(finder, findsOneWidget);
+
+      await tester.tap(finder);
+      await tester.pumpAndSettle();
+
+      final linkMenu = find.byType(LinkMenu);
+      expect(linkMenu, findsNothing);
+
+      expect(find.text(link, findRichText: true), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
There are two changes here:
- Stop showing action menu and edge resize on image node when editor is not editable
- Stop showing link menu on tapping a link if editor is not editable (if you click a link in non-editable mode, you open it.)