### PR TITLE
fixed documentation typo issue: #35 

### DIFF
--- a/documentation/customizing.md
+++ b/documentation/customizing.md
@@ -214,7 +214,7 @@ class _NetworkImageNodeWidget extends StatefulWidget {
 }
 
 class __NetworkImageNodeWidgetState extends State<_NetworkImageNodeWidget>
-    with Selectable {
+    with SelectableMixin {
   RenderBox get _renderBox => context.findRenderObject() as RenderBox;
 
   @override


### PR DESCRIPTION
#35  Fixed documentation typo  in appflowy-editor/documentation/customisation.md file under customizing a component 
