### PR TITLE
fix: fixed image placeholder border color

### DIFF
--- a/lib/src/render/image/image_node_widget.dart
+++ b/lib/src/render/image/image_node_widget.dart
@@ -219,7 +219,7 @@ class ImageNodeWidgetState extends State<ImageNodeWidget> with SelectableMixin {
       padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
       decoration: BoxDecoration(
         borderRadius: const BorderRadius.all(Radius.circular(4.0)),
-        border: Border.all(width: 1, color: Colors.black),
+        border: Border.all(width: 1, color: Colors.grey),
       ),
       child: const Text('Could not load the image'),
     );


### PR DESCRIPTION
The image placeholder color now matches Divider's color, so it will be visible both on the light and dark themes

<img width="1552" alt="image" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/28860230/700b9969-ea84-46fe-9708-7969d4439351">

<img width="1552" alt="image" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/28860230/04d3caed-d3bb-4e9e-8b06-72f4c6200ef3">
