### PR TITLE
fix: remove action container space in mobile

### DIFF
--- a/lib/src/editor/editor_component/service/renderer/block_component_action.dart
+++ b/lib/src/editor/editor_component/service/renderer/block_component_action.dart
@@ -15,14 +15,17 @@ class BlockComponentActionContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.centerRight,
-      width: 50,
-      height: 25, // TODO: magic number, change it to the height of the block
-      color: Colors
-          .transparent, // have to set the color to transparent to make the MouseRegion work
-      child: !showActions ? const SizedBox.shrink() : actionBuilder(context),
-    );
+    return showActions
+        ? Container(
+            alignment: Alignment.centerRight,
+            width: 50,
+            height:
+                25, // TODO: magic number, change it to the height of the block
+            color: Colors
+                .transparent, // have to set the color to transparent to make the MouseRegion work
+            child: actionBuilder(context),
+          )
+        : const SizedBox.shrink();
   }
 }
 


### PR DESCRIPTION
I removed the action container when there is no action(in mobile). The previous code still occupy a space when `showActions` is false

![image](https://github.com/AppFlowy-IO/appflowy-editor/assets/14248245/6ae1f7df-eef0-4927-b124-680ccc44d5a4)
