### PR TITLE
Added code block support for conversion from  markdown to document

### DIFF
--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -12,7 +12,6 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
 
   @override
   Delta convert(String input) {
-    final document =
     final document = md.Document(
       extensionSet: md.ExtensionSet.gitHubWeb,
       encodeHtml: false,

--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -13,7 +13,7 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
   @override
   Delta convert(String input) {
     final document =
-        md.Document(extensionSet: md.ExtensionSet.gitHubWeb).parseInline(input);
+        md.Document(extensionSet: md.ExtensionSet.gitHubWeb,encodeHtml: false).parseInline(input);
     for (final node in document) {
       node.accept(this);
     }

--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -13,7 +13,8 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
   @override
   Delta convert(String input) {
     final document =
-        md.Document(extensionSet: md.ExtensionSet.gitHubWeb,encodeHtml: false).parseInline(input);
+        md.Document(extensionSet: md.ExtensionSet.gitHubWeb, encodeHtml: false)
+            .parseInline(input);
     for (final node in document) {
       node.accept(this);
     }

--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -13,8 +13,10 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
   @override
   Delta convert(String input) {
     final document =
-        md.Document(extensionSet: md.ExtensionSet.gitHubWeb, encodeHtml: false)
-            .parseInline(input);
+    final document = md.Document(
+      extensionSet: md.ExtensionSet.gitHubWeb,
+      encodeHtml: false,
+    ).parseInline(input);
     for (final node in document) {
       node.accept(this);
     }

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -89,7 +89,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       );
     } else if (line.isNotEmpty && RegExp('^-*').stringMatch(line) == line) {
       return Node(type: 'divider');
-    } else if (line.startsWith('```') && line.endsWith('```')){
+    } else if (line.startsWith('```') && line.endsWith('```')) {
       return _codeBlockNodeFromMarkdown(line, decoder);
     }
 
@@ -99,33 +99,41 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       );
     }
 
-
     return paragraphNode(
       attributes: {'delta': Delta().toJson()},
     );
   }
 
   Node _codeBlockNodeFromMarkdown(
-      String markdown, DeltaMarkdownDecoder decoder,) {
+    String markdown,
+    DeltaMarkdownDecoder decoder,
+  ) {
     String codeStartMarker = "```";
     String codeEndMarker = "```";
     String language = "";
     String codeContent = "";
     int codeStartIndex = markdown.indexOf(codeStartMarker);
     int codeEndIndex = markdown.indexOf(
-        codeEndMarker, codeStartIndex + codeStartMarker.length,);
+      codeEndMarker,
+      codeStartIndex + codeStartMarker.length,
+    );
 
     String codeBlock = markdown.substring(
-        codeStartIndex + codeStartMarker.length, codeEndIndex,);
+      codeStartIndex + codeStartMarker.length,
+      codeEndIndex,
+    );
     List<String> codeLines = codeBlock.trim().split('\n');
 
     language = codeLines[0].trim();
     List<String> codeContentLines = codeLines.sublist(1);
     codeContent = codeContentLines.join('\n');
 
-    return Node(type: 'code', attributes: {
-      'delta': decoder.convert(codeContent).toJson(),
-      'language': language
-    },);
+    return Node(
+      type: 'code',
+      attributes: {
+        'delta': decoder.convert(codeContent).toJson(),
+        'language': language
+      },
+    );
   }
 }

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -7,9 +7,44 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
   Document convert(String input) {
     final lines = input.split('\n');
     final document = Document.blank();
+    //previously
+    // for (var i = 0; i < lines.length; i++) {
+    //   document.insert([i], [_convertLineToNode(lines[i])]);
+    // }
+    int i = 0;
+    //In the below while loop we iterate through each line of the input markdown
+    //if the line starts with ``` it means there are chances it may be a code block
+    // so it iterates through all the lines(using another while loop) storing them in a
+    //string variable codeblock until it fing another ``` which marks the end of code
+    // block it then sends this to convert _convertLineToNode function .
+    // If we reach the end of lines and we still haven't found ``` thenwe will treat the
+    // line starting with ``` as a regular paragraph and continue the main while loop from
+    // a temporary pointer which stored the line number of the line with starting ```
 
-    for (var i = 0; i < lines.length; i++) {
-      document.insert([i], [_convertLineToNode(lines[i])]);
+    while (i < lines.length) {
+      if (lines[i].startsWith("```")) {
+        String codeBlock = "";
+        codeBlock += "${lines[i]}\n";
+        int tempLinePointer = i;
+        i++;
+        while (!lines[i].endsWith("```") && i < lines.length) {
+          codeBlock += lines[i];
+          i++;
+        }
+
+        if (i == lines.length) {
+          document.insert([i], [_convertLineToNode(lines[i])]);
+          i = tempLinePointer;
+          i++;
+        } else {
+          codeBlock += lines[i];
+          document.insert([tempLinePointer], [_convertLineToNode(codeBlock)]);
+          i++;
+        }
+      } else {
+        document.insert([i], [_convertLineToNode(lines[i])]);
+        i++;
+      }
     }
 
     return document;
@@ -54,6 +89,8 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       );
     } else if (line.isNotEmpty && RegExp('^-*').stringMatch(line) == line) {
       return Node(type: 'divider');
+    } else if (line.startsWith('```') && line.endsWith('```')){
+      return _codeBlockNodeFromMarkdown(line, decoder);
     }
 
     if (line.isNotEmpty) {
@@ -62,8 +99,33 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       );
     }
 
+
     return paragraphNode(
       attributes: {'delta': Delta().toJson()},
     );
+  }
+
+  Node _codeBlockNodeFromMarkdown(
+      String markdown, DeltaMarkdownDecoder decoder) {
+    String codeStartMarker = "```";
+    String codeEndMarker = "```";
+    String language = "";
+    String codeContent = "";
+    int codeStartIndex = markdown.indexOf(codeStartMarker);
+    int codeEndIndex = markdown.indexOf(
+        codeEndMarker, codeStartIndex + codeStartMarker.length);
+
+    String codeBlock = markdown.substring(
+        codeStartIndex + codeStartMarker.length, codeEndIndex);
+    List<String> codeLines = codeBlock.trim().split('\n');
+
+    language = codeLines[0].trim();
+    List<String> codeContentLines = codeLines.sublist(1);
+    codeContent = codeContentLines.join('\n');
+
+    return Node(type: 'code', attributes: {
+      'delta': decoder.convert(codeContent).toJson(),
+      'language': language
+    });
   }
 }

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -28,7 +28,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
         int tempLinePointer = i;
         i++;
         while (!lines[i].endsWith("```") && i < lines.length) {
-          codeBlock += lines[i];
+          codeBlock += "${lines[i]}\n";
           i++;
         }
 

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -7,20 +7,15 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
   Document convert(String input) {
     final lines = input.split('\n');
     final document = Document.blank();
-    //previously
-    // for (var i = 0; i < lines.length; i++) {
-    //   document.insert([i], [_convertLineToNode(lines[i])]);
-    // }
-    int i = 0;
-    //In the below while loop we iterate through each line of the input markdown
-    //if the line starts with ``` it means there are chances it may be a code block
+    // In the below while loop we iterate through each line of the input markdown
+    // if the line starts with ``` it means there are chances it may be a code block
     // so it iterates through all the lines(using another while loop) storing them in a
-    //string variable codeblock until it fing another ``` which marks the end of code
+    // string variable codeblock until it finds another ``` which marks the end of code
     // block it then sends this to convert _convertLineToNode function .
-    // If we reach the end of lines and we still haven't found ``` thenwe will treat the
+    // If we reach the end of lines and we still haven't found ``` then we will treat the
     // line starting with ``` as a regular paragraph and continue the main while loop from
     // a temporary pointer which stored the line number of the line with starting ```
-
+    int i = 0;
     while (i < lines.length) {
       if (lines[i].startsWith("```")) {
         String codeBlock = "";
@@ -104,29 +99,29 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
     );
   }
 
-  Node _codeBlockNodeFromMarkdown(
+  Node? _codeBlockNodeFromMarkdown(
     String markdown,
     DeltaMarkdownDecoder decoder,
   ) {
-    String codeStartMarker = "```";
-    String codeEndMarker = "```";
-    String language = "";
-    String codeContent = "";
-    int codeStartIndex = markdown.indexOf(codeStartMarker);
+    const codeMarker = '````';
+    int codeStartIndex = markdown.indexOf(codeMarker);
     int codeEndIndex = markdown.indexOf(
-      codeEndMarker,
-      codeStartIndex + codeStartMarker.length,
+      codeMarker,
+      codeStartIndex + codeMarker.length,
     );
 
     String codeBlock = markdown.substring(
-      codeStartIndex + codeStartMarker.length,
+      codeStartIndex + codeMarker.length,
       codeEndIndex,
     );
     List<String> codeLines = codeBlock.trim().split('\n');
 
-    language = codeLines[0].trim();
-    List<String> codeContentLines = codeLines.sublist(1);
-    codeContent = codeContentLines.join('\n');
+    if (codeLines.isEmpty) {
+      // handle error
+      return null;
+    }
+    final language = codeLines[0].trim();
+    final codeContent = codeLines.sublist(1).join('\n');
 
     return Node(
       type: 'code',

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -106,17 +106,17 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
   }
 
   Node _codeBlockNodeFromMarkdown(
-      String markdown, DeltaMarkdownDecoder decoder) {
+      String markdown, DeltaMarkdownDecoder decoder,) {
     String codeStartMarker = "```";
     String codeEndMarker = "```";
     String language = "";
     String codeContent = "";
     int codeStartIndex = markdown.indexOf(codeStartMarker);
     int codeEndIndex = markdown.indexOf(
-        codeEndMarker, codeStartIndex + codeStartMarker.length);
+        codeEndMarker, codeStartIndex + codeStartMarker.length,);
 
     String codeBlock = markdown.substring(
-        codeStartIndex + codeStartMarker.length, codeEndIndex);
+        codeStartIndex + codeStartMarker.length, codeEndIndex,);
     List<String> codeLines = codeBlock.trim().split('\n');
 
     language = codeLines[0].trim();
@@ -126,6 +126,6 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
     return Node(type: 'code', attributes: {
       'delta': decoder.convert(codeContent).toJson(),
       'language': language
-    });
+    },);
   }
 }

--- a/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
@@ -187,6 +187,17 @@ void main() async {
         }
       },
       {
+        "type": "code",
+        "data": {
+          "delta": [
+            {
+              "insert": "void main(){print('hello world');}"
+            }
+          ],
+          "language": "dart"
+        }
+      },
+      {
         "type": "paragraph",
         "data": {
           "delta": []
@@ -218,9 +229,14 @@ You can also use ***AppFlowy Editor*** as a component to build your own app.
 * Select text to trigger to the toolbar to format your notes.
 
 If you have questions or feedback, please submit an issue on Github or join the community along with 1000+ builders!
+```dart
+void main(){
+print('hello world');
+}
+```
 ''';
       final result = DocumentMarkdownDecoder().convert(markdown);
-      final data = Map<String, Object>.from(json.decode(example));
+      final data = jsonDecode(example);
       expect(result.toJson(), data);
     });
   });

--- a/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
@@ -191,7 +191,7 @@ void main() async {
         "data": {
           "delta": [
             {
-              "insert": "void main(){print('hello world');}"
+              "insert": "void main(){\\nprint('hello world');\\n}"
             }
           ],
           "language": "dart"

--- a/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
@@ -187,14 +187,122 @@ void main() async {
         }
       },
       {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      }
+    ]
+  }
+}
+''';
+    const example2 = '''
+{
+  "document": {
+    "type": "page",
+    "children": [
+      {
+        "type": "heading",
+        "data": {
+          "level": 1,
+          "delta": [
+            {
+              "insert": "Welcome to AppFlowy"
+            }
+          ]
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
         "type": "code",
         "data": {
           "delta": [
             {
-              "insert": "void main(){\\nprint('hello world');\\n}"
+              "insert": "void main(){\\nprint(\\"hello world\\");\\n}"
             }
           ],
           "language": "dart"
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
+        "type": "code",
+        "data": {
+          "delta": [
+            {
+              "insert": "void main(){\\n  print(\\"Welcome to AppFlowy\\");\\n}"
+            }
+          ],
+          "language": "dart"
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": [
+            {
+              "insert": "``````"
+            }
+          ]
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
+        "type": "code",
+        "data": {
+          "delta": [],
+          "language": "dart"
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
+        "type": "code",
+        "data": {
+          "delta": [],
+          "language": null
+        }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
+        "type": "code",
+        "data": {
+          "delta": [
+            {
+              "insert": "hello world"
+            }
+          ],
+          "language": null
         }
       },
       {
@@ -207,7 +315,6 @@ void main() async {
   }
 }
 ''';
-
     setUpAll(() {
       TestWidgetsFlutterBinding.ensureInitialized();
     });
@@ -229,14 +336,39 @@ You can also use ***AppFlowy Editor*** as a component to build your own app.
 * Select text to trigger to the toolbar to format your notes.
 
 If you have questions or feedback, please submit an issue on Github or join the community along with 1000+ builders!
-```dart
-void main(){
-print('hello world');
-}
-```
 ''';
       final result = DocumentMarkdownDecoder().convert(markdown);
       final data = jsonDecode(example);
+      expect(result.toJson(), data);
+    });
+    test('test code block', () async {
+      const markdown = '''
+# Welcome to AppFlowy
+
+```dart
+void main(){
+print("hello world");
+}
+```
+
+```dart
+void main(){
+  print("Welcome to AppFlowy");
+}
+```
+
+``````
+
+```dart
+```
+
+```
+```
+
+```hello world```
+''';
+      final result = DocumentMarkdownDecoder().convert(markdown);
+      final data = jsonDecode(example2);
       expect(result.toJson(), data);
     });
   });


### PR DESCRIPTION
This PR is related to issue https://github.com/AppFlowy-IO/AppFlowy/issues/2781 

Earlier the code block was being treated as a regular paragraph and was being returned as regular paragraph node now it is return as a node of type code.

Before -
![image](https://github.com/AppFlowy-IO/appflowy-editor/assets/71614009/29360f01-4d3f-465f-967f-e764aa7551ab)

After-
<img width="818" alt="Screenshot 2023-06-14 at 6 53 36 PM" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/71614009/47c4b238-ced3-411b-ac19-e8556e45bfa6">



