### PR TITLE
fix: tabbing whitespace at the front will convert current paragraph into heading

### DIFF
--- a/lib/src/editor/block_component/heading_block_component/heading_character_shortcut.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_character_shortcut.dart
@@ -16,7 +16,9 @@ CharacterShortcutEvent formatSignToHeading = CharacterShortcutEvent(
     (text, selection) {
       final characters = text.split('');
       // only supports heading1 to heading6 levels
-      return characters.every((element) => element == '#') &&
+      // if the characters is empty, the every function will return true directly
+      return characters.isNotEmpty &&
+          characters.every((element) => element == '#') &&
           characters.length < 7;
     },
     (text, node, delta) {

--- a/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
+++ b/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
@@ -20,11 +20,26 @@ void main() async {
 
   group('formate', () {
     const text = 'Welcome to AppFlowy Editor 🔥!';
+
+    // Before
+    // ''
+    // After
+    // ' '
+    test('mock inputting a ` ` after the >', () async {
+      testFormatCharacterShortcut(formatSignToHeading, '', 0,
+          (result, before, after) {
+        expect(result, false);
+        expect(before.delta!.toPlainText(), '');
+        expect(after.delta!.toPlainText(), '');
+        expect(after.type != HeadingBlockKeys.type, true);
+      }, text: '');
+    });
+
     // Before
     // #|Welcome to AppFlowy Editor 🔥!
     // After
     // [heading] Welcome to AppFlowy Editor 🔥!
-    test('mock inputting a ` ` after the >', () async {
+    test('mock inputting a ` ` after the #', () async {
       for (var i = 1; i <= 6; i++) {
         testFormatCharacterShortcut(
           formatSignToHeading,
@@ -44,7 +59,7 @@ void main() async {
     // #######|Welcome to AppFlowy Editor 🔥!
     // After
     // #######|Welcome to AppFlowy Editor 🔥!
-    test('mock inputting a ` ` after the >', () async {
+    test('mock inputting a ` ` after the #', () async {
       testFormatCharacterShortcut(
         formatSignToHeading,
         '#' * 7,


### PR DESCRIPTION
close #205 