### PR TITLE
chore: export keymapping file and fix outdent typo

### DIFF
--- a/lib/appflowy_editor.dart
+++ b/lib/appflowy_editor.dart
@@ -24,6 +24,7 @@ export 'src/service/scroll_service.dart';
 export 'src/service/toolbar_service.dart';
 export 'src/service/keyboard_service.dart';
 export 'src/service/input_service.dart';
+export 'src/service/shortcut_event/key_mapping.dart';
 export 'src/service/shortcut_event/keybinding.dart';
 export 'src/service/shortcut_event/shortcut_event.dart';
 export 'src/service/shortcut_event/shortcut_event_handler.dart';

--- a/lib/src/editor/block_component/base_component/outdent_command.dart
+++ b/lib/src/editor/block_component/base_component/outdent_command.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 ///   - web
 ///
 final CommandShortcutEvent outdentCommand = CommandShortcutEvent(
-  key: 'indent',
+  key: 'outdent',
   command: 'shift+tab',
   handler: _outdentCommandHandler,
 );


### PR DESCRIPTION
Adds an export of the `key_mapping.dart` file from the appflowy_editor.dart barrel file. 
Fixes a typo by changing the key of the outdent handler from `indent` to `outdent`