### PR TITLE
fix: behaviour of home and end keys on windows

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_left_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_left_command.dart
@@ -38,7 +38,7 @@ CommandShortcutEventHandler _arrowLeftCommandHandler = (editorState) {
 // move the cursor to the beginning of the block
 final CommandShortcutEvent moveCursorToBeginCommand = CommandShortcutEvent(
   key: 'move the cursor at the start of line',
-  command: 'home',
+  command: 'ctrl+arrow left,home',
   macOSCommand: 'cmd+arrow left',
   handler: _moveCursorToBeginCommandHandler,
 );

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_left_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_left_command.dart
@@ -37,8 +37,8 @@ CommandShortcutEventHandler _arrowLeftCommandHandler = (editorState) {
 // arrow left key + ctrl or command
 // move the cursor to the beginning of the block
 final CommandShortcutEvent moveCursorToBeginCommand = CommandShortcutEvent(
-  key: 'move the cursor forward one character',
-  command: 'ctrl+arrow left',
+  key: 'move the cursor at the start of line',
+  command: 'home',
   macOSCommand: 'cmd+arrow left',
   handler: _moveCursorToBeginCommandHandler,
 );
@@ -125,7 +125,7 @@ CommandShortcutEventHandler _moveCursorLeftSelectCommandHandler =
 
 // arrow left key + shift + ctrl or cmd
 final CommandShortcutEvent moveCursorBeginSelectCommand = CommandShortcutEvent(
-  key: 'move the cursor left select',
+  key: 'move the cursor left select line',
   command: 'ctrl+shift+arrow left',
   macOSCommand: 'cmd+shift+arrow left',
   handler: _moveCursorBeginSelectCommandHandler,

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_right_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_right_command.dart
@@ -38,7 +38,7 @@ CommandShortcutEventHandler _arrowRightCommandHandler = (editorState) {
 // move the cursor to the end of the block
 final CommandShortcutEvent moveCursorToEndCommand = CommandShortcutEvent(
   key: 'move the cursor to the end of line',
-  command: 'end',
+  command: 'ctrl+arrow right,end',
   macOSCommand: 'cmd+arrow right',
   handler: _moveCursorToEndCommandHandler,
 );

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_right_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/arrow_right_command.dart
@@ -37,8 +37,8 @@ CommandShortcutEventHandler _arrowRightCommandHandler = (editorState) {
 // arrow right key + ctrl or command
 // move the cursor to the end of the block
 final CommandShortcutEvent moveCursorToEndCommand = CommandShortcutEvent(
-  key: 'move the cursor backward one character',
-  command: 'ctrl+arrow right',
+  key: 'move the cursor to the end of line',
+  command: 'end',
   macOSCommand: 'cmd+arrow right',
   handler: _moveCursorToEndCommandHandler,
 );

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/end_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/end_command.dart
@@ -9,7 +9,8 @@ import 'package:flutter/material.dart';
 ///
 final CommandShortcutEvent endCommand = CommandShortcutEvent(
   key: 'scroll to the bottom of the document',
-  command: 'end',
+  command: 'ctrl+end',
+  macOSCommand: 'end',
   handler: _endCommandHandler,
 );
 
@@ -22,7 +23,7 @@ CommandShortcutEventHandler _endCommandHandler = (editorState) {
   if (scrollService == null) {
     return KeyEventResult.ignored;
   }
-  // scroll the document to the top
+  // scroll the document to the bottom
   scrollService.scrollTo(
     scrollService.maxScrollExtent,
     duration: const Duration(milliseconds: 150),

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/home_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/home_command.dart
@@ -9,7 +9,8 @@ import 'package:flutter/material.dart';
 ///
 final CommandShortcutEvent homeCommand = CommandShortcutEvent(
   key: 'scroll to the top of the document',
-  command: 'home',
+  command: 'ctrl+home',
+  macOSCommand: 'home',
   handler: _homeCommandHandler,
 );
 

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/undo_redo_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/undo_redo_command.dart
@@ -30,7 +30,7 @@ CommandShortcutEventHandler _undoCommandHandler = (editorState) {
 ///   - web
 ///
 final CommandShortcutEvent redoCommand = CommandShortcutEvent(
-  key: 'undo',
+  key: 'redo',
   command: 'ctrl+shift+z',
   macOSCommand: 'cmd+shift+z',
   handler: _redoCommandHandler,

--- a/test/new/service/shortcuts/command_shortcut_events/end_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/end_command_test.dart
@@ -44,47 +44,43 @@ void main() async {
 
       await simulateKeyDownEvent(LogicalKeyboardKey.end);
 
-      // End key on MacOS scrolls to the end of the page, since we only have one
-      // paragraph in our page, the cursor is expected to move to the end
-      // of line.
-      expect(
-        editor.selection,
-        Selection.single(path: [0], startOffset: text.length),
-      );
+      if (Platform.isWindows || Platform.isLinux) {
+        expect(
+          editor.selection,
+          Selection.single(path: [0], startOffset: text.length),
+        );
+      }
+      //On Mac OS, the document will scroll to the bottom but the selection
+      //will not be updated.
+
       await editor.dispose();
     });
 
-    testWidgets('press the end key to go to the end of page in macOs',
+    testWidgets('press the home key to go to the start of selected line',
         (tester) async {
-      final editor = tester.editor
-        ..addParagraph(
-          initialText: text,
-        );
+      final editor = tester.editor..addParagraphs(10, initialText: text);
 
-      editor.addParagraphs(10, initialText: text);
       await editor.startTesting();
 
-      expect(editor.documentRootLen, 11);
+      expect(editor.documentRootLen, 10);
 
       final selection = Selection.collapse(
-        [0],
+        [5],
         0,
       );
       await editor.updateSelection(selection);
 
       await simulateKeyDownEvent(LogicalKeyboardKey.end);
 
-      if (Platform.isMacOS) {
+      if (Platform.isWindows || Platform.isLinux) {
         expect(
           editor.selection,
-          Selection.single(path: [10], startOffset: text.length),
-        );
-      } else {
-        expect(
-          editor.selection,
-          Selection.single(path: [0], startOffset: text.length),
+          Selection.single(path: [5], startOffset: text.length),
         );
       }
+      //On Mac OS, the document will scroll to the bottom but the selection
+      //will not be updated.
+
       await editor.dispose();
     });
   });

--- a/test/new/service/shortcuts/command_shortcut_events/end_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/end_command_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io' show Platform;
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../infra/testable_editor.dart';
+import '../../../util/util.dart';
+
+// single | means the cursor
+void main() async {
+  setUpAll(() {
+    if (kDebugMode) {
+      activateLog();
+    }
+  });
+
+  tearDownAll(() {
+    if (kDebugMode) {
+      deactivateLog();
+    }
+  });
+
+  group('end - widget test', () {
+    const text = 'Welcome to AppFlowy Editor 🔥!';
+
+    // Before
+    // Welcome to AppFlowy Editor 🔥!|
+    // After
+    // |Welcome to AppFlowy Editor 🔥!
+    testWidgets('press the end key to go to the end of line if only one line',
+        (tester) async {
+      final editor = tester.editor
+        ..addParagraph(
+          initialText: text,
+        );
+      await editor.startTesting();
+
+      final selection = Selection.collapse(
+        [0],
+        0,
+      );
+      await editor.updateSelection(selection);
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.end);
+
+      // End key on MacOS scrolls to the end of the page, since we only have one
+      // paragraph in our page, the cursor is expected to move to the end
+      // of line.
+      expect(
+        editor.selection,
+        Selection.single(path: [0], startOffset: text.length),
+      );
+      await editor.dispose();
+    });
+
+    testWidgets('press the end key to go to the end of page in macOs',
+        (tester) async {
+      final editor = tester.editor
+        ..addParagraph(
+          initialText: text,
+        );
+
+      editor.addParagraphs(10, initialText: text);
+      await editor.startTesting();
+
+      expect(editor.documentRootLen, 11);
+
+      final selection = Selection.collapse(
+        [0],
+        0,
+      );
+      await editor.updateSelection(selection);
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.end);
+
+      if (Platform.isMacOS) {
+        expect(
+          editor.selection,
+          Selection.single(path: [10], startOffset: text.length),
+        );
+      } else {
+        expect(
+          editor.selection,
+          Selection.single(path: [0], startOffset: text.length),
+        );
+      }
+      await editor.dispose();
+    });
+  });
+}

--- a/test/new/service/shortcuts/command_shortcut_events/home_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/home_command_test.dart
@@ -45,47 +45,43 @@ void main() async {
 
       await simulateKeyDownEvent(LogicalKeyboardKey.home);
 
-      // Home key on MacOS goes to the top of the page, since we only have one
-      // paragraph in our page, the cursor is expected to move to the start
-      // of line.
-      expect(
-        editor.selection,
-        Selection.single(path: [0], startOffset: 0),
-      );
+      if (Platform.isWindows || Platform.isLinux) {
+        expect(
+          editor.selection,
+          Selection.single(path: [0], startOffset: 0),
+        );
+      }
+      //On Mac OS, the document will scroll to the top but the selection
+      //will not be updated.
+
       await editor.dispose();
     });
 
-    testWidgets('press the home key to go to the start of page in macOs',
+    testWidgets('press the home key to go to the start of selected line',
         (tester) async {
-      final editor = tester.editor
-        ..addParagraph(
-          initialText: text,
-        );
+      final editor = tester.editor..addParagraphs(10, initialText: text);
 
-      editor.addParagraphs(10, initialText: text);
       await editor.startTesting();
 
-      expect(editor.documentRootLen, 11);
+      expect(editor.documentRootLen, 10);
 
       final selection = Selection.collapse(
-        [10],
+        [5],
         text.length,
       );
       await editor.updateSelection(selection);
 
       await simulateKeyDownEvent(LogicalKeyboardKey.home);
 
-      if (Platform.isMacOS) {
+      if (Platform.isWindows || Platform.isLinux) {
         expect(
           editor.selection,
-          Selection.single(path: [0], startOffset: 0),
-        );
-      } else {
-        expect(
-          editor.selection,
-          Selection.single(path: [10], startOffset: 0),
+          Selection.single(path: [5], startOffset: 0),
         );
       }
+      //On Mac OS, the document will scroll to the top but the selection
+      //will not be updated.
+
       await editor.dispose();
     });
   });

--- a/test/new/service/shortcuts/command_shortcut_events/home_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/home_command_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io' show Platform;
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../infra/testable_editor.dart';
+import '../../../util/util.dart';
+
+// single | means the cursor
+void main() async {
+  setUpAll(() {
+    if (kDebugMode) {
+      activateLog();
+    }
+  });
+
+  tearDownAll(() {
+    if (kDebugMode) {
+      deactivateLog();
+    }
+  });
+
+  group('home - widget test', () {
+    const text = 'Welcome to AppFlowy Editor 🔥!';
+
+    // Before
+    // Welcome to AppFlowy Editor 🔥!|
+    // After
+    // |Welcome to AppFlowy Editor 🔥!
+    testWidgets(
+        'press the home key to go to the start of line if only one line',
+        (tester) async {
+      final editor = tester.editor
+        ..addParagraph(
+          initialText: text,
+        );
+      await editor.startTesting();
+
+      final selection = Selection.collapse(
+        [0],
+        text.length,
+      );
+      await editor.updateSelection(selection);
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.home);
+
+      // Home key on MacOS goes to the top of the page, since we only have one
+      // paragraph in our page, the cursor is expected to move to the start
+      // of line.
+      expect(
+        editor.selection,
+        Selection.single(path: [0], startOffset: 0),
+      );
+      await editor.dispose();
+    });
+
+    testWidgets('press the home key to go to the start of page in macOs',
+        (tester) async {
+      final editor = tester.editor
+        ..addParagraph(
+          initialText: text,
+        );
+
+      editor.addParagraphs(10, initialText: text);
+      await editor.startTesting();
+
+      expect(editor.documentRootLen, 11);
+
+      final selection = Selection.collapse(
+        [10],
+        text.length,
+      );
+      await editor.updateSelection(selection);
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.home);
+
+      if (Platform.isMacOS) {
+        expect(
+          editor.selection,
+          Selection.single(path: [0], startOffset: 0),
+        );
+      } else {
+        expect(
+          editor.selection,
+          Selection.single(path: [10], startOffset: 0),
+        );
+      }
+      await editor.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Default Behavior of Home and End Key on Windows/Linux

The default behavior of the home key on Windows/Linux is to navigate the cursor to the start of a line.
The default behavior of the home key on MacOS is to scroll the page to the top of the document.
Currently, we only support the MacOS behavior, this PR aims to make the cursor navigate to the start of a line on Windows/Linux.

It also introduces a new shortcut `Ctrl+Home` to scroll to the top of the document in Windows and `Ctrl+End` to scroll to the bottom of the document. 

The default behavior for MacOS is retained:
 - `Ctrl+arrow keys` to go to the beginning or end of a line.
 - `Home` and `End`keys to scroll in the document.

Solves [#2817](https://github.com/AppFlowy-IO/AppFlowy/issues/2817).

