### PR TITLE
feat: replace DeltaTextInputClient with TextInputClient

### DIFF
--- a/lib/src/editor/block_component/divider_block_component/divider_character_shortcut.dart
+++ b/lib/src/editor/block_component/divider_block_component/divider_character_shortcut.dart
@@ -10,7 +10,9 @@ import 'package:appflowy_editor/appflowy_editor.dart';
 final CharacterShortcutEvent convertMinusesToDivider = CharacterShortcutEvent(
   key: 'convert minuses to a divider',
   character: '-',
-  handler: (editorState) => _convertSyntaxToDivider(editorState, '--'),
+  handler: (editorState) async =>
+      await _convertSyntaxToDivider(editorState, '--') ||
+      await _convertSyntaxToDivider(editorState, ' —'),
 );
 
 final CharacterShortcutEvent convertStarsToDivider = CharacterShortcutEvent(

--- a/lib/src/editor/block_component/quote_block_component/quote_character_shortcut.dart
+++ b/lib/src/editor/block_component/quote_block_component/quote_character_shortcut.dart
@@ -1,6 +1,6 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 
-const _doubleQuote = '"';
+const _doubleQuotes = ['"', '“'];
 
 /// Convert '" ' to quote
 ///
@@ -15,11 +15,11 @@ CharacterShortcutEvent formatDoubleQuoteToQuote = CharacterShortcutEvent(
   handler: (editorState) async => await formatMarkdownSymbol(
     editorState,
     (node) => node.type != QuoteBlockKeys.type,
-    (_, text, __) => text == _doubleQuote,
+    (_, text, __) => _doubleQuotes.any((element) => element == text),
     (_, node, delta) => Node(
       type: 'quote',
       attributes: {
-        'delta': delta.compose(Delta()..delete(_doubleQuote.length)).toJson(),
+        'delta': delta.compose(Delta()..delete(1)).toJson(),
       },
     ),
   ),

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -14,18 +14,21 @@ Future<void> onDelete(
   }
 
   // IME
-  if (selection.isSingle && deletion.composing.isValid) {
-    final node = editorState.getNodesInSelection(selection).first;
-    final transaction = editorState.transaction;
-    final start = deletion.deletedRange.start;
-    final length = deletion.deletedRange.end - start;
-    transaction.deleteText(node, start, length);
-    await editorState.apply(transaction);
-  } else {
-    // use backspace command instead.
-    if (KeyEventResult.ignored ==
-        convertToParagraphCommand.execute(editorState)) {
-      backspaceCommand.execute(editorState);
+  if (selection.isSingle) {
+    if (deletion.composing.isValid || !deletion.deletedRange.isCollapsed) {
+      final node = editorState.getNodesInSelection(selection).first;
+      final transaction = editorState.transaction;
+      final start = deletion.deletedRange.start;
+      final length = deletion.deletedRange.end - start;
+      transaction.deleteText(node, start, length);
+      await editorState.apply(transaction);
+      return;
     }
+  }
+
+  // use backspace command instead.
+  if (KeyEventResult.ignored ==
+      convertToParagraphCommand.execute(editorState)) {
+    backspaceCommand.execute(editorState);
   }
 }

--- a/lib/src/editor/editor_component/service/ime/delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_service.dart
@@ -309,7 +309,7 @@ extension on String {
   String operator <<(int shiftAmount) => shift(shiftAmount);
   String shift(int shiftAmount) {
     if (shiftAmount > length) {
-      throw const FormatException();
+      return '';
     }
     return substring(shiftAmount);
   }

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -1,0 +1,286 @@
+import 'dart:math';
+
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/editor_component/service/ime/text_diff.dart';
+import 'package:flutter/services.dart';
+
+class NonDeltaTextInputService extends TextInputService with TextInputClient {
+  NonDeltaTextInputService({
+    required super.onInsert,
+    required super.onDelete,
+    required super.onReplace,
+    required super.onNonTextUpdate,
+    required super.onPerformAction,
+  });
+
+  @override
+  TextRange? composingTextRange;
+
+  @override
+  bool get attached => _textInputConnection?.attached ?? false;
+
+  @override
+  AutofillScope? get currentAutofillScope => throw UnimplementedError();
+
+  @override
+  TextEditingValue? currentTextEditingValue;
+
+  TextInputConnection? _textInputConnection;
+
+  @override
+  Future<void> apply(List<TextEditingDelta> deltas) async {
+    final formattedDeltas = deltas.map((e) => e.format()).toList();
+    for (final delta in formattedDeltas) {
+      _updateComposing(delta);
+
+      if (delta is TextEditingDeltaInsertion) {
+        await onInsert(delta);
+      } else if (delta is TextEditingDeltaDeletion) {
+        await onDelete(delta);
+      } else if (delta is TextEditingDeltaReplacement) {
+        await onReplace(delta);
+      } else if (delta is TextEditingDeltaNonTextUpdate) {
+        await onNonTextUpdate(delta);
+      }
+    }
+  }
+
+  @override
+  void attach(TextEditingValue textEditingValue) {
+    if (_textInputConnection == null ||
+        _textInputConnection!.attached == false) {
+      _textInputConnection = TextInput.attach(
+        this,
+        const TextInputConfiguration(
+          enableDeltaModel: false,
+          inputType: TextInputType.multiline,
+          textCapitalization: TextCapitalization.sentences,
+          inputAction: TextInputAction.newline,
+        ),
+      );
+    }
+
+    final formattedValue = textEditingValue.format();
+    _textInputConnection!
+      ..setEditingState(formattedValue)
+      ..show();
+    currentTextEditingValue = formattedValue;
+
+    Log.input.debug(
+      'attach text editing value: $textEditingValue',
+    );
+  }
+
+  @override
+  void updateEditingValue(TextEditingValue value) {
+    final deltas = getTextEditingDeltas(currentTextEditingValue, value);
+    apply(deltas);
+  }
+
+  @override
+  void close() {
+    composingTextRange = null;
+    _textInputConnection?.close();
+    _textInputConnection = null;
+  }
+
+  // TODO: support IME in linux / ios / android
+  // Only verify in macOS and Windows now.
+  @override
+  void updateCaretPosition(Size size, Matrix4 transform, Rect rect) {
+    _textInputConnection
+      ?..setEditableSizeAndTransform(size, transform)
+      ..setCaretRect(rect)
+      ..setComposingRect(rect.translate(0, rect.height));
+  }
+
+  @override
+  void connectionClosed() {}
+
+  @override
+  void insertTextPlaceholder(Size size) {}
+
+  @override
+  Future<void> performAction(TextInputAction action) async {
+    return onPerformAction(action);
+  }
+
+  @override
+  void performPrivateCommand(String action, Map<String, dynamic> data) {}
+
+  @override
+  void removeTextPlaceholder() {}
+
+  @override
+  void showAutocorrectionPromptRect(int start, int end) {}
+
+  @override
+  void showToolbar() {}
+
+  @override
+  void updateFloatingCursor(RawFloatingCursorPoint point) {}
+
+  @override
+  void didChangeInputControl(
+    TextInputControl? oldControl,
+    TextInputControl? newControl,
+  ) {}
+
+  @override
+  void performSelector(String selectorName) {
+    final currentTextEditingValue = this.currentTextEditingValue;
+    if (currentTextEditingValue == null) {
+      return;
+    }
+    // magic string from flutter callback
+    if (selectorName == 'deleteBackward:') {
+      final oldText = currentTextEditingValue.text;
+      final selection = currentTextEditingValue.selection;
+      final deleteRange = selection.isCollapsed
+          ? TextRange(
+              start: selection.start - 1,
+              end: selection.end,
+            )
+          : selection;
+      onDelete(
+        TextEditingDeltaDeletion(
+          oldText: oldText,
+          deletedRange: deleteRange,
+          selection: const TextSelection.collapsed(
+            offset: -1,
+          ), // just pass a invalid value, because we don't use this selection inside.
+          composing: TextRange.empty,
+        ),
+      );
+    }
+  }
+
+  @override
+  void insertContent(KeyboardInsertedContent content) {}
+
+  void _updateComposing(TextEditingDelta delta) {
+    if (delta is! TextEditingDeltaNonTextUpdate) {
+      if (composingTextRange != null &&
+          composingTextRange!.start != -1 &&
+          delta.composing.end != -1) {
+        composingTextRange = TextRange(
+          start: composingTextRange!.start,
+          end: delta.composing.end,
+        );
+      } else {
+        composingTextRange = delta.composing;
+      }
+    } else {
+      final textEditingValue = TextEditingValue(
+        text: delta.oldText,
+        selection: delta.selection,
+        composing: delta.composing,
+      );
+      composingTextRange = delta.composing;
+      if (currentTextEditingValue != textEditingValue.format()) {
+        attach(textEditingValue);
+      }
+    }
+  }
+}
+
+const String _whitespace = ' ';
+const int _len = 1;
+
+extension on TextEditingValue {
+  // The IME will not report the backspace button if the cursor is at the beginning of the text.
+  // Therefore, we need to add a transparent symbol at the start to ensure that we can capture the backspace event.
+  TextEditingValue format() {
+    final text = _whitespace + this.text;
+    final selection = this.selection >> _len;
+    final composing = this.composing >> _len;
+
+    return TextEditingValue(
+      text: text,
+      selection: selection,
+      composing: composing,
+    );
+  }
+}
+
+extension on TextEditingDelta {
+  TextEditingDelta format() {
+    if (this is TextEditingDeltaInsertion) {
+      return (this as TextEditingDeltaInsertion).format();
+    } else if (this is TextEditingDeltaDeletion) {
+      return (this as TextEditingDeltaDeletion).format();
+    } else if (this is TextEditingDeltaReplacement) {
+      return (this as TextEditingDeltaReplacement).format();
+    } else if (this is TextEditingDeltaNonTextUpdate) {
+      return (this as TextEditingDeltaNonTextUpdate).format();
+    }
+    throw UnimplementedError();
+  }
+}
+
+extension on TextEditingDeltaInsertion {
+  TextEditingDeltaInsertion format() => TextEditingDeltaInsertion(
+        oldText: oldText << _len,
+        textInserted: textInserted,
+        insertionOffset: insertionOffset - _len,
+        selection: selection << _len,
+        composing: composing << _len,
+      );
+}
+
+extension on TextEditingDeltaDeletion {
+  TextEditingDeltaDeletion format() => TextEditingDeltaDeletion(
+        oldText: oldText << _len,
+        deletedRange: deletedRange << _len,
+        selection: selection << _len,
+        composing: composing << _len,
+      );
+}
+
+extension on TextEditingDeltaReplacement {
+  TextEditingDeltaReplacement format() => TextEditingDeltaReplacement(
+        oldText: oldText << _len,
+        replacementText: replacementText,
+        replacedRange: replacedRange << _len,
+        selection: selection << _len,
+        composing: composing << _len,
+      );
+}
+
+extension on TextEditingDeltaNonTextUpdate {
+  TextEditingDeltaNonTextUpdate format() => TextEditingDeltaNonTextUpdate(
+        oldText: oldText << _len,
+        selection: selection << _len,
+        composing: composing << _len,
+      );
+}
+
+extension on TextSelection {
+  TextSelection operator <<(int shiftAmount) => shift(-shiftAmount);
+  TextSelection operator >>(int shiftAmount) => shift(shiftAmount);
+  TextSelection shift(int shiftAmount) => TextSelection(
+        baseOffset: max(0, baseOffset + shiftAmount),
+        extentOffset: max(0, extentOffset + shiftAmount),
+      );
+}
+
+extension on TextRange {
+  TextRange operator <<(int shiftAmount) => shift(-shiftAmount);
+  TextRange operator >>(int shiftAmount) => shift(shiftAmount);
+  TextRange shift(int shiftAmount) => !isValid
+      ? this
+      : TextRange(
+          start: max(0, start + shiftAmount),
+          end: max(0, end + shiftAmount),
+        );
+}
+
+extension on String {
+  String operator <<(int shiftAmount) => shift(shiftAmount);
+  String shift(int shiftAmount) {
+    if (shiftAmount > length) {
+      return '';
+    }
+    return substring(shiftAmount);
+  }
+}

--- a/lib/src/editor/editor_component/service/ime/text_diff.dart
+++ b/lib/src/editor/editor_component/service/ime/text_diff.dart
@@ -1,0 +1,106 @@
+// https://github.com/singerdmx/flutter-quill/blob/master/lib/src/utils/delta.dart
+
+import 'dart:math' as math;
+
+import 'package:flutter/services.dart';
+
+// Diff between two texts - old text and new text
+class Diff {
+  Diff(this.start, this.deleted, this.inserted);
+
+  // Start index in old text at which changes begin.
+  final int start;
+
+  /// The deleted text
+  final String deleted;
+
+  // The inserted text
+  final String inserted;
+
+  @override
+  String toString() {
+    return 'Diff[$start, "$deleted", "$inserted"]';
+  }
+}
+
+/* Get diff operation between old text and new text */
+Diff getDiff(String oldText, String newText, int cursorPosition) {
+  var end = oldText.length;
+  final delta = newText.length - end;
+  for (final limit = math.max(0, cursorPosition - delta);
+      end > limit && oldText[end - 1] == newText[end + delta - 1];
+      end--) {}
+  var start = 0;
+  for (final startLimit = cursorPosition - math.max(0, delta);
+      start < startLimit && oldText[start] == newText[start];
+      start++) {}
+  final deleted = (start >= end) ? '' : oldText.substring(start, end);
+  final inserted = newText.substring(start, end + delta);
+  return Diff(start, deleted, inserted);
+}
+
+List<TextEditingDelta> getTextEditingDeltas(
+  TextEditingValue? oldValue,
+  TextEditingValue newValue,
+) {
+  if (oldValue == null) {
+    return [
+      TextEditingDeltaNonTextUpdate(
+        oldText: newValue.text,
+        selection: newValue.selection,
+        composing: newValue.composing,
+      ),
+    ];
+  }
+  final currentText = oldValue.text;
+  final diff = getDiff(
+    currentText,
+    newValue.text,
+    newValue.selection.extentOffset,
+  );
+  if (diff.inserted.isNotEmpty && diff.deleted.isEmpty) {
+    return [
+      TextEditingDeltaInsertion(
+        oldText: currentText,
+        textInserted: diff.inserted,
+        insertionOffset: diff.start,
+        selection: newValue.selection,
+        composing: newValue.composing,
+      )
+    ];
+  } else if (diff.inserted.isEmpty && diff.deleted.isNotEmpty) {
+    return [
+      TextEditingDeltaDeletion(
+        oldText: currentText,
+        selection: newValue.selection,
+        composing: newValue.composing,
+        deletedRange: TextRange(
+          start: diff.start,
+          end: diff.start + diff.deleted.length,
+        ),
+      ),
+    ];
+  } else if (diff.inserted.isNotEmpty && diff.deleted.isNotEmpty) {
+    return [
+      TextEditingDeltaReplacement(
+        oldText: currentText,
+        selection: newValue.selection,
+        composing: newValue.composing,
+        replacementText: diff.inserted,
+        replacedRange: TextRange(
+          start: diff.start,
+          end: diff.start + diff.deleted.length,
+        ),
+      ),
+    ];
+  } else if (diff.inserted.isEmpty && diff.deleted.isEmpty) {
+    return [
+      TextEditingDeltaNonTextUpdate(
+        oldText: newValue.text,
+        selection: newValue.selection,
+        composing: newValue.composing,
+      ),
+    ];
+  }
+  throw UnsupportedError('Unknown diff: $diff');
+}

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/editor_component/service/ime/non_delta_input_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -54,7 +55,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
     editorState.service.selectionService
         .registerGestureInterceptor(interceptor);
 
-    textInputService = DeltaTextInputService(
+    textInputService = NonDeltaTextInputService(
       onInsert: (insertion) async => await onInsert(
         insertion,
         editorState,


### PR DESCRIPTION
`DeltaTextInputClient` has different behavior on different platforms, making it hard to maintain the state. Therefore, I'm trying to replace it with `TextInputClient` and implement the diff myself.