### PR TITLE
fix: add underline syntax parser

### DIFF
--- a/lib/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart
+++ b/lib/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart
@@ -1,12 +1,13 @@
 import 'package:markdown/markdown.dart' as md;
 
 class UnderlineInlineSyntax extends md.InlineSyntax {
-  UnderlineInlineSyntax() : super('<u>(.*)<\/u>');
+  UnderlineInlineSyntax() : super('<u>(.*)</u>');
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
     final text = parser.source.substring(match.start + 3, match.end - 4);
-    parser.addNode(md.Element('u', [md.Text(text)]));
+    List<md.Node> nestedNodes = md.InlineParser(text, parser.document).parse();
+    parser.addNode(md.Element('u', nestedNodes));
     return true;
   }
 }

--- a/lib/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart
+++ b/lib/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart
@@ -5,7 +5,7 @@ class UnderlineInlineSyntax extends md.InlineSyntax {
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
-    final text = parser.source.substring(match.start + 3, match.end - 4);
+    final text = match.group(1) ?? '';
     List<md.Node> nestedNodes = md.InlineParser(text, parser.document).parse();
     parser.addNode(md.Element('u', nestedNodes));
     return true;

--- a/lib/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart
+++ b/lib/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart
@@ -1,0 +1,12 @@
+import 'package:markdown/markdown.dart' as md;
+
+class UnderlineInlineSyntax extends md.InlineSyntax {
+  UnderlineInlineSyntax() : super('<u>(.*)<\/u>');
+
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    final text = parser.source.substring(match.start + 3, match.end - 4);
+    parser.addNode(md.Element('u', [md.Text(text)]));
+    return true;
+  }
+}

--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:appflowy_editor/src/core/document/attributes.dart';
 import 'package:appflowy_editor/src/core/document/text_delta.dart';
 import 'package:appflowy_editor/src/core/legacy/built_in_attribute_keys.dart';
+import 'package:appflowy_editor/src/plugins/markdown/decoder/custom_syntaxes/underline_syntax.dart';
 import 'package:markdown/markdown.dart' as md;
 
 class DeltaMarkdownDecoder extends Converter<String, Delta>
@@ -12,8 +13,12 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
 
   @override
   Delta convert(String input) {
+    final inlineSyntaxes = [
+      UnderlineInlineSyntax(),
+    ];
     final document = md.Document(
       extensionSet: md.ExtensionSet.gitHubWeb,
+      inlineSyntaxes: inlineSyntaxes,
       encodeHtml: false,
     ).parseInline(input);
     for (final node in document) {
@@ -49,6 +54,8 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
       _attributes[BuiltInAttributeKey.strikethrough] = true;
     } else if (element.tag == 'a') {
       _attributes[BuiltInAttributeKey.href] = element.attributes['href'];
+    } else if (element.tag == 'u') {
+      _attributes[BuiltInAttributeKey.underline] = true;
     }
   }
 
@@ -63,6 +70,8 @@ class DeltaMarkdownDecoder extends Converter<String, Delta>
       _attributes.remove(BuiltInAttributeKey.strikethrough);
     } else if (element.tag == 'a') {
       _attributes.remove(BuiltInAttributeKey.href);
+    } else if (element.tag == 'u') {
+      _attributes.remove(BuiltInAttributeKey.underline);
     }
   }
 }

--- a/test/plugins/markdown/decoder/delta_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/delta_markdown_decoder_test.dart
@@ -90,25 +90,12 @@ void main() async {
       final delta = Delta(
         operations: [
           TextInsert(
-            '<u>',
-            attributes: {
-              BuiltInAttributeKey.italic: true,
-              BuiltInAttributeKey.bold: true,
-            },
-          ),
-          TextInsert(
             'Welcome',
             attributes: {
               BuiltInAttributeKey.code: true,
               BuiltInAttributeKey.italic: true,
               BuiltInAttributeKey.bold: true,
-            },
-          ),
-          TextInsert(
-            '</u>',
-            attributes: {
-              BuiltInAttributeKey.italic: true,
-              BuiltInAttributeKey.bold: true,
+              BuiltInAttributeKey.underline: true,
             },
           ),
           TextInsert(' '),


### PR DESCRIPTION
The underline tag is not detected correctly, this PR introduces a syntax parser for underline tag, additionally keeping open a possibility to add more custom parsers