### PR TITLE
fix: desktop tooltips incorrect

### DIFF
--- a/lib/src/editor/toolbar/desktop/items/format_toolbar_items.dart
+++ b/lib/src/editor/toolbar/desktop/items/format_toolbar_items.dart
@@ -18,7 +18,7 @@ final List<ToolbarItem> markdownFormatItems = [
     id: 'editor.italic',
     name: 'italic',
     tooltip:
-        '${AppFlowyEditorLocalizations.current.bold}${shortcutTooltips('⌘ + I', 'CTRL + I', 'CTRL + I')}',
+        '${AppFlowyEditorLocalizations.current.italic}${shortcutTooltips('⌘ + I', 'CTRL + I', 'CTRL + I')}',
   ),
   _FormatToolbarItem(
     id: 'editor.strikethrough',

--- a/lib/src/editor/toolbar/desktop/items/heading_toolbar_items.dart
+++ b/lib/src/editor/toolbar/desktop/items/heading_toolbar_items.dart
@@ -20,15 +20,7 @@ class _HeadingToolbarItem extends ToolbarItem {
             return IconItemWidget(
               iconName: 'toolbar/h$level',
               isHighlight: isHighlight,
-              tooltip: (() {
-                if (level == 1) {
-                  return AppFlowyEditorLocalizations.current.heading1;
-                } else if (level == 2) {
-                  return AppFlowyEditorLocalizations.current.heading2;
-                } else {
-                  return AppFlowyEditorLocalizations.current.heading3;
-                }
-              }()),
+              tooltip: levelToTooltips(level),
               onPressed: () => editorState.formatNode(
                 selection,
                 (node) => node.copyWith(
@@ -46,4 +38,15 @@ class _HeadingToolbarItem extends ToolbarItem {
             );
           },
         );
+
+  static String levelToTooltips(int level) {
+    if (level == 1) {
+      return AppFlowyEditorLocalizations.current.heading1;
+    } else if (level == 2) {
+      return AppFlowyEditorLocalizations.current.heading2;
+    } else if (level == 3) {
+      return AppFlowyEditorLocalizations.current.heading3;
+    }
+    return '';
+  }
 }

--- a/lib/src/editor/toolbar/desktop/items/heading_toolbar_items.dart
+++ b/lib/src/editor/toolbar/desktop/items/heading_toolbar_items.dart
@@ -20,7 +20,15 @@ class _HeadingToolbarItem extends ToolbarItem {
             return IconItemWidget(
               iconName: 'toolbar/h$level',
               isHighlight: isHighlight,
-              tooltip: AppFlowyEditorLocalizations.current.heading1,
+              tooltip: (() {
+                if (level == 1) {
+                  return AppFlowyEditorLocalizations.current.heading1;
+                } else if (level == 2) {
+                  return AppFlowyEditorLocalizations.current.heading2;
+                } else {
+                  return AppFlowyEditorLocalizations.current.heading3;
+                }
+              }()),
               onPressed: () => editorState.formatNode(
                 selection,
                 (node) => node.copyWith(


### PR DESCRIPTION
While implementing the editor into my app, I noticed the desktop tooltips were incorrect:
![SCR-20230628-ljdv](https://github.com/AppFlowy-IO/appflowy-editor/assets/64292655/a737ae14-d9b4-40ac-b58b-3641b49df0df)
![SCR-20230628-ljff](https://github.com/AppFlowy-IO/appflowy-editor/assets/64292655/189384f5-368c-4362-b5c9-797e6d30304d)
![SCR-20230628-ljgs](https://github.com/AppFlowy-IO/appflowy-editor/assets/64292655/cedb864a-842e-4981-b64e-173f8664b6d2)

As seen above, H2 and H3 still had the tooltip of H1, and the italics option had the tooltip of "bold". This is also reflected in the official AppFlowy app, but is a very quick and simple fix :D