### PR TITLE
feat: support customizing the block icon

### DIFF
--- a/lib/src/editor/block_component/base_component/block_icon_builder.dart
+++ b/lib/src/editor/block_component/base_component/block_icon_builder.dart
@@ -1,0 +1,4 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+
+typedef BlockIconBuilder = Widget Function(BuildContext context, Node node);

--- a/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
+++ b/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/block_component/base_component/block_icon_builder.dart';
 import 'package:flutter/material.dart';
 
 class BulletedListBlockKeys {
@@ -25,10 +26,13 @@ Node bulletedListNode({
 class BulletedListBlockComponentBuilder extends BlockComponentBuilder {
   BulletedListBlockComponentBuilder({
     this.configuration = const BlockComponentConfiguration(),
+    this.iconBuilder,
   });
 
   @override
   final BlockComponentConfiguration configuration;
+
+  final BlockIconBuilder? iconBuilder;
 
   @override
   BlockComponentWidget build(BlockComponentContext blockComponentContext) {
@@ -37,6 +41,7 @@ class BulletedListBlockComponentBuilder extends BlockComponentBuilder {
       key: node.key,
       node: node,
       configuration: configuration,
+      iconBuilder: iconBuilder,
       showActions: showActions(node),
       actionBuilder: (context, state) => actionBuilder(
         blockComponentContext,
@@ -56,7 +61,10 @@ class BulletedListBlockComponentWidget extends BlockComponentStatefulWidget {
     super.showActions,
     super.actionBuilder,
     super.configuration = const BlockComponentConfiguration(),
+    this.iconBuilder,
   });
+
+  final BlockIconBuilder? iconBuilder;
 
   @override
   State<BulletedListBlockComponentWidget> createState() =>
@@ -92,10 +100,12 @@ class _BulletedListBlockComponentWidgetState
         mainAxisAlignment: MainAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          _BulletedListIcon(
-            node: widget.node,
-            textStyle: textStyle,
-          ),
+          widget.iconBuilder != null
+              ? widget.iconBuilder!(context, node)
+              : _BulletedListIcon(
+                  node: widget.node,
+                  textStyle: textStyle,
+                ),
           Flexible(
             child: FlowyRichText(
               key: forwardKey,

--- a/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
+++ b/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
@@ -1,5 +1,7 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/block_component/base_component/block_icon_builder.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class NumberedListBlockKeys {
   const NumberedListBlockKeys._();
@@ -31,10 +33,13 @@ Node numberedListNode({
 class NumberedListBlockComponentBuilder extends BlockComponentBuilder {
   NumberedListBlockComponentBuilder({
     this.configuration = const BlockComponentConfiguration(),
+    this.iconBuilder,
   });
 
   @override
   final BlockComponentConfiguration configuration;
+
+  final BlockIconBuilder? iconBuilder;
 
   @override
   BlockComponentWidget build(BlockComponentContext blockComponentContext) {
@@ -43,6 +48,7 @@ class NumberedListBlockComponentBuilder extends BlockComponentBuilder {
       key: node.key,
       node: node,
       configuration: configuration,
+      iconBuilder: iconBuilder,
       showActions: showActions(node),
       actionBuilder: (context, state) => actionBuilder(
         blockComponentContext,
@@ -62,7 +68,10 @@ class NumberedListBlockComponentWidget extends BlockComponentStatefulWidget {
     super.showActions,
     super.actionBuilder,
     super.configuration = const BlockComponentConfiguration(),
+    this.iconBuilder,
   });
+
+  final BlockIconBuilder? iconBuilder;
 
   @override
   State<NumberedListBlockComponentWidget> createState() =>
@@ -98,7 +107,12 @@ class _NumberedListBlockComponentWidgetState
         mainAxisAlignment: MainAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          defaultIcon(),
+          widget.iconBuilder != null
+              ? widget.iconBuilder!(context, node)
+              : _NumberedListIcon(
+                  node: node,
+                  textStyle: textStyle,
+                ),
           Flexible(
             child: FlowyRichText(
               key: forwardKey,
@@ -128,10 +142,22 @@ class _NumberedListBlockComponentWidgetState
 
     return child;
   }
+}
 
-  Widget defaultIcon() {
+class _NumberedListIcon extends StatelessWidget {
+  const _NumberedListIcon({
+    required this.node,
+    required this.textStyle,
+  });
+
+  final Node node;
+  final TextStyle textStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final editorState = context.read<EditorState>();
     final text = editorState.editorStyle.textStyleConfiguration.text;
-    final level = _NumberedListIconBuilder(node: widget.node).level;
+    final level = _NumberedListIconBuilder(node: node).level;
     return Padding(
       padding: const EdgeInsets.only(right: 5.0),
       child: Text.rich(

--- a/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
+++ b/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/block_component/base_component/block_icon_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -26,10 +27,13 @@ Node quoteNode({
 class QuoteBlockComponentBuilder extends BlockComponentBuilder {
   QuoteBlockComponentBuilder({
     this.configuration = const BlockComponentConfiguration(),
+    this.iconBuilder,
   });
 
   @override
   final BlockComponentConfiguration configuration;
+
+  final BlockIconBuilder? iconBuilder;
 
   @override
   BlockComponentWidget build(BlockComponentContext blockComponentContext) {
@@ -38,6 +42,7 @@ class QuoteBlockComponentBuilder extends BlockComponentBuilder {
       key: node.key,
       node: node,
       configuration: configuration,
+      iconBuilder: iconBuilder,
       showActions: showActions(node),
       actionBuilder: (context, state) => actionBuilder(
         blockComponentContext,
@@ -57,7 +62,10 @@ class QuoteBlockComponentWidget extends BlockComponentStatefulWidget {
     super.showActions,
     super.actionBuilder,
     super.configuration = const BlockComponentConfiguration(),
+    this.iconBuilder,
   });
+
+  final BlockIconBuilder? iconBuilder;
 
   @override
   State<QuoteBlockComponentWidget> createState() =>
@@ -94,7 +102,9 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
           mainAxisAlignment: MainAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            defaultIcon(),
+            widget.iconBuilder != null
+                ? widget.iconBuilder!(context, node)
+                : const _QuoteIcon(),
             Flexible(
               child: FlowyRichText(
                 key: forwardKey,
@@ -125,9 +135,13 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
 
     return child;
   }
+}
 
-  // TODO: support custom icon.
-  Widget defaultIcon() {
+class _QuoteIcon extends StatelessWidget {
+  const _QuoteIcon();
+
+  @override
+  Widget build(BuildContext context) {
     return const FlowySvg(
       width: 20,
       height: 20,

--- a/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
+++ b/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/block_component/base_component/block_icon_builder.dart';
 import 'package:flutter/material.dart';
 
 class TodoListBlockKeys {
@@ -33,7 +34,7 @@ class TodoListBlockComponentBuilder extends BlockComponentBuilder {
   TodoListBlockComponentBuilder({
     this.configuration = const BlockComponentConfiguration(),
     this.textStyleBuilder,
-    this.icon,
+    this.iconBuilder,
   });
 
   @override
@@ -42,8 +43,7 @@ class TodoListBlockComponentBuilder extends BlockComponentBuilder {
   /// The text style of the todo list block.
   final TextStyle Function(bool checked)? textStyleBuilder;
 
-  /// The icon of the todo list block.
-  final Widget? Function(bool checked)? icon;
+  final BlockIconBuilder? iconBuilder;
 
   @override
   BlockComponentWidget build(BlockComponentContext blockComponentContext) {
@@ -53,7 +53,7 @@ class TodoListBlockComponentBuilder extends BlockComponentBuilder {
       node: node,
       configuration: configuration,
       textStyleBuilder: textStyleBuilder,
-      icon: icon,
+      iconBuilder: iconBuilder,
       showActions: showActions(node),
       actionBuilder: (context, state) => actionBuilder(
         blockComponentContext,
@@ -77,11 +77,11 @@ class TodoListBlockComponentWidget extends BlockComponentStatefulWidget {
     super.actionBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.textStyleBuilder,
-    this.icon,
+    this.iconBuilder,
   });
 
   final TextStyle Function(bool checked)? textStyleBuilder;
-  final Widget? Function(bool checked)? icon;
+  final BlockIconBuilder? iconBuilder;
 
   @override
   State<TodoListBlockComponentWidget> createState() =>
@@ -119,10 +119,12 @@ class _TodoListBlockComponentWidgetState
         mainAxisAlignment: MainAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          _TodoListIcon(
-            icon: widget.icon?.call(checked) ?? defaultCheckboxIcon(),
-            onTap: checkOrUncheck,
-          ),
+          widget.iconBuilder != null
+              ? widget.iconBuilder!(context, node)
+              : _TodoListIcon(
+                  checked: checked,
+                  onTap: checkOrUncheck,
+                ),
           Flexible(
             child: FlowyRichText(
               key: forwardKey,
@@ -163,15 +165,6 @@ class _TodoListBlockComponentWidgetState
     return editorState.apply(transaction);
   }
 
-  FlowySvg defaultCheckboxIcon() {
-    return FlowySvg(
-      width: 22,
-      height: 22,
-      padding: const EdgeInsets.only(right: 5.0),
-      name: checked ? 'check' : 'uncheck',
-    );
-  }
-
   TextStyle? defaultTextStyle() {
     if (!checked) {
       return null;
@@ -185,12 +178,12 @@ class _TodoListBlockComponentWidgetState
 
 class _TodoListIcon extends StatelessWidget {
   const _TodoListIcon({
-    required this.icon,
     required this.onTap,
+    required this.checked,
   });
 
-  final Widget icon;
   final VoidCallback onTap;
+  final bool checked;
 
   @override
   Widget build(BuildContext context) {
@@ -199,7 +192,12 @@ class _TodoListIcon extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
-        child: icon,
+        child: FlowySvg(
+          width: 22,
+          height: 22,
+          padding: const EdgeInsets.only(right: 5.0),
+          name: checked ? 'check' : 'uncheck',
+        ),
       ),
     );
   }

--- a/lib/src/editor/toolbar/desktop/items/icon_item_widget.dart
+++ b/lib/src/editor/toolbar/desktop/items/icon_item_widget.dart
@@ -8,6 +8,7 @@ class IconItemWidget extends StatelessWidget {
     this.iconSize = const Size.square(18.0),
     required this.iconName,
     required this.isHighlight,
+    this.highlightColor = Colors.lightBlue,
     this.tooltip,
     this.onPressed,
   });
@@ -16,6 +17,7 @@ class IconItemWidget extends StatelessWidget {
   final Size iconSize;
   final String iconName;
   final bool isHighlight;
+  final Color highlightColor;
   final String? tooltip;
   final VoidCallback? onPressed;
 
@@ -23,7 +25,7 @@ class IconItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget child = FlowySvg(
       name: iconName,
-      color: isHighlight ? Colors.lightBlue : null,
+      color: isHighlight ? highlightColor : null,
       width: iconSize.width,
       height: iconSize.height,
     );

--- a/test/customer/custom_block_icon_test.dart
+++ b/test/customer/custom_block_icon_test.dart
@@ -1,0 +1,85 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+void main() async {
+  /// supports
+  ///
+  /// - numbered list
+  /// - bulleted list
+  /// - todo list
+  /// - quote
+  testWidgets('custom block icon', (tester) async {
+    await mockNetworkImagesFor(() async {
+      const widget = CustomBlockIcon();
+      await tester.pumpWidget(widget);
+      await tester.pumpAndSettle();
+
+      iconMap.forEach((key, value) {
+        expect(find.byIcon(value), findsOneWidget);
+      });
+    });
+  });
+}
+
+const menu = 'Here\'s a custom menu!';
+
+final iconMap = {
+  BulletedListBlockKeys.type: Icons.format_list_bulleted,
+  NumberedListBlockKeys.type: Icons.format_list_numbered,
+  QuoteBlockKeys.type: Icons.format_quote,
+  TodoListBlockKeys.type: Icons.check_box_outline_blank,
+};
+
+class CustomBlockIcon extends StatelessWidget {
+  const CustomBlockIcon({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final delta = Delta()..insert('Hello World');
+    final document = Document.blank()
+      ..insert(
+        [0],
+        [
+          bulletedListNode(delta: delta),
+          numberedListNode(delta: delta),
+          todoListNode(delta: delta, checked: false),
+          quoteNode(delta: delta),
+        ],
+      );
+
+    final customBlockComponentBuilders = {
+      ...standardBlockComponentBuilderMap,
+      BulletedListBlockKeys.type: BulletedListBlockComponentBuilder(
+        iconBuilder: (_, __) => Icon(iconMap[BulletedListBlockKeys.type]),
+      ),
+      NumberedListBlockKeys.type: NumberedListBlockComponentBuilder(
+        iconBuilder: (_, __) => Icon(iconMap[NumberedListBlockKeys.type]),
+      ),
+      TodoListBlockKeys.type: TodoListBlockComponentBuilder(
+        iconBuilder: (_, __) => Icon(iconMap[TodoListBlockKeys.type]),
+      ),
+      QuoteBlockKeys.type: QuoteBlockComponentBuilder(
+        iconBuilder: (_, __) => Icon(iconMap[QuoteBlockKeys.type]),
+      ),
+    };
+
+    final editorState = EditorState(document: document);
+    return MaterialApp(
+      home: Scaffold(
+        body: SafeArea(
+          child: SizedBox(
+            width: 500,
+            child: AppFlowyEditor.custom(
+              editorState: editorState,
+              blockComponentBuilders: customBlockComponentBuilders,
+              commandShortcutEvents: standardCommandShortcutEvents,
+              characterShortcutEvents: standardCharacterShortcutEvents,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/customer/custom_image_menu_test.dart
+++ b/test/customer/custom_image_menu_test.dart
@@ -6,14 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 
 void main() async {
-  // column
-  // - text field
-  // - editor
-
-  // 1. When the text field is focused, the editor's cursor should be disabled.
-  // 2. When the editor is focused, the text field's cursor should be disabled.
-  // 3. Tapping a non-first line of the editor should still allow the editor to grab focus.
-  testWidgets('text field + editor', (tester) async {
+  /// customize the image menu
+  testWidgets('customize the image block\'s menu', (tester) async {
     await mockNetworkImagesFor(() async {
       const widget = CustomImageMenu();
       await tester.pumpWidget(widget);


### PR DESCRIPTION
Support customizing the built-in block's icon

<img width="456" alt="Screenshot 2023-07-02 at 12 26 11" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/1b11b800-c29d-4367-a051-e6e61056592f">

Here's the sample code 

```dart
final iconMap = {
  BulletedListBlockKeys.type: Icons.format_list_bulleted,
  NumberedListBlockKeys.type: Icons.format_list_numbered,
  QuoteBlockKeys.type: Icons.format_quote,
  TodoListBlockKeys.type: Icons.check_box_outline_blank,
};

class CustomBlockIcon extends StatelessWidget {
  const CustomBlockIcon({super.key});

  @override
  Widget build(BuildContext context) {
    final delta = Delta()..insert('Hello World');
    final document = Document.blank()
      ..insert(
        [0],
        [
          bulletedListNode(delta: delta),
          numberedListNode(delta: delta),
          todoListNode(delta: delta, checked: false),
          quoteNode(delta: delta),
        ],
      );

    final customBlockComponentBuilders = {
      ...standardBlockComponentBuilderMap,
      BulletedListBlockKeys.type: BulletedListBlockComponentBuilder(
        iconBuilder: (_, __) => Icon(iconMap[BulletedListBlockKeys.type]),
      ),
      NumberedListBlockKeys.type: NumberedListBlockComponentBuilder(
        iconBuilder: (_, __) => Icon(iconMap[NumberedListBlockKeys.type]),
      ),
      TodoListBlockKeys.type: TodoListBlockComponentBuilder(
        iconBuilder: (_, __) => Icon(iconMap[TodoListBlockKeys.type]),
      ),
      QuoteBlockKeys.type: QuoteBlockComponentBuilder(
        iconBuilder: (_, __) => Icon(iconMap[QuoteBlockKeys.type]),
      ),
    };

    final editorState = EditorState(document: document);
    return MaterialApp(
      home: Scaffold(
        body: SafeArea(
          child: SizedBox(
            width: 500,
            child: AppFlowyEditor.custom(
              editorState: editorState,
              blockComponentBuilders: customBlockComponentBuilders,
              commandShortcutEvents: standardCommandShortcutEvents,
              characterShortcutEvents: standardCharacterShortcutEvents,
            ),
          ),
        ),
      ),
    );
  }
}

```