### PR TITLE
fix: fix overflow in heading mobile toolbar menu

### DIFF
--- a/lib/src/editor/toolbar/mobile/toolbar_items/heading_mobile_toolbar_item.dart
+++ b/lib/src/editor/toolbar/mobile/toolbar_items/heading_mobile_toolbar_item.dart
@@ -47,7 +47,7 @@ class _HeadingMenuState extends State<_HeadingMenu> {
   @override
   Widget build(BuildContext context) {
     final style = MobileToolbarStyle.of(context);
-    final size = MediaQuery.of(context).size;
+    final size = MediaQuery.sizeOf(context);
     final btnList = headings.map((currentHeading) {
       // Check if current node is heading and its level
       final node =

--- a/lib/src/editor/toolbar/mobile/toolbar_items/heading_mobile_toolbar_item.dart
+++ b/lib/src/editor/toolbar/mobile/toolbar_items/heading_mobile_toolbar_item.dart
@@ -47,6 +47,7 @@ class _HeadingMenuState extends State<_HeadingMenu> {
   @override
   Widget build(BuildContext context) {
     final style = MobileToolbarStyle.of(context);
+    final size = MediaQuery.of(context).size;
     final btnList = headings.map((currentHeading) {
       // Check if current node is heading and its level
       final node =
@@ -54,38 +55,46 @@ class _HeadingMenuState extends State<_HeadingMenu> {
       final isSelected = node.type == HeadingBlockKeys.type &&
           node.attributes[HeadingBlockKeys.level] == currentHeading.level;
 
-      return MobileToolbarItemMenuBtn(
-        icon: AFMobileIcon(afMobileIcons: currentHeading.icon),
-        label: Text(currentHeading.label),
-        isSelected: isSelected,
-        onPressed: () {
-          setState(() {
-            widget.editorState.formatNode(
-              widget.selection,
-              (node) => node.copyWith(
-                type: isSelected
-                    ? ParagraphBlockKeys.type
-                    : HeadingBlockKeys.type,
-                attributes: {
-                  HeadingBlockKeys.level: currentHeading.level,
-                  HeadingBlockKeys.backgroundColor:
-                      node.attributes[blockComponentBackgroundColor],
-                  ParagraphBlockKeys.delta: (node.delta ?? Delta()).toJson(),
-                },
-              ),
-            );
-          });
-        },
+      return ConstrainedBox(
+        constraints: BoxConstraints.tightFor(
+          // 3 buttons in a row
+          width: (size.width - 4 * style.buttonSpacing) / 3,
+        ),
+        child: MobileToolbarItemMenuBtn(
+          icon: AFMobileIcon(afMobileIcons: currentHeading.icon),
+          label: Text(
+            currentHeading.label,
+            maxLines: 2,
+          ),
+          isSelected: isSelected,
+          onPressed: () {
+            setState(() {
+              widget.editorState.formatNode(
+                widget.selection,
+                (node) => node.copyWith(
+                  type: isSelected
+                      ? ParagraphBlockKeys.type
+                      : HeadingBlockKeys.type,
+                  attributes: {
+                    HeadingBlockKeys.level: currentHeading.level,
+                    HeadingBlockKeys.backgroundColor:
+                        node.attributes[blockComponentBackgroundColor],
+                    ParagraphBlockKeys.delta: (node.delta ?? Delta()).toJson(),
+                  },
+                ),
+              );
+            });
+          },
+        ),
       );
     }).toList();
 
-    return GridView(
-      shrinkWrap: true,
-      gridDelegate: buildMobileToolbarMenuGridDelegate(
-        mobileToolbarStyle: style,
-        crossAxisCount: 3,
+    return ConstrainedBox(
+      constraints: BoxConstraints.tightFor(width: size.width),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: btnList,
       ),
-      children: btnList,
     );
   }
 }


### PR DESCRIPTION
To fix #285 
I refactored the UI to make sure it always has three buttons on the heading mobile toolbar menu.
If the width of the screen is too small, the button texts will show in 2 lines

<img width="302" alt="Pasted Graphic" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/14248245/aed6ad0c-54d6-474d-a86e-18e083f65754">
