### PR TITLE
chore: change windows and linux command for redo

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/undo_redo_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/undo_redo_command.dart
@@ -31,7 +31,7 @@ CommandShortcutEventHandler _undoCommandHandler = (editorState) {
 ///
 final CommandShortcutEvent redoCommand = CommandShortcutEvent(
   key: 'redo',
-  command: 'ctrl+shift+z',
+  command: 'ctrl+y',
   macOSCommand: 'cmd+shift+z',
   handler: _redoCommandHandler,
 );

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/undo_redo_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/undo_redo_command.dart
@@ -31,7 +31,7 @@ CommandShortcutEventHandler _undoCommandHandler = (editorState) {
 ///
 final CommandShortcutEvent redoCommand = CommandShortcutEvent(
   key: 'redo',
-  command: 'ctrl+y',
+  command: 'ctrl+y,ctrl+shift+z',
   macOSCommand: 'cmd+shift+z',
   handler: _redoCommandHandler,
 );

--- a/test/new/service/shortcuts/command_shortcut_events/undo_redo_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/undo_redo_command_test.dart
@@ -126,18 +126,12 @@ Future<void> _pressUndoCommand(TestableEditor editor) async {
 }
 
 Future<void> _pressRedoCommand(TestableEditor editor) async {
-  if (Platform.isMacOS) {
-    await editor.pressKey(
-      key: LogicalKeyboardKey.keyZ,
-      isMetaPressed: true,
-      isShiftPressed: true,
-    );
-  } else {
-    await editor.pressKey(
-      key: LogicalKeyboardKey.keyY,
-      isControlPressed: true,
-    );
-  }
+  await editor.pressKey(
+    key: Platform.isMacOS ? LogicalKeyboardKey.keyZ : LogicalKeyboardKey.keyY,
+    isMetaPressed: Platform.isMacOS,
+    isShiftPressed: Platform.isMacOS,
+    isControlPressed: !Platform.isMacOS,
+  );
 }
 
 Future<void> _selectNodeAtPathAndDelete(TestableEditor editor) async {

--- a/test/new/service/shortcuts/command_shortcut_events/undo_redo_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/undo_redo_command_test.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../infra/testable_editor.dart';
+import '../../../util/util.dart';
+
+// single | means the cursor
+// double | means the selection
+void main() async {
+  setUpAll(() {
+    if (kDebugMode) {
+      activateLog();
+    }
+  });
+
+  tearDownAll(() {
+    if (kDebugMode) {
+      deactivateLog();
+    }
+  });
+
+  const text = 'Welcome to AppFlowy Editor 🔥!';
+
+  group('undo and redo commands - widget test', () {
+    // Before
+    // |Welcome| to AppFlowy Editor 🔥!
+    // After Undo
+    // | to AppFlowy Editor 🔥!
+    // After Redo
+    // |Welcome| to AppFlowy Editor 🔥!
+    testWidgets('Delete text and then perform undo & redo', (tester) async {
+      final editor = tester.editor
+        ..addParagraph(
+          initialText: text,
+        );
+      await editor.startTesting();
+
+      // |Welcome| to AppFlowy Editor 🔥!
+      const welcome = 'Welcome';
+      final selection = Selection.single(
+        path: [0],
+        startOffset: 0,
+        endOffset: welcome.length,
+      );
+      await editor.updateSelection(selection);
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await tester.pumpAndSettle();
+
+      // the first node should be deleted.
+      expect(
+        editor.nodeAtPath([0])?.delta?.toPlainText(),
+        text.substring(welcome.length),
+      );
+
+      //pressing undo shortcut should bring back deleted text.
+      await _pressUndoCommand(editor);
+
+      expect(
+        editor.nodeAtPath([0])?.delta?.toPlainText(),
+        text,
+      );
+
+      //redo should delete the text again.
+      await _pressRedoCommand(editor);
+
+      expect(
+        editor.nodeAtPath([0])?.delta?.toPlainText(),
+        text.substring(welcome.length),
+      );
+
+      await editor.dispose();
+    });
+
+    testWidgets('Delete a non-text node and then perform undo and redo',
+        (tester) async {
+      const kParagraphType = "paragraph";
+      const kDividerType = "divider";
+
+      final editor = tester.editor
+        ..addParagraph(initialText: text)
+        ..addNode(dividerNode())
+        ..addParagraph(initialText: text);
+
+      await editor.startTesting();
+
+      await _selectNodeAtPathAndDelete(editor);
+      await tester.pumpAndSettle();
+
+      expect(
+        editor.nodeAtPath([1])?.type,
+        kParagraphType,
+      );
+
+      //pressing undo should add the divider back to the editor
+      await _pressUndoCommand(editor);
+
+      expect(
+        editor.nodeAtPath([1])?.type,
+        kDividerType,
+      );
+
+      //redo should remove the divider again.
+      await _pressRedoCommand(editor);
+
+      expect(
+        editor.nodeAtPath([1])?.type,
+        kParagraphType,
+      );
+
+      await editor.dispose();
+    });
+  });
+}
+
+Future<void> _pressUndoCommand(TestableEditor editor) async {
+  await editor.pressKey(
+    key: LogicalKeyboardKey.keyZ,
+    isMetaPressed: Platform.isMacOS,
+    isControlPressed: Platform.isWindows || Platform.isLinux,
+  );
+}
+
+Future<void> _pressRedoCommand(TestableEditor editor) async {
+  if (Platform.isMacOS) {
+    await editor.pressKey(
+      key: LogicalKeyboardKey.keyZ,
+      isMetaPressed: true,
+      isShiftPressed: true,
+    );
+  } else {
+    await editor.pressKey(
+      key: LogicalKeyboardKey.keyY,
+      isControlPressed: true,
+    );
+  }
+}
+
+Future<void> _selectNodeAtPathAndDelete(TestableEditor editor) async {
+  final selection = Selection.single(
+    path: [1],
+    startOffset: 0,
+    endOffset: 1,
+  );
+  await editor.updateSelection(selection);
+
+  await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+}

--- a/test/service/internal_key_event_handlers/redo_undo_handler_test.dart
+++ b/test/service/internal_key_event_handlers/redo_undo_handler_test.dart
@@ -55,12 +55,7 @@ Future<void> _testRedoWithoutUndo(WidgetTester tester) async {
 
   expect(editor.documentRootLen, 3);
 
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-    isShiftPressed: true,
-  );
+  await _pressRedoCommand(editor);
 
   expect(editor.documentRootLen, 3);
 
@@ -106,22 +101,13 @@ Future<void> _testWithTextFormattingBold(WidgetTester tester) async {
   expect(result, true);
 
   //undo should remove bold style and make it normal.
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-  );
+  await _pressUndoCommand(editor);
 
   result = node.allBold(selection);
   expect(result, false);
 
   //redo should make text bold.
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-    isShiftPressed: true,
-  );
+  await _pressRedoCommand(editor);
 
   result = node.allBold(selection);
   expect(result, true);
@@ -163,11 +149,7 @@ Future<void> _testWithTextFormattingItalics(WidgetTester tester) async {
   expect(allItalics, true);
 
   //undo should remove italic style and make it normal.
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-  );
+  await _pressUndoCommand(editor);
 
   allItalics = node.allItalic(
     Selection.single(path: [0], startOffset: 1, endOffset: text.length),
@@ -175,12 +157,7 @@ Future<void> _testWithTextFormattingItalics(WidgetTester tester) async {
   expect(allItalics, false);
 
   //redo should make text italic again.
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-    isShiftPressed: true,
-  );
+  await _pressRedoCommand(editor);
 
   allItalics = node.allItalic(
     Selection.single(path: [0], startOffset: 1, endOffset: text.length),
@@ -223,25 +200,16 @@ Future<void> _testWithTextFormattingUnderline(WidgetTester tester) async {
   );
   expect(allUnderline, true);
 
-  //undo should remove bold style and make it normal.
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-  );
+  //undo should remove underline style and make it normal.
+  await _pressUndoCommand(editor);
 
   allUnderline = node.allUnderline(
     Selection.single(path: [0], startOffset: 1, endOffset: text.length),
   );
   expect(allUnderline, false);
 
-  //redo should make text bold.
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-    isShiftPressed: true,
-  );
+  //redo should make text underline.
+  await _pressRedoCommand(editor);
 
   allUnderline = node.allUnderline(
     Selection.single(path: [0], startOffset: 1, endOffset: text.length),
@@ -269,24 +237,38 @@ Future<void> _testBackspaceUndoRedo(
   await editor.pressKey(key: LogicalKeyboardKey.backspace);
   expect(editor.documentRootLen, 2);
 
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-  );
+  await _pressUndoCommand(editor);
 
   expect(editor.documentRootLen, 3);
   expect(editor.nodeAtPath([1])!.delta!.toPlainText(), text);
   expect(editor.selection, selection);
 
-  await editor.pressKey(
-    key: LogicalKeyboardKey.keyZ,
-    isControlPressed: Platform.isWindows || Platform.isLinux,
-    isMetaPressed: Platform.isMacOS,
-    isShiftPressed: true,
-  );
+  await _pressRedoCommand(editor);
 
   expect(editor.documentRootLen, 2);
 
   await editor.dispose();
+}
+
+Future<void> _pressUndoCommand(TestableEditor editor) async {
+  await editor.pressKey(
+    key: LogicalKeyboardKey.keyZ,
+    isMetaPressed: Platform.isMacOS,
+    isControlPressed: Platform.isWindows || Platform.isLinux,
+  );
+}
+
+Future<void> _pressRedoCommand(TestableEditor editor) async {
+  if (Platform.isMacOS) {
+    await editor.pressKey(
+      key: LogicalKeyboardKey.keyZ,
+      isMetaPressed: true,
+      isShiftPressed: true,
+    );
+  } else {
+    await editor.pressKey(
+      key: LogicalKeyboardKey.keyY,
+      isControlPressed: true,
+    );
+  }
 }

--- a/test/service/internal_key_event_handlers/redo_undo_handler_test.dart
+++ b/test/service/internal_key_event_handlers/redo_undo_handler_test.dart
@@ -259,16 +259,10 @@ Future<void> _pressUndoCommand(TestableEditor editor) async {
 }
 
 Future<void> _pressRedoCommand(TestableEditor editor) async {
-  if (Platform.isMacOS) {
-    await editor.pressKey(
-      key: LogicalKeyboardKey.keyZ,
-      isMetaPressed: true,
-      isShiftPressed: true,
-    );
-  } else {
-    await editor.pressKey(
-      key: LogicalKeyboardKey.keyY,
-      isControlPressed: true,
-    );
-  }
+  await editor.pressKey(
+    key: Platform.isMacOS ? LogicalKeyboardKey.keyZ : LogicalKeyboardKey.keyY,
+    isMetaPressed: Platform.isMacOS,
+    isShiftPressed: Platform.isMacOS,
+    isControlPressed: !Platform.isMacOS,
+  );
 }


### PR DESCRIPTION
I have changed the default shortcut for redo operation on Windows and Linux from `ctrl+shift+z` to `ctrl+y`.
Partially Solves: [#2888](https://github.com/AppFlowy-IO/AppFlowy/issues/2888)