### PR TITLE
fix: toolbar item tooltips are too responsive

### DIFF
--- a/lib/src/editor/toolbar/desktop/items/icon_item_widget.dart
+++ b/lib/src/editor/toolbar/desktop/items/icon_item_widget.dart
@@ -52,6 +52,7 @@ class SVGIconItemWidget extends StatelessWidget {
         textAlign: TextAlign.center,
         preferBelow: false,
         message: tooltip,
+        waitDuration: const Duration(milliseconds: 500),
         child: child,
       );
     }


### PR DESCRIPTION
linked to https://github.com/AppFlowy-IO/appflowy-editor/issues/302

[Bug] Toolbar Item Tooltips are too responsive

https://github.com/AppFlowy-IO/appflowy-editor/assets/22239637/6f043058-72d9-4dfa-b20e-c3ca35ceed15



