### PR TITLE
Import assets from markdown file

### DIFF
--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -52,7 +52,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
 
   Node _convertLineToNode(String line) {
     final decoder = DeltaMarkdownDecoder();
-    final assetRegex = RegExp(r'\!\[.*\]\(.*\)');
+    final assetRegex = RegExp(r'^!\[.*\]\(.*\)$');
     // Heading Style
     if (line.startsWith('### ')) {
       return headingNode(
@@ -91,9 +91,9 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       return Node(type: 'divider');
     } else if (line.startsWith('```') && line.endsWith('```')) {
       return _codeBlockNodeFromMarkdown(line, decoder);
-    } else if(assetRegex.hasMatch(line)){
-      var match = assetRegex.firstMatch(line);
-      String? filepath =  match?.group(1);
+    } else if(assetRegex.hasMatch(line.trim())){
+      
+      String? filepath =  extractImagePath(line.trim());
       //checking if filepath is present or if the filepath is an image or not
       if(filepath == null || (!filepath.endsWith('.png') && !filepath.endsWith('.jpg') && !filepath.endsWith('.jpeg') )){
         return paragraphNode(
@@ -115,7 +115,18 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       attributes: {'delta': Delta().toJson()},
     );
   }
-
+  String? extractImagePath(String text) {
+  const startDelimiter = "![";
+  const endDelimiter = "](";
+  final startIndex = text.indexOf(startDelimiter);
+  final endIndex = text.indexOf(endDelimiter, startIndex + startDelimiter.length);
+  
+  if (startIndex != -1 && endIndex != -1) {
+    return text.substring(endIndex + endDelimiter.length, text.length - 1);
+  } else {
+    return null;
+  }
+}
   Node _codeBlockNodeFromMarkdown(
     String markdown,
     DeltaMarkdownDecoder decoder,

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -52,7 +52,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
 
   Node _convertLineToNode(String line) {
     final decoder = DeltaMarkdownDecoder();
-
+    final assetRegex = RegExp(r'\!\[.*\]\(.*\)');
     // Heading Style
     if (line.startsWith('### ')) {
       return headingNode(
@@ -91,6 +91,18 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       return Node(type: 'divider');
     } else if (line.startsWith('```') && line.endsWith('```')) {
       return _codeBlockNodeFromMarkdown(line, decoder);
+    } else if(assetRegex.hasMatch(line)){
+      var match = assetRegex.firstMatch(line);
+      String? filepath =  match?.group(1);
+      //checking if filepath is present or if the filepath is an image or not
+      if(filepath == null || (!filepath.endsWith('.png') && !filepath.endsWith('.jpg') && !filepath.endsWith('.jpeg') )){
+        return paragraphNode(
+          attributes: {'delta': decoder.convert(line).toJson()},
+        );
+      }
+      else{
+        return imageNode(url: filepath);
+      }
     }
 
     if (line.isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   nanoid: ^1.0.0
   visibility_detector: ^0.4.0+2
   file_picker: ^5.3.1
+  path: ^1.8.3
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
@@ -191,6 +191,35 @@ void main() async {
         "data": {
           "delta": []
         }
+      },
+      {
+          "type": "paragraph",
+            "data": {
+                "delta": [
+                  {
+                    "insert": "This file is cuurently not supported : [Example file.pdf](path/to/file.pdf)"
+                  }
+                ]
+              }
+      },      
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
+      },
+      {
+        "type": "image",
+        "data": {
+            "url": "path/to/image.png",
+            "align": "center"
+          }
+      },
+      {
+        "type": "paragraph",
+        "data": {
+          "delta": []
+        }
       }
     ]
   }
@@ -334,6 +363,10 @@ You can also use ***AppFlowy Editor*** as a component to build your own app.
 * Select text to trigger to the toolbar to format your notes.
 
 If you have questions or feedback, please submit an issue on Github or join the community along with 1000+ builders!
+
+[Example file.pdf](path/to/file.pdf)
+
+![Example image](path/to/image.png)
 ''';
       final result = DocumentMarkdownDecoder().convert(markdown);
       final data = jsonDecode(example);

--- a/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
@@ -197,11 +197,11 @@ void main() async {
             "data": {
                 "delta": [
                   {
-                    "insert": "This file is cuurently not supported : [Example file.pdf](path/to/file.pdf)"
+                    "insert": "[Example file.pdf](path/to/file.pdf)"
                   }
                 ]
               }
-      },      
+      },
       {
         "type": "paragraph",
         "data": {


### PR DESCRIPTION
This PR adds support to detect images from markdown file which are in ![Alt text](path to image) format
It also fixes the error where if a file is there in markdown file it is detected as a url since both have a similar representation in markdown - [Alt tex](url or file path) not if it is a file it is treated as a simple paragraph  with text "This is currently not supported : [Alt text](file path)"
Related to https://github.com/AppFlowy-IO/AppFlowy/pull/2981