### PR TITLE
chore: support extending the convertibleBlockTypes

### DIFF
--- a/lib/src/editor/block_component/base_component/convert_to_paragraph_command.dart
+++ b/lib/src/editor/block_component/base_component/convert_to_paragraph_command.dart
@@ -1,12 +1,12 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
 
-const convertibleBlockTypes = [
-  'bulleted_list',
-  'numbered_list',
-  'todo_list',
-  'quote',
-  'heading',
+final convertibleBlockTypes = [
+  BulletedListBlockKeys.type,
+  NumberedListBlockKeys.type,
+  TodoListBlockKeys.type,
+  QuoteBlockKeys.type,
+  HeadingBlockKeys.type,
 ];
 
 /// Convert to paragraph command.


### PR DESCRIPTION
For developers who want to customize the backspace command for converting the block type.


```dart
  @override
  void initState() {
    super.initState();

    indentableBlockTypes.add(ToggleListBlockKeys.type);
    convertibleBlockTypes.add(ToggleListBlockKeys.type);

  }
```