### PR TITLE
fix: fixed the issue of code block not being exported in markdown

### DIFF
--- a/lib/src/plugins/markdown/encoder/parser/code_block_node_parser.dart
+++ b/lib/src/plugins/markdown/encoder/parser/code_block_node_parser.dart
@@ -4,18 +4,19 @@ class CodeBlockNodeParser extends NodeParser {
   const CodeBlockNodeParser();
 
   @override
-  String get id => 'code_block';
+  String get id => 'code';
 
   @override
   String transform(Node node) {
-    assert(node.type == 'code_block');
+    assert(node.type == 'code');
 
     final delta = node.delta;
+    final language = node.attributes['language'] ?? '';
     if (delta == null) {
       throw Exception('Delta is null');
     }
     final markdown = DeltaMarkdownEncoder().convert(delta);
-    final result = '```\n$markdown\n```';
+    final result = '```$language\n$markdown\n```';
     final suffix = node.next == null ? '' : '\n';
 
     return '$result$suffix';

--- a/test/plugins/markdown/encoder/parser/text_node_parser_test.dart
+++ b/test/plugins/markdown/encoder/parser/text_node_parser_test.dart
@@ -70,7 +70,7 @@ void main() async {
 
     test('code block style', () {
       final node = Node(
-        type: 'code_block',
+        type: 'code',
         attributes: {
           'delta': (Delta()..insert(text)).toJson(),
         },


### PR DESCRIPTION
fixes: https://github.com/AppFlowy-IO/AppFlowy/issues/3055

Before -

https://github.com/AppFlowy-IO/appflowy-editor/assets/71614009/c760decc-0561-4dec-bb30-ee97795d6b52


After -

https://github.com/AppFlowy-IO/appflowy-editor/assets/71614009/3c2e2287-7cbc-475d-9edf-1e43a1f298e0









