### PR TITLE
feat: expose context in nodeBuilder

### DIFF
--- a/lib/src/editor/selection_menu/selection_menu_widget.dart
+++ b/lib/src/editor/selection_menu/selection_menu_widget.dart
@@ -85,7 +85,8 @@ class SelectionMenuItem {
     required String name,
     required IconData iconData,
     required List<String> keywords,
-    required Node Function(EditorState editorState) nodeBuilder,
+    required Node Function(EditorState editorState, BuildContext context)
+        nodeBuilder,
     bool Function(EditorState editorState, Node node)? insertBefore,
     bool Function(EditorState editorState, Node node)? replace,
     Selection? Function(
@@ -105,7 +106,7 @@ class SelectionMenuItem {
         size: 18.0,
       ),
       keywords: keywords,
-      handler: (editorState, _, __) {
+      handler: (editorState, _, context) {
         final selection = editorState.selection;
         if (selection == null || !selection.isCollapsed) {
           return;
@@ -115,7 +116,7 @@ class SelectionMenuItem {
         if (node == null || delta == null) {
           return;
         }
-        final newNode = nodeBuilder(editorState);
+        final newNode = nodeBuilder(editorState, context);
         final transaction = editorState.transaction;
         final bReplace = replace?.call(editorState, node) ?? false;
         final bInsertBefore = insertBefore?.call(editorState, node) ?? false;


### PR DESCRIPTION
Sometimes we need `BuildContext` to build a new node. 

For example in the callout feature, if we want to insert a new callout node with a background color that matches the current theme, we need `BuildContext` to get its color to build the node. 

<img width="911" alt="image" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/14248245/0683c8db-02ad-4046-884a-8816f5c73628">
