### PR TITLE
fix: show selection menu at left

### DIFF
--- a/lib/src/editor/block_component/image_block_component/image_upload_widget.dart
+++ b/lib/src/editor/block_component/image_block_component/image_upload_widget.dart
@@ -20,7 +20,7 @@ void showImageMenu(
 }) {
   menuService.dismiss();
 
-  final (left, top, bottom) = menuService.getPosition();
+  final (left, top, right, bottom) = menuService.getPosition();
 
   late final OverlayEntry imageMenuEntry;
 
@@ -40,6 +40,7 @@ void showImageMenu(
   keepEditorFocusNotifier.value += 1;
   imageMenuEntry = FullScreenOverlayEntry(
     left: left,
+    right: right,
     top: top,
     bottom: bottom,
     dismissCallback: () => keepEditorFocusNotifier.value -= 1,

--- a/lib/src/editor/toolbar/desktop/floating_toolbar.dart
+++ b/lib/src/editor/toolbar/desktop/floating_toolbar.dart
@@ -151,7 +151,7 @@ class _FloatingToolbarState extends State<FloatingToolbar>
     }
 
     final rect = _findSuitableRect(rects);
-    final (top, left, right) = calculateToolbarOffset(rect);
+    final (left, top, right) = calculateToolbarOffset(rect);
     _toolbarContainer = OverlayEntry(
       builder: (context) {
         return Positioned(
@@ -203,7 +203,7 @@ class _FloatingToolbarState extends State<FloatingToolbar>
     return minRect;
   }
 
-  (double top, double? left, double? right) calculateToolbarOffset(Rect rect) {
+  (double? left, double top, double? right) calculateToolbarOffset(Rect rect) {
     final editorOffset =
         editorState.renderBox?.localToGlobal(Offset.zero) ?? Offset.zero;
     final editorSize = editorState.renderBox?.size ?? Size.zero;
@@ -218,13 +218,13 @@ class _FloatingToolbarState extends State<FloatingToolbar>
         : rect.top;
     if (rect.left >= threshold && rect.right <= threshold * 2.0) {
       // show in center
-      return (top, threshold, null);
+      return (threshold, top, null);
     } else if (left >= right && rect.left <= threshold) {
       // show in left
-      return (top, rect.left, null);
+      return (rect.left, top, null);
     } else {
       // show in right
-      return (top, null, editorRect.right - rect.right);
+      return (null, top, editorRect.right - rect.right);
     }
   }
 }


### PR DESCRIPTION
When the selection rect is in the right half of editor show selection menu on left.

closes #329 