### PR TITLE
feat: paste from html

### DIFF
--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+
 import 'ime/delta_input_impl.dart';
 
 // handle software keyboard and hardware keyboard

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/paste_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/paste_command.dart
@@ -93,7 +93,7 @@ CommandShortcutEventHandler _pasteCommandHandler = (editorState) {
     final text = data.text;
     final html = data.html;
     if (html != null && html.isNotEmpty) {
-      pasteHTML(editorState, html);
+      editorState.pasteHtml(html);
     } else if (text != null && text.isNotEmpty) {
       handlePastePlainText(editorState, data.text!);
     }
@@ -101,3 +101,152 @@ CommandShortcutEventHandler _pasteCommandHandler = (editorState) {
 
   return KeyEventResult.handled;
 };
+
+extension on EditorState {
+  Future<void> pasteHtml(String html) async {
+    final nodes = htmlToDocument(html).root.children;
+    if (nodes.isEmpty) {
+      return;
+    }
+    if (nodes.length == 1) {
+      await pasteSingleLineNode(nodes.first);
+    } else {
+      await pasteMultiLineNodes(nodes.toList());
+    }
+  }
+
+  Future<void> pasteSingleLineNode(Node insertedNode) async {
+    final selection = await _deleteSelectionIfNeeded();
+    if (selection == null) {
+      return;
+    }
+    final node = getNodeAtPath(selection.start.path);
+    final delta = node?.delta;
+    if (node == null || delta == null) {
+      return;
+    }
+    final transaction = this.transaction;
+    final insertedDelta = insertedNode.delta;
+    // if the node is empty, replace it with the inserted node.
+    if (delta.isEmpty || insertedDelta == null) {
+      transaction.insertNode(selection.end.path.next, insertedNode);
+      transaction.deleteNode(node);
+      transaction.afterSelection = Selection.collapse(
+        selection.end.path,
+        insertedDelta?.length ?? 0,
+      );
+    } else {
+      // if the node is not empty, insert the delta from inserted node after the selection.
+      transaction.insertTextDelta(node, selection.endIndex, insertedDelta);
+    }
+    await apply(transaction);
+  }
+
+  Future<void> pasteMultiLineNodes(List<Node> nodes) async {
+    assert(nodes.length > 1);
+
+    final selection = await _deleteSelectionIfNeeded();
+    if (selection == null) {
+      return;
+    }
+    final node = getNodeAtPath(selection.start.path);
+    final delta = node?.delta;
+    if (node == null || delta == null) {
+      return;
+    }
+    final transaction = this.transaction;
+
+    final lastNodeLength = nodes.last.delta?.length ?? 0;
+    // merge the current selected node delta into the nodes.
+    if (delta.isNotEmpty) {
+      nodes.first.insertDelta(
+        delta.slice(0, selection.startIndex),
+        insertAfter: false,
+      );
+      nodes[0] = nodes.first.copyWith(
+        type: node.type,
+        attributes: {
+          ...node.attributes,
+          ...nodes.first.attributes,
+        },
+      );
+      nodes.last.insertDelta(
+        delta.slice(selection.endIndex),
+        insertAfter: true,
+      );
+    }
+
+    for (final child in node.children) {
+      nodes.last.insert(child);
+    }
+
+    transaction.insertNodes(selection.end.path, nodes);
+
+    // delete the current node.
+    transaction.deleteNode(node);
+
+    var path = selection.end.path;
+    for (var i = 0; i < nodes.length; i++) {
+      path = path.next;
+    }
+    transaction.afterSelection = Selection.collapse(
+      path.previous, // because a node is deleted.
+      lastNodeLength,
+    );
+
+    await apply(transaction);
+  }
+
+  // delete the selection if it's not collapsed.
+  Future<Selection?> _deleteSelectionIfNeeded() async {
+    var selection = this.selection;
+    if (selection == null) {
+      return null;
+    }
+
+    // delete the selection first.
+    if (!selection.isCollapsed) {
+      deleteSelection(selection);
+    }
+
+    // fetch selection again.selection = editorState.selection;
+    assert(this.selection?.isCollapsed == true);
+    return this.selection;
+  }
+}
+
+extension on Node {
+  void insertDelta(Delta delta, {bool insertAfter = true}) {
+    assert(delta.every((element) => element is TextInsert));
+    if (this.delta == null) {
+      updateAttributes({
+        blockComponentDelta: delta.toJson(),
+      });
+    } else if (insertAfter) {
+      updateAttributes(
+        {
+          blockComponentDelta: this
+              .delta!
+              .compose(
+                Delta()
+                  ..retain(this.delta!.length)
+                  ..addAll(delta),
+              )
+              .toJson(),
+        },
+      );
+    } else {
+      updateAttributes(
+        {
+          blockComponentDelta: delta
+              .compose(
+                Delta()
+                  ..retain(delta.length)
+                  ..addAll(this.delta!),
+              )
+              .toJson(),
+        },
+      );
+    }
+  }
+}

--- a/lib/src/editor/util/color_util.dart
+++ b/lib/src/editor/util/color_util.dart
@@ -10,7 +10,11 @@ extension ColorExtension on String {
   }
 
   Color? tryToColor() {
-    final reg = RegExp(r'rgba\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)');
+    if (startsWith('#') || startsWith('0x')) {
+      return toColor();
+    }
+
+    final reg = RegExp(r'rgba\((\d+),(\d+),(\d+),([\d.]+)\)');
     final match = reg.firstMatch(this);
     if (match == null) {
       return null;
@@ -27,13 +31,13 @@ extension ColorExtension on String {
     final red = redStr != null ? int.tryParse(redStr) : null;
     final green = greenStr != null ? int.tryParse(greenStr) : null;
     final blue = blueStr != null ? int.tryParse(blueStr) : null;
-    final alpha = alphaStr != null ? int.tryParse(alphaStr) : null;
+    final alpha = alphaStr != null ? double.tryParse(alphaStr) ?? 1.0 : 1.0;
 
-    if (red == null || green == null || blue == null || alpha == null) {
+    if (red == null || green == null || blue == null) {
       return null;
     }
 
-    return Color.fromARGB(alpha, red, green, blue);
+    return Color.fromARGB((alpha * 255).toInt(), red, green, blue);
   }
 }
 


### PR DESCRIPTION
- Use the 'html' package to parse the raw HTML string.
- Parse the result into a document structure.
- When pasting, replace the current selection with the new nodes.

For a single DOM element, we only need to insert it at the selected position.
For multiple DOM elements, we should split the selected node, merge it into the parsed nodes, and then insert the parsed nodes before removing the selected one.