### PR TITLE
fix: add variable to hold editor selection for colour menu

### DIFF
--- a/lib/src/editor/toolbar/desktop/items/color/color_menu.dart
+++ b/lib/src/editor/toolbar/desktop/items/color/color_menu.dart
@@ -36,6 +36,7 @@ void showColorMenu(
     overlay = null;
   }
 
+  keepEditorFocusNotifier.value += 1;
   final editorSelection = editorState.selection;
   overlay = FullScreenOverlayEntry(
     top: top,
@@ -62,6 +63,7 @@ void showColorMenu(
                   color,
                 );
           dismissOverlay();
+          keepEditorFocusNotifier.value -= 1;
         },
         onDismiss: dismissOverlay,
       );

--- a/lib/src/editor/toolbar/desktop/items/color/color_menu.dart
+++ b/lib/src/editor/toolbar/desktop/items/color/color_menu.dart
@@ -36,6 +36,7 @@ void showColorMenu(
     overlay = null;
   }
 
+  final editorSelection = editorState.selection;
   overlay = FullScreenOverlayEntry(
     top: top,
     bottom: bottom,
@@ -52,12 +53,12 @@ void showColorMenu(
           isTextColor
               ? formatFontColor(
                   editorState,
-                  editorState.selection,
+                  editorSelection,
                   color,
                 )
               : formatHighlightColor(
                   editorState,
-                  editorState.selection,
+                  editorSelection,
                   color,
                 );
           dismissOverlay();


### PR DESCRIPTION
This pr solves issue #342 
Adding a variable to hold the selection temporarily while the user chooses a custom colour solves the issue.
Since the focus would have moved from the editor onto the colour, that's how the selection was lost.