### PR TITLE
feat: default text direction property

### DIFF
--- a/lib/src/editor/block_component/base_component/text_direction_mixin.dart
+++ b/lib/src/editor/block_component/base_component/text_direction_mixin.dart
@@ -9,20 +9,20 @@ final _regex = RegExp(
 );
 
 mixin BlockComponentTextDirectionMixin {
+  EditorState get editorState;
   Node get node;
 
   TextDirection? lastDirection;
 
   /// Calculate the text direction of a block component.
   // defaultTextDirection will be ltr if caller hasn't passed any value.
-  TextDirection calculateTextDirection({
-    TextDirection? defaultTextDirection,
-  }) {
-    defaultTextDirection ??= TextDirection.ltr;
+  TextDirection calculateTextDirection({TextDirection? layoutDirection}) {
+    layoutDirection ??= TextDirection.ltr;
 
     final direction = calculateNodeDirection(
       node: node,
-      defaultTextDirection: defaultTextDirection,
+      layoutDirection: layoutDirection,
+      defaultTextDirection: editorState.editorStyle.defaultTextDirection,
       lastDirection: lastDirection,
     );
 
@@ -47,45 +47,53 @@ mixin BlockComponentTextDirectionMixin {
 }
 
 /// Calculate the text direction of a node.
-// If the textDirection attribute is not set we will use defaultTextDirection.
+// If the textDirection attribute is not set we will use defaultTextDirection
+//  if set. If not will use layoutDirection.
 // If the textDirection is ltr or rtl we will apply that.
 // If the textDirection is auto we go by these priorities:
 // 1. Determine the direction by first character with strong directionality
 // 2. lastDirection which is the node last determined direction
 // 3. previous line direction
 // 4. defaultTextDirection
+// 5. layoutDirection
 // We will move from first priority when for example the node text is empty or
 // it only has characters without strong directionality e.g. '@'.
 TextDirection calculateNodeDirection({
   required Node node,
-  required TextDirection defaultTextDirection,
+  required TextDirection layoutDirection,
+  String? defaultTextDirection,
   TextDirection? lastDirection,
 }) {
-  defaultTextDirection = lastDirection ?? defaultTextDirection;
-
   // if the block component has a text direction attribute which is not auto,
   // use it
   final value = node.attributes[blockComponentTextDirection] as String?;
   if (value != null && value != blockComponentTextDirectionAuto) {
-    return value.toTextDirection(fallback: defaultTextDirection);
+    final direction = value.toTextDirection();
+    if (direction != null) {
+      return direction;
+    }
   }
 
-  // previous line direction
-  final previousNodeContainsTextDirection = node.previousNodeWhere(
-    (element) => element.attributes.containsKey(blockComponentTextDirection),
-  );
-  if (lastDirection == null &&
-      value == blockComponentTextDirectionAuto &&
-      previousNodeContainsTextDirection != null) {
-    final String previousValue = previousNodeContainsTextDirection
-        .attributes[blockComponentTextDirection];
-    if (previousValue == blockComponentTextDirectionAuto) {
-      defaultTextDirection =
-          previousNodeContainsTextDirection.selectable?.textDirection() ??
-              defaultTextDirection;
-    } else {
-      defaultTextDirection =
-          previousValue.toTextDirection(fallback: defaultTextDirection);
+  if (value == blockComponentTextDirectionAuto) {
+    // previous line direction
+    final previousNodeContainsTextDirection = node.previousNodeWhere(
+      (element) => element.attributes.containsKey(blockComponentTextDirection),
+    );
+
+    if (lastDirection != null) {
+      defaultTextDirection = lastDirection.name;
+    } else if (previousNodeContainsTextDirection != null) {
+      final String previousValue = previousNodeContainsTextDirection
+          .attributes[blockComponentTextDirection];
+      if (previousValue == blockComponentTextDirectionAuto) {
+        defaultTextDirection = previousNodeContainsTextDirection.selectable
+                ?.textDirection()
+                .name ??
+            defaultTextDirection;
+      } else {
+        defaultTextDirection =
+            previousValue.toTextDirection()?.name ?? defaultTextDirection;
+      }
     }
   }
 
@@ -93,7 +101,7 @@ TextDirection calculateNodeDirection({
   // use the default text direction
   final text = node.delta?.toPlainText();
   if (value == null || text == null || text.isEmpty) {
-    return defaultTextDirection;
+    return defaultTextDirection?.toTextDirection() ?? layoutDirection;
   }
 
   // if the value is auto and the text isn't null or empty,
@@ -107,16 +115,16 @@ TextDirection calculateNodeDirection({
     }
   }
 
-  return defaultTextDirection;
+  return defaultTextDirection?.toTextDirection() ?? layoutDirection;
 }
 
 extension on String {
-  TextDirection toTextDirection({required TextDirection fallback}) {
+  TextDirection? toTextDirection() {
     if (this == blockComponentTextDirectionLTR) {
       return TextDirection.ltr;
     } else if (this == blockComponentTextDirectionRTL) {
       return TextDirection.rtl;
     }
-    return fallback;
+    return null;
   }
 }

--- a/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
+++ b/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
@@ -111,7 +111,7 @@ class _BulletedListBlockComponentWidgetState
   @override
   Widget buildComponent(BuildContext context) {
     final textDirection = calculateTextDirection(
-      defaultTextDirection: Directionality.maybeOf(context),
+      layoutDirection: Directionality.maybeOf(context),
     );
 
     Widget child = Container(

--- a/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
@@ -116,6 +116,7 @@ class _HeadingBlockComponentWidgetState
   @override
   Node get node => widget.node;
 
+  @override
   late final editorState = Provider.of<EditorState>(context, listen: false);
 
   int get level => widget.node.attributes[HeadingBlockKeys.level] as int? ?? 1;
@@ -123,7 +124,7 @@ class _HeadingBlockComponentWidgetState
   @override
   Widget build(BuildContext context) {
     final textDirection = calculateTextDirection(
-      defaultTextDirection: Directionality.maybeOf(context),
+      layoutDirection: Directionality.maybeOf(context),
     );
 
     Widget child = Container(

--- a/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
+++ b/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
@@ -116,7 +116,7 @@ class _NumberedListBlockComponentWidgetState
   @override
   Widget buildComponent(BuildContext context) {
     final textDirection = calculateTextDirection(
-      defaultTextDirection: Directionality.maybeOf(context),
+      layoutDirection: Directionality.maybeOf(context),
     );
 
     Widget child = Container(

--- a/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
+++ b/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
@@ -104,12 +104,13 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
   @override
   Node get node => widget.node;
 
+  @override
   late final editorState = Provider.of<EditorState>(context, listen: false);
 
   @override
   Widget build(BuildContext context) {
     final textDirection = calculateTextDirection(
-      defaultTextDirection: Directionality.maybeOf(context),
+      layoutDirection: Directionality.maybeOf(context),
     );
 
     Widget child = Container(

--- a/lib/src/editor/block_component/text_block_component/text_block_component.dart
+++ b/lib/src/editor/block_component/text_block_component/text_block_component.dart
@@ -127,7 +127,7 @@ class _TextBlockComponentWidgetState extends State<TextBlockComponentWidget>
   @override
   Widget buildComponent(BuildContext context) {
     final textDirection = calculateTextDirection(
-      defaultTextDirection: Directionality.maybeOf(context),
+      layoutDirection: Directionality.maybeOf(context),
     );
 
     Widget child = Container(

--- a/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
+++ b/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
@@ -127,7 +127,7 @@ class _TodoListBlockComponentWidgetState
   @override
   Widget buildComponent(BuildContext context) {
     final textDirection = calculateTextDirection(
-      defaultTextDirection: Directionality.maybeOf(context),
+      layoutDirection: Directionality.maybeOf(context),
     );
 
     Widget child = Container(

--- a/lib/src/editor/editor_component/service/renderer/block_component_widget.dart
+++ b/lib/src/editor/editor_component/service/renderer/block_component_widget.dart
@@ -79,7 +79,7 @@ mixin NestedBlockComponentStatefulWidgetMixin<
     if (node.children.isNotEmpty) {
       direction = calculateNodeDirection(
         node: node.children.first,
-        defaultTextDirection: direction,
+        layoutDirection: direction,
       );
     }
     return configuration.indentPadding(node, direction);

--- a/lib/src/editor/editor_component/style/editor_style.dart
+++ b/lib/src/editor/editor_component/style/editor_style.dart
@@ -14,6 +14,7 @@ class EditorStyle {
     required this.selectionColor,
     required this.textStyleConfiguration,
     required this.textSpanDecorator,
+    this.defaultTextDirection,
   });
 
   /// The padding of the editor.
@@ -40,12 +41,15 @@ class EditorStyle {
   ///   or override the built-in text span.
   final TextSpanDecoratorForAttribute? textSpanDecorator;
 
+  final String? defaultTextDirection;
+
   const EditorStyle.desktop({
     EdgeInsets? padding,
     Color? cursorColor,
     Color? selectionColor,
     TextStyleConfiguration? textStyleConfiguration,
     TextSpanDecoratorForAttribute? textSpanDecorator,
+    this.defaultTextDirection,
   })  : padding = padding ?? const EdgeInsets.symmetric(horizontal: 100),
         cursorColor = cursorColor ?? const Color(0xFF00BCF0),
         selectionColor =
@@ -63,6 +67,7 @@ class EditorStyle {
     Color? selectionColor,
     TextStyleConfiguration? textStyleConfiguration,
     TextSpanDecoratorForAttribute? textSpanDecorator,
+    this.defaultTextDirection,
   })  : padding = padding ?? const EdgeInsets.symmetric(horizontal: 20),
         cursorColor = cursorColor ?? const Color(0xFF00BCF0),
         selectionColor =
@@ -80,6 +85,7 @@ class EditorStyle {
     Color? selectionColor,
     TextStyleConfiguration? textStyleConfiguration,
     TextSpanDecoratorForAttribute? textSpanDecorator,
+    String? defaultTextDirection,
   }) {
     return EditorStyle(
       padding: padding ?? this.padding,
@@ -88,6 +94,7 @@ class EditorStyle {
       textStyleConfiguration:
           textStyleConfiguration ?? this.textStyleConfiguration,
       textSpanDecorator: textSpanDecorator ?? this.textSpanDecorator,
+      defaultTextDirection: defaultTextDirection,
     );
   }
 }

--- a/test/new/block_component/text_direction_mixin_test.dart
+++ b/test/new/block_component/text_direction_mixin_test.dart
@@ -7,10 +7,21 @@ import '../infra/testable_editor.dart';
 class TextDirectionTest with BlockComponentTextDirectionMixin {
   TextDirectionTest({
     required this.node,
-  });
+    String? defaultTextDirection,
+    this.lastDirection,
+  }) {
+    editorState.editorStyle =
+        EditorStyle.desktop(defaultTextDirection: defaultTextDirection);
+  }
 
   @override
   final Node node;
+
+  @override
+  final EditorState editorState = EditorState.blank(withInitialText: false);
+
+  @override
+  TextDirection? lastDirection;
 }
 
 void main() {
@@ -33,6 +44,38 @@ void main() {
       expect(direction, TextDirection.ltr);
     });
 
+    test('fallback to layout direction', () {
+      final node = paragraphNode(
+        text: 'سلام',
+      );
+      final direction = TextDirectionTest(node: node).calculateTextDirection();
+      expect(direction, TextDirection.ltr);
+    });
+
+    test('fallback to default text direction', () {
+      final node = paragraphNode(
+        text: 'سلام',
+      );
+      final direction =
+          TextDirectionTest(node: node, defaultTextDirection: "rtl")
+              .calculateTextDirection();
+      expect(direction, TextDirection.rtl);
+    });
+
+    test(
+        'fallback to default text direction even if we have last direction (only fallback to last direction when node textDirection is auto)',
+        () {
+      final node = paragraphNode(
+        text: 'سلام',
+      );
+      final direction = TextDirectionTest(
+        node: node,
+        defaultTextDirection: "rtl",
+        lastDirection: TextDirection.ltr,
+      ).calculateTextDirection();
+      expect(direction, TextDirection.rtl);
+    });
+
     test('auto empty text', () {
       final node = paragraphNode(
         text: '',
@@ -50,7 +93,7 @@ void main() {
       final textDirectionTest = TextDirectionTest(node: node);
       textDirectionTest.lastDirection = TextDirection.rtl;
       final direction = textDirectionTest.calculateTextDirection(
-        defaultTextDirection: TextDirection.ltr,
+        layoutDirection: TextDirection.ltr,
       );
       expect(direction, TextDirection.rtl);
     });
@@ -114,7 +157,7 @@ void main() {
       );
       final direction =
           TextDirectionTest(node: node.children.last).calculateTextDirection(
-        defaultTextDirection: TextDirection.ltr,
+        layoutDirection: TextDirection.ltr,
       );
       expect(direction, TextDirection.rtl);
     });
@@ -133,7 +176,7 @@ void main() {
       );
       final direction =
           TextDirectionTest(node: node.children.last).calculateTextDirection(
-        defaultTextDirection: TextDirection.ltr,
+        layoutDirection: TextDirection.ltr,
       );
       expect(direction, TextDirection.ltr);
     });
@@ -155,7 +198,7 @@ void main() {
       );
       final direction =
           TextDirectionTest(node: node.children.last).calculateTextDirection(
-        defaultTextDirection: TextDirection.rtl,
+        layoutDirection: TextDirection.rtl,
       );
       expect(direction, TextDirection.ltr);
     });
@@ -180,7 +223,7 @@ void main() {
       textDirectionTest.lastDirection = TextDirection.ltr;
 
       final direction = textDirectionTest.calculateTextDirection(
-        defaultTextDirection: TextDirection.rtl,
+        layoutDirection: TextDirection.rtl,
       );
       expect(direction, TextDirection.ltr);
     });


### PR DESCRIPTION
Introduced default text direction property on editor style. which accepts rtl|ltr|auto for controlling default fallback direction. Before this we had something controlled by Directionality but it had two problems:
1. It didn't accept auto text direction. We had to introduce our own Directionality component.
2. Directionality also affects layout direction, for example setting Directionality to RTL will cause the handlers and other things move to right side of the screen. While this is good but there are cases which we don't want to change whole layout direction but only the text default direction to for example auto.