### PR TITLE
chore: comment suggesting use of deprecated method

### DIFF
--- a/lib/src/core/location/selection.dart
+++ b/lib/src/core/location/selection.dart
@@ -35,9 +35,7 @@ class Selection {
   })  : start = Position(path: path, offset: startOffset),
         end = Position(path: path, offset: endOffset ?? startOffset);
 
-  /// deprecated: use [Selection.collapse] instead.
   /// Create a collapsed selection with [position].
-  ///
   Selection.collapsed(Position position)
       : start = position,
         end = position;


### PR DESCRIPTION
Recently we have deprecated the the use of `selection.collapse()` and asked devs to use `selection.collapsed()` instead.
But the comment on `selection.collapsed()` suggests otherwise, this is confusing for the developer.

This PR removes the old comment on `selection.collapsed()` which asks the dev to use the `selection.collapse()` method.