### PR TITLE
fix: keyboard shortcut formatting error fix. Fixes #416 

### DIFF
--- a/lib/src/editor/command/text_commands.dart
+++ b/lib/src/editor/command/text_commands.dart
@@ -186,7 +186,7 @@ extension TextTransforms on EditorState {
         " ";
   }
 
-
+  
   /// Toggles the given attribute on or off for the selected text.
   ///
   /// If the [Selection] is not passed in, use the current selection.
@@ -199,6 +199,29 @@ extension TextTransforms on EditorState {
       return;
     }
     final nodes = getNodesInSelection(selection);
+
+    if (selection.length == 0) {
+      if (selection.end.offset == 0) {
+        insertTextAtCurrentSelection(" ");
+        selection = selection.copyWith(
+          start: selection.end.copyWith(offset: selection.end.offset),
+          end: selection.end.copyWith(offset: selection.end.offset + 1),
+        );
+      } else {
+        if (iswhiteSpaceBeforeSelected(selection)) {
+          selection = selection.copyWith(
+            start: selection.end.copyWith(offset: selection.end.offset - 1),
+            end: selection.end.copyWith(offset: selection.end.offset),
+          );
+        } else {
+          insertTextAtCurrentSelection(" ");
+          selection = selection.copyWith(
+            start: selection.end.copyWith(offset: selection.end.offset),
+            end: selection.end.copyWith(offset: selection.end.offset + 1),
+          );
+        }
+      }
+    }
     final isHighlight = nodes.allSatisfyInSelection(selection, (delta) {
       return delta.everyAttributes(
         (attributes) => attributes[key] == true,

--- a/lib/src/editor/command/text_commands.dart
+++ b/lib/src/editor/command/text_commands.dart
@@ -173,6 +173,19 @@ extension TextTransforms on EditorState {
       withUpdateSelection: withUpdateSelection,
     );
   }
+ bool iswhiteSpaceBeforeSelected(Selection selection) {
+    if (selection.end.offset == 0) {
+      return false;
+    }
+    return getTextInSelection(
+          selection.copyWith(
+            start: selection.end.copyWith(offset: selection.end.offset - 1),
+            end: selection.end.copyWith(offset: selection.end.offset),
+          ),
+        ).first ==
+        " ";
+  }
+
 
   /// Toggles the given attribute on or off for the selected text.
   ///

--- a/lib/src/editor/command/text_commands.dart
+++ b/lib/src/editor/command/text_commands.dart
@@ -173,7 +173,11 @@ extension TextTransforms on EditorState {
       withUpdateSelection: withUpdateSelection,
     );
   }
- bool iswhiteSpaceBeforeSelected(Selection selection) {
+
+  static const whiteSpaceCharacter = " ";
+  // A function to check if the character before the selection is a white space.
+  // Returs true if the character is a white space, false otherwise.
+  bool iswhiteSpaceBeforeSelected(Selection selection) {
     if (selection.end.offset == 0) {
       return false;
     }
@@ -182,11 +186,9 @@ extension TextTransforms on EditorState {
             start: selection.end.copyWith(offset: selection.end.offset - 1),
             end: selection.end.copyWith(offset: selection.end.offset),
           ),
-        ).first ==
-        " ";
+        ).first == whiteSpaceCharacter;
   }
 
-  
   /// Toggles the given attribute on or off for the selected text.
   ///
   /// If the [Selection] is not passed in, use the current selection.
@@ -199,10 +201,10 @@ extension TextTransforms on EditorState {
       return;
     }
     final nodes = getNodesInSelection(selection);
-
+// If the selection is collapsed, insert a white space character at the current selection. and format it.
     if (selection.length == 0) {
       if (selection.end.offset == 0) {
-        insertTextAtCurrentSelection(" ");
+        insertTextAtCurrentSelection(whiteSpaceCharacter);
         selection = selection.copyWith(
           start: selection.end.copyWith(offset: selection.end.offset),
           end: selection.end.copyWith(offset: selection.end.offset + 1),
@@ -214,7 +216,7 @@ extension TextTransforms on EditorState {
             end: selection.end.copyWith(offset: selection.end.offset),
           );
         } else {
-          insertTextAtCurrentSelection(" ");
+          insertTextAtCurrentSelection(whiteSpaceCharacter);
           selection = selection.copyWith(
             start: selection.end.copyWith(offset: selection.end.offset),
             end: selection.end.copyWith(offset: selection.end.offset + 1),


### PR DESCRIPTION
**This PR fixes the issue #416**


Steps I took to fix the issue:
 1. Having a selection is mandatory for formatting. ```selection.lenght > 0```
 2. Hence, when a keyboard shortcut is pressed, a **white space** is inserted. and the formatting is carried out on the whitespace
 3. from then, any text entered after the shortcut will have the same formatting options.

demo:



  
[Screencast from 08-09-23 01:22:34 AM IST.webm](https://github.com/AppFlowy-IO/appflowy-editor/assets/37525954/04e00a1b-a8ab-483b-a1f3-d3c27b97049b)


