### PR TITLE
fix: resolve "Bad state: no element" when in-table paragraph deleted

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
@@ -67,10 +67,18 @@ CommandShortcutEventHandler _backspaceInCollapsedSelection = (editorState) {
           ),
         );
     } else {
-      // merge with the previous node contains delta.
-      final prev = node.previousNodeWhere((element) => element.delta != null || element.type.contains('table'));
+      Node? tableParent = node.findParent((element) => element.type == TableBlockKeys.type);
+      Node? prevTableParent;
+      // table node should be deleted using table menu,
+      // in-table paragraph should only be deleted inside the table
+      final prev = node.previousNodeWhere((element) {
+        prevTableParent = element.findParent((element) => element.type == TableBlockKeys.type);
+        return tableParent != prevTableParent // break if only one in table or they're in different tables
+            || element.delta != null; // merge with the previous node contains delta.
+      });
       // table node should be deleted using table menu
-      if (prev != null && (!prev.type.contains('table') && (prev.parent != null && !prev.parent!.type.contains('table')))) {
+      // in-table paragraph should only be deleted inside the table
+      if (prev != null && tableParent == prevTableParent) {
         assert(prev.delta != null);
         transaction
           ..mergeText(prev, node)

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
@@ -70,8 +70,6 @@ CommandShortcutEventHandler _backspaceInCollapsedSelection = (editorState) {
       Node? tableParent =
           node.findParent((element) => element.type == TableBlockKeys.type);
       Node? prevTableParent;
-      // table node should be deleted using table menu,
-      // in-table paragraph should only be deleted inside the table
       final prev = node.previousNodeWhere((element) {
         prevTableParent = element
             .findParent((element) => element.type == TableBlockKeys.type);

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
@@ -78,8 +78,8 @@ CommandShortcutEventHandler _backspaceInCollapsedSelection = (editorState) {
             // merge with the previous node contains delta.
             element.delta != null;
       });
-      // table node should be deleted using table menu
-      // in-table paragraph should only be deleted inside the table
+      // table nodes should be deleted using the table menu
+      // in-table paragraphs should only be deleted inside the table
       if (prev != null && tableParent == prevTableParent) {
         assert(prev.delta != null);
         transaction

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
@@ -68,22 +68,22 @@ CommandShortcutEventHandler _backspaceInCollapsedSelection = (editorState) {
         );
     } else {
       // merge with the previous node contains delta.
-      final previousNodeWithDelta =
-          node.previousNodeWhere((element) => element.delta != null);
-      if (previousNodeWithDelta != null) {
-        assert(previousNodeWithDelta.delta != null);
+      final prev = node.previousNodeWhere((element) => element.delta != null || element.type.contains('table'));
+      // table node should be deleted using table menu
+      if (prev != null && (!prev.type.contains('table') && (prev.parent != null && !prev.parent!.type.contains('table')))) {
+        assert(prev.delta != null);
         transaction
-          ..mergeText(previousNodeWithDelta, node)
+          ..mergeText(prev, node)
           ..insertNodes(
             // insert children to previous node
-            previousNodeWithDelta.path.next,
+            prev.path.next,
             node.children.toList(),
           )
           ..deleteNode(node)
           ..afterSelection = Selection.collapsed(
             Position(
-              path: previousNodeWithDelta.path,
-              offset: previousNodeWithDelta.delta!.length,
+              path: prev.path,
+              offset: prev.delta!.length,
             ),
           );
       } else {

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/backspace_command.dart
@@ -67,14 +67,18 @@ CommandShortcutEventHandler _backspaceInCollapsedSelection = (editorState) {
           ),
         );
     } else {
-      Node? tableParent = node.findParent((element) => element.type == TableBlockKeys.type);
+      Node? tableParent =
+          node.findParent((element) => element.type == TableBlockKeys.type);
       Node? prevTableParent;
       // table node should be deleted using table menu,
       // in-table paragraph should only be deleted inside the table
       final prev = node.previousNodeWhere((element) {
-        prevTableParent = element.findParent((element) => element.type == TableBlockKeys.type);
-        return tableParent != prevTableParent // break if only one in table or they're in different tables
-            || element.delta != null; // merge with the previous node contains delta.
+        prevTableParent = element
+            .findParent((element) => element.type == TableBlockKeys.type);
+        // break if only one is in a table or they're in different tables
+        return tableParent != prevTableParent ||
+            // merge with the previous node contains delta.
+            element.delta != null;
       });
       // table node should be deleted using table menu
       // in-table paragraph should only be deleted inside the table

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -56,8 +56,8 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
           // merge the next node with delta
           element.delta != null;
     });
-    // table node should be deleted using table menu
-    // in-table paragraph should only be deleted inside the table
+    // table nodes should be deleted using the table menu
+    // in-table paragraphs should only be deleted inside the table
     if (next != null && tableParent == nextTableParent) {
       if (next.children.isNotEmpty) {
         final path = node.path + [node.children.length];

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -47,8 +47,10 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
   // merge the next node with delta
   if (position.offset == delta.length) {
     // stop findDownward if table node encountered
-    final next = node.findDownward((element) =>
-        element.type.contains('table') ? null : element.delta != null);
+    final next = node.findDownward(
+      (element) =>
+          element.type.contains('table') ? null : element.delta != null,
+    );
     if (next != null) {
       if (next.children.isNotEmpty) {
         final path = node.path + [node.children.length];

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -46,11 +46,7 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
 
   // merge the next node with delta
   if (position.offset == delta.length) {
-    // stop findDownward if table node encountered
-    final next = node.findDownward(
-      (element) =>
-          element.type.contains('table') ? null : element.delta != null,
-    );
+    final next = node.findDownward((element) => element.delta != null);
     if (next != null) {
       if (next.children.isNotEmpty) {
         final path = node.path + [node.children.length];

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -46,9 +46,11 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
 
   // merge the next node with delta
   if (position.offset == delta.length) {
-    final next = node.findDownward((element) => element.delta != null);
-    if (next != null) {
+    final next = node.findDownward((element) => element.delta != null || element.type.contains('table'));
+    // table node should be deleted using table menu
+    if (next != null && !next.type.contains('table')) {
       if (next.children.isNotEmpty) {
+
         final path = node.path + [node.children.length];
         transaction.insertNodes(path, next.children);
       }

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -45,12 +45,16 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
   final transaction = editorState.transaction;
 
   if (position.offset == delta.length) {
-    Node? tableParent = node.findParent((element) => element.type == TableBlockKeys.type);
+    Node? tableParent =
+        node.findParent((element) => element.type == TableBlockKeys.type);
     Node? nextTableParent;
     final next = node.findDownward((element) {
-      nextTableParent = element.findParent((element) => element.type == TableBlockKeys.type);
-      return tableParent != nextTableParent // break if only one in table or they're in different tables
-          || element.delta != null; // merge the next node with delta
+      nextTableParent =
+          element.findParent((element) => element.type == TableBlockKeys.type);
+      // break if only one is in a table or they're in different tables
+      return tableParent != nextTableParent ||
+          // merge the next node with delta
+          element.delta != null;
     });
     // table node should be deleted using table menu
     // in-table paragraph should only be deleted inside the table

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -46,7 +46,8 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
 
   // merge the next node with delta
   if (position.offset == delta.length) {
-    final next = node.findDownward((element) => element.delta != null);
+    final next = node.findDownward((element) =>
+        element.type.contains('table') ? null : element.delta != null);
     if (next != null) {
       if (next.children.isNotEmpty) {
         final path = node.path + [node.children.length];

--- a/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command_shortcut_events/delete_command.dart
@@ -46,6 +46,7 @@ CommandShortcutEventHandler _deleteInCollapsedSelection = (editorState) {
 
   // merge the next node with delta
   if (position.offset == delta.length) {
+    // stop findDownward if table node encountered
     final next = node.findDownward((element) =>
         element.type.contains('table') ? null : element.delta != null);
     if (next != null) {

--- a/lib/src/extensions/node_extensions.dart
+++ b/lib/src/extensions/node_extensions.dart
@@ -132,6 +132,14 @@ extension NodeExtensions on Node {
     }
     return false;
   }
+
+  Node? findParent(bool Function(Node element) test) {
+    if (test(this)) {
+      return this;
+    }
+    final parent = this.parent;
+    return parent?.findParent(test);
+  }
 }
 
 extension NodesExtensions<T extends Node> on List<T> {

--- a/lib/src/extensions/node_extensions.dart
+++ b/lib/src/extensions/node_extensions.dart
@@ -79,33 +79,25 @@ extension NodeExtensions on Node {
   }
 
   // find the node from it's children or it's next sibling to find the node that matches the given predicate
-  Node? findDownward(bool? Function(Node element) test) {
+  Node? findDownward(bool Function(Node element) test) {
     final children = this.children.toList();
     for (final child in children) {
-      switch (test(child)) {
-        case null:
-          return null;
-        case true:
-          return child;
-        case false:
-          if (child.children.isNotEmpty) {
-            final node = child.findDownward(test);
-            if (node != null) {
-              return node;
-            }
-          }
+      if (test(child)) {
+        return child;
+      }
+      if (child.children.isNotEmpty) {
+        final node = child.findDownward(test);
+        if (node != null) {
+          return node;
+        }
       }
     }
     final next = this.next;
     if (next != null) {
-      switch (test(next)) {
-        case null:
-          return null;
-        case true:
-          return next;
-        case false:
-          return next.findDownward(test);
+      if (test(next)) {
+        return next;
       }
+      return next.findDownward(test);
     }
     return null;
   }

--- a/lib/src/extensions/node_extensions.dart
+++ b/lib/src/extensions/node_extensions.dart
@@ -79,25 +79,33 @@ extension NodeExtensions on Node {
   }
 
   // find the node from it's children or it's next sibling to find the node that matches the given predicate
-  Node? findDownward(bool Function(Node element) test) {
+  Node? findDownward(bool? Function(Node element) test) {
     final children = this.children.toList();
     for (final child in children) {
-      if (test(child)) {
-        return child;
-      }
-      if (child.children.isNotEmpty) {
-        final node = child.findDownward(test);
-        if (node != null) {
-          return node;
-        }
+      switch (test(child)) {
+        case null:
+          return null;
+        case true:
+          return child;
+        case false:
+          if (child.children.isNotEmpty) {
+            final node = child.findDownward(test);
+            if (node != null) {
+              return node;
+            }
+          }
       }
     }
     final next = this.next;
     if (next != null) {
-      if (test(next)) {
-        return next;
+      switch (test(next)) {
+        case null:
+          return null;
+        case true:
+          return next;
+        case false:
+          return next.findDownward(test);
       }
-      return next.findDownward(test);
     }
     return null;
   }


### PR DESCRIPTION
Close #465 .

This occurred because the table was not deleted, instead, the paragraph in the first cell was deleted. As a result, no child elements could be found in the cell when building the table (and thus throws "bad state, no element").

I'm not sure if this is the right way. If this fix is not correct or not the best practice, please make any suggestions or modifications, or, of course, close it.