### PR TITLE
fix: fix mobile selection drag

### DIFF
--- a/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
@@ -319,14 +319,17 @@ class _MobileSelectionServiceWidgetState
     if (end != null) {
       if (dragMode == MobileSelectionDragMode.leftSelectionHandler) {
         updateSelection(
-          selection.copyWith(
+          Selection(
+            start: _panStartSelection!.normalized.end,
             end: end,
-            start: _panStartSelection?.normalized.end,
-          ),
+          ).normalized,
         );
       } else if (dragMode == MobileSelectionDragMode.rightSelectionHandler) {
         updateSelection(
-          selection.copyWith(end: end),
+          Selection(
+            start: _panStartSelection!.normalized.start,
+            end: end,
+          ).normalized,
         );
       } else if (dragMode == MobileSelectionDragMode.cursor) {
         updateSelection(
@@ -479,8 +482,7 @@ class _MobileSelectionServiceWidgetState
         }
         break;
       case MobileSelectionHandlerType.rightHandler:
-        selectable =
-            editorState.getNodeAtPath(selection.start.path)?.selectable;
+        selectable = editorState.getNodeAtPath(selection.end.path)?.selectable;
         if (selectable == null) {
           return false;
         }


### PR DESCRIPTION
bug screen record:
when you drag left handler first, then you drag right handler will cause this bug, selection changed wrong.

![bug](https://github.com/AppFlowy-IO/appflowy-editor/assets/37775224/df0ebe25-3cac-4a10-a725-77d9fb68be87)

fixed:
![fixed](https://github.com/AppFlowy-IO/appflowy-editor/assets/37775224/944ef4cc-6129-4857-b750-ecff0aa67d22)
