### PR TITLE
fix: the selection handles remain on the screen after cutting the text

### DIFF
--- a/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
@@ -203,6 +203,7 @@ class _MobileSelectionServiceWidgetState
   void _updateSelection() {
     final selection = editorState.selection;
     if (currentSelection.value != selection) {
+      clearSelection();
       return;
     }
 


### PR DESCRIPTION
closes #514 