### PR TITLE
fix: cursor blink at wrong location when inserting text

### DIFF
--- a/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
@@ -73,6 +73,14 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _updateSelectionIfNeeded();
     });
+    widget.listenable.addListener(_clearCursorRect);
+  }
+
+  @override
+  void dispose() {
+    widget.listenable.removeListener(_clearCursorRect);
+
+    super.dispose();
   }
 
   @override
@@ -205,5 +213,9 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       _updateSelectionIfNeeded();
     });
+  }
+
+  void _clearCursorRect() {
+    prevCursorRect = null;
   }
 }


### PR DESCRIPTION
# Preview
## Before

https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/101e6c3b-1b5e-4827-8194-ca5589d8cef4

## After

https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/9f782d84-6af7-44e6-9e89-c439f2962e8f

