### PR TITLE
feat: power checkbox shortcut

### DIFF
--- a/lib/src/editor/block_component/standard_block_components.dart
+++ b/lib/src/editor/block_component/standard_block_components.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 const standardBlockComponentConfiguration = BlockComponentConfiguration();
 
@@ -16,6 +17,11 @@ final Map<String, BlockComponentBuilder> standardBlockComponentBuilderMap = {
     configuration: standardBlockComponentConfiguration.copyWith(
       placeholderText: (_) => 'To-do',
     ),
+    toggleChildrenTriggers: [
+      LogicalKeyboardKey.shift,
+      LogicalKeyboardKey.shiftLeft,
+      LogicalKeyboardKey.shiftRight,
+    ],
   ),
   BulletedListBlockKeys.type: BulletedListBlockComponentBuilder(
     configuration: standardBlockComponentConfiguration.copyWith(

--- a/test/new/block_component/todo_list_block_component/todo_list_power_toggle_test.dart
+++ b/test/new/block_component/todo_list_block_component/todo_list_power_toggle_test.dart
@@ -1,0 +1,62 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../infra/testable_editor.dart';
+
+void main() async {
+  group('todo list power toggle', () {
+    const text = 'Welcome to AppFlowy Editor 🔥!';
+
+    // - [] Welcome to AppFlowy Editor 🔥!
+    //   - [] Welcome to AppFlowy Editor 🔥!
+    //     - [] Welcome to AppFlowy Editor 🔥!
+    testWidgets('use power toggle', (tester) async {
+      final editor = tester.editor
+        ..addNode(
+          todoListNode(
+            delta: Delta()..insert(text),
+            checked: false,
+            children: [
+              todoListNode(
+                delta: Delta()..insert(text),
+                checked: false,
+                children: [
+                  todoListNode(
+                    delta: Delta()..insert(text),
+                    checked: false,
+                    children: [],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+
+      await editor.startTesting();
+
+      Node n1 = editor.document.root.children.first;
+      Node n2 = n1.children.first;
+      Node n3 = n2.children.first;
+
+      expect(n1.attributes[TodoListBlockKeys.checked], false);
+      expect(n2.attributes[TodoListBlockKeys.checked], false);
+      expect(n3.attributes[TodoListBlockKeys.checked], false);
+
+      final finder = find.byType(EditorSvg).first;
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(finder);
+      await tester.pumpAndSettle();
+
+      n1 = editor.document.root.children.first;
+      n2 = n1.children.first;
+      n3 = n2.children.first;
+
+      expect(n1.attributes[TodoListBlockKeys.checked], true);
+      expect(n2.attributes[TodoListBlockKeys.checked], true);
+      expect(n3.attributes[TodoListBlockKeys.checked], true);
+
+      await editor.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Add an easy way to add LogicalKeyboardKey triggers to the Todo Block, to power toggle a checkbox, which toggles all of it's children to the same state of the todo that is toggled.


https://github.com/AppFlowy-IO/appflowy-editor/assets/42929161/da5b9854-d023-4912-96de-ed97e3305e9a

