### PR TITLE
fix: on ui event reset selection type

### DIFF
--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -439,43 +439,6 @@ class _DesktopSelectionServiceWidgetState
     return min.clamp(start, end);
   }
 
-  /*void _showDebugLayerIfNeeded() {
-     remove false to show debug overlay.
-     if (kDebugMode && false) {
-       _debugOverlay?.remove();
-       if (offset != null) {
-         _debugOverlay = OverlayEntry(
-           builder: (context) => Positioned.fromRect(
-             rect: Rect.fromPoints(offset, offset.translate(20, 20)),
-             child: Container(
-               color: Colors.red.withOpacity(0.2),
-             ),
-           ),
-         );
-         Overlay.of(context)?.insert(_debugOverlay!);
-       } else if (_panStartOffset != null) {
-         _debugOverlay = OverlayEntry(
-           builder: (context) => Positioned.fromRect(
-             rect: Rect.fromPoints(
-                 _panStartOffset?.translate(
-                       0,
-                       -(editorState.service.scrollService!.dy -
-                           _panStartScrollDy!),
-                     ) ??
-                     Offset.zero,
-                 offset ?? Offset.zero),
-             child: Container(
-               color: Colors.red.withOpacity(0.2),
-             ),
-           ),
-         );
-         Overlay.of(context)?.insert(_debugOverlay!);
-       } else {
-         _debugOverlay = null;
-       }
-     }
-  }*/
-
   @override
   void registerGestureInterceptor(SelectionGestureInterceptor interceptor) {
     _interceptors.add(interceptor);

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -191,6 +191,7 @@ class EditorState {
     final completer = Completer<void>();
 
     if (reason == SelectionUpdateReason.uiEvent) {
+      selectionType = SelectionType.inline;
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) => completer.complete(),
       );
@@ -199,6 +200,7 @@ class EditorState {
     // broadcast to other users here
     selectionExtraInfo = extraInfo;
     _selectionUpdateReason = reason;
+
     this.selection = selection;
 
     return completer.future;

--- a/test/service/selection_service_test.dart
+++ b/test/service/selection_service_test.dart
@@ -160,5 +160,29 @@ void main() async {
 
       await editor.dispose();
     });
+
+    testWidgets('Block selection and then single tap', (tester) async {
+      const text = 'Welcome to Appflowy 😁';
+      final editor = tester.editor..addParagraph(initialText: text);
+      await editor.startTesting();
+
+      final firstNode = editor.nodeAtPath([0]);
+      final finder = find.byKey(firstNode!.key);
+
+      final rect = tester.getRect(finder);
+
+      editor.editorState.selectionType = SelectionType.block;
+
+      // tap at the beginning
+      await tester.tapAt(rect.centerLeft);
+      expect(
+        editor.selection,
+        Selection.single(path: [0], startOffset: 0),
+      );
+
+      expect(editor.editorState.selectionType, SelectionType.inline);
+
+      await editor.dispose();
+    });
   });
 }


### PR DESCRIPTION
By resetting the SelectionType on `SelectionUpdateReason.uiEvent`, when a Block is selected with the type `SelectionType.block`, you can cancel it by making a new selection (pressing).