### PR TITLE
fix: selection menu positioning on right half of editor

### DIFF
--- a/lib/src/editor/selection_menu/selection_menu_service.dart
+++ b/lib/src/editor/selection_menu/selection_menu_service.dart
@@ -192,8 +192,8 @@ class SelectionMenu extends SelectionMenuService {
 
   void calculateSelectionMenuOffset(Rect rect) {
     // Workaround: We can customize the padding through the [EditorStyle],
-    //  but the coordinates of overlay are not properly converted currently.
-    //  Just subtract the padding here as a result.
+    // but the coordinates of overlay are not properly converted currently.
+    // Just subtract the padding here as a result.
     const menuHeight = 200.0;
     const menuOffset = Offset(0, 10);
     final editorOffset =
@@ -223,13 +223,13 @@ class SelectionMenu extends SelectionMenuService {
     }
 
     // show on left
-    if (_offset.dx > editorWidth / 2) {
+    if (_offset.dx - editorOffset.dx > editorWidth / 2) {
       _alignment = _alignment == Alignment.topLeft
           ? Alignment.topRight
           : Alignment.bottomRight;
 
       _offset = Offset(
-        editorWidth - _offset.dx,
+        editorWidth - _offset.dx + editorOffset.dx,
         _offset.dy,
       );
     }


### PR DESCRIPTION
part of https://github.com/AppFlowy-IO/AppFlowy/issues/3414.

The problem was presupposing that the editor width equal to the application width. So when there was something like a sidebar in AppFlowy the calculations were going wrong.

There will be still issues with the selection menu because the width is too long. It should get shorter and other items should get access through scroll. 
Personally, I prefer a vertical menu rather than a horizontal one.