### PR TITLE
fix: renamed duplicated shortcut key

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command/paste_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/paste_command.dart
@@ -22,7 +22,7 @@ final CommandShortcutEvent pasteCommand = CommandShortcutEvent(
 
 final CommandShortcutEvent pasteTextWithoutFormattingCommand =
     CommandShortcutEvent(
-  key: 'paste the content',
+  key: 'paste the content as plain text',
   command: 'ctrl+shift+v',
   macOSCommand: 'cmd+shift+v',
   handler: _pasteTextWithoutFormattingCommandHandler,


### PR DESCRIPTION
Renamed the key **"paste the content"** for shortcut `ctrl+shift+v` to **"paste the content as plain text"**

this PR is related to [[Bug] Duplicate commands and key bindings in Shortcuts menu #4193](https://github.com/AppFlowy-IO/AppFlowy/issues/4193)