### PR TITLE
feat: backslash to ignore shortcut event

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/character/format_single_character/format_single_character.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/character/format_single_character/format_single_character.dart
@@ -46,9 +46,12 @@ bool handleFormatByWrappingWithSingleCharacter({
   // 3. The text between the last char and trigger char are all spaces. For example, adding '_' after '_abc_ ' won't trigger formatting.
   // Note since we support using '\' to escape the character,it could be possible that multiple shortcut characters exist in the plainText.
   // We should only format the last one. like adding '_' after '\_abc\_ _123' should format the text to '123'
+  // 4. If the character before the last 'Character' is the same as the 'Character', we don't need to format it in single character case.
+  // For example, adding * after **a*, it skips the single character formatting and it will be handled by double character formatting.
   if (lastCharIndex == -1 ||
       lastCharIndex + 1 == triggerCharIndex ||
-      isFullOfSpaces) {
+      isFullOfSpaces ||
+      plainText[lastCharIndex - 1] == character) {
     return false;
   }
 

--- a/test/new/editor_component/service/shortcuts/character_shortcuts/back_slash_igore_format_test.dart
+++ b/test/new/editor_component/service/shortcuts/character_shortcuts/back_slash_igore_format_test.dart
@@ -68,6 +68,26 @@ void main() async {
 
         await editor.dispose();
       });
+
+      testWidgets('`AppFlowy[backslash]` to `AppFlowy` ', (tester) async {
+        const originalText = '`AppFlowy\\';
+        const resultText = '`AppFlowy`';
+
+        final editor = tester.editor..addParagraph(initialText: originalText);
+        await editor.startTesting();
+
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: originalText.length)),
+        );
+
+        await editor.ime.typeText('`');
+
+        final node = editor.nodeAtPath([0]);
+        expect(node!.delta!.toList()[0].attributes, null);
+        expect(node.delta!.toPlainText(), resultText);
+
+        await editor.dispose();
+      });
     });
 
     group('For the space enabled shortcut events', () {
@@ -91,9 +111,9 @@ void main() async {
         await editor.dispose();
       });
 
-      testWidgets('`AppFlowy[backslash]` to `AppFlowy` ', (tester) async {
-        const originalText = '`AppFlowy\\';
-        const resultText = '`AppFlowy`';
+      testWidgets('[{backslash}] to [] ', (tester) async {
+        const originalText = '[\\]';
+        const resultText = '[] ';
 
         final editor = tester.editor..addParagraph(initialText: originalText);
         await editor.startTesting();
@@ -102,7 +122,7 @@ void main() async {
           Selection.collapsed(Position(path: [0], offset: originalText.length)),
         );
 
-        await editor.ime.typeText('`');
+        await editor.ime.typeText(' ');
 
         final node = editor.nodeAtPath([0]);
         expect(node!.delta!.toList()[0].attributes, null);

--- a/test/new/editor_component/service/shortcuts/character_shortcuts/back_slash_igore_format_test.dart
+++ b/test/new/editor_component/service/shortcuts/character_shortcuts/back_slash_igore_format_test.dart
@@ -69,5 +69,47 @@ void main() async {
         await editor.dispose();
       });
     });
+
+    group('For the space enabled shortcut events', () {
+      testWidgets('[backslash]- to - ', (tester) async {
+        const originalText = '\\-';
+        const resultText = '- ';
+
+        final editor = tester.editor..addParagraph(initialText: originalText);
+        await editor.startTesting();
+
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: originalText.length)),
+        );
+
+        await editor.ime.typeText(' ');
+
+        final node = editor.nodeAtPath([0]);
+        expect(node!.delta!.toList()[0].attributes, null);
+        expect(node.delta!.toPlainText(), resultText);
+
+        await editor.dispose();
+      });
+
+      testWidgets('`AppFlowy[backslash]` to `AppFlowy` ', (tester) async {
+        const originalText = '`AppFlowy\\';
+        const resultText = '`AppFlowy`';
+
+        final editor = tester.editor..addParagraph(initialText: originalText);
+        await editor.startTesting();
+
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: originalText.length)),
+        );
+
+        await editor.ime.typeText('`');
+
+        final node = editor.nodeAtPath([0]);
+        expect(node!.delta!.toList()[0].attributes, null);
+        expect(node.delta!.toPlainText(), resultText);
+
+        await editor.dispose();
+      });
+    });
   });
 }

--- a/test/new/editor_component/service/shortcuts/character_shortcuts/back_slash_igore_format_test.dart
+++ b/test/new/editor_component/service/shortcuts/character_shortcuts/back_slash_igore_format_test.dart
@@ -1,0 +1,73 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../../../../infra/testable_editor.dart';
+
+void main() async {
+  group('backslash to igore character shortcut', () {
+    group('For the wrapped style shortcut events', () {
+      testWidgets('_AppFlowy[backslash]_ to _AppFlowy_', (tester) async {
+        const originalText = '_AppFlowy\\';
+        const resultText = '_AppFlowy_';
+
+        final editor = tester.editor..addParagraph(initialText: originalText);
+        await editor.startTesting();
+
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: originalText.length)),
+        );
+
+        await editor.ime.typeText('_');
+
+        final node = editor.nodeAtPath([0]);
+        expect(node!.delta!.toList()[0].attributes, null);
+        expect(node.delta!.toPlainText(), resultText);
+        await editor.dispose();
+      });
+
+      testWidgets('__AppFlowy_[backslash]_ to __AppFlowy__', (tester) async {
+        const originalText = '__AppFlowy_\\';
+        const resultText = '__AppFlowy__';
+
+        final editor = tester.editor..addParagraph(initialText: originalText);
+        await editor.startTesting();
+
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: originalText.length)),
+        );
+
+        await editor.ime.typeText('_');
+
+        final node = editor.nodeAtPath([0]);
+        expect(node!.delta!.toList()[0].attributes, null);
+        expect(node.delta!.toPlainText(), resultText);
+
+        await editor.dispose();
+      });
+
+// Even the previous text has ignored the character shortcut by back slash
+// The rest of the text should still can be formatted by character shortcut later
+// The following '_Hello_' has been ignored the character shortcut by back slash
+      testWidgets('_Hello_ _AppFlowy_ to _Hello_ AppFlowy[italic]',
+          (tester) async {
+        const originalText = '_Hello_ _AppFlowy';
+        const resultText = '_Hello_ AppFlowy';
+
+        final editor = tester.editor..addParagraph(initialText: originalText);
+        await editor.startTesting();
+
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: originalText.length)),
+        );
+
+        await editor.ime.typeText('_');
+
+        final node = editor.nodeAtPath([0]);
+        expect(node!.delta!.toList()[0].attributes, null);
+        expect(node.delta!.toList()[1].attributes, {'italic': true});
+        expect(node.delta!.toPlainText(), resultText);
+
+        await editor.dispose();
+      });
+    });
+  });
+}


### PR DESCRIPTION
###  Feature Preview
To close
 https://github.com/AppFlowy-IO/AppFlowy/issues/3628
 https://github.com/AppFlowy-IO/AppFlowy/issues/3964
 
 Add the ability to ignore the `CharacterShortcutEvent`
 Use `\` to skip all the markdown style


**For the wrapped style shortcut events**
like \_abc_   \**abc**  \__abc__  \~~abc~~  \`abc`

Put `\` in front of the enable character. 

https://github.com/AppFlowy-IO/appflowy-editor/assets/14248245/a6546c46-6890-4485-afd7-b1f5759c7a3b

**For the space enabled shortcut events**
like - abc, " abc, > abc, # abc, -[] ABC

Put `\` in front of the character before the space

https://github.com/AppFlowy-IO/appflowy-editor/assets/14248245/af3ea7ec-55c4-4ede-b38e-c109ff40a131






