### PR TITLE
fix: ignore_parent_gesture

### DIFF
--- a/lib/src/editor/block_component/base_component/widget/ignore_parent_gesture.dart
+++ b/lib/src/editor/block_component/base_component/widget/ignore_parent_gesture.dart
@@ -20,7 +20,6 @@ class IgnoreEditorSelectionGesture extends StatefulWidget {
 class _IgnoreEditorSelectionGestureState
     extends State<IgnoreEditorSelectionGesture> {
   final key = Random(10000).toString();
-  final FocusNode _focusNode = FocusNode();
   late final SelectionGestureInterceptor interceptor;
   late final EditorState editorState = context.read<EditorState>();
 
@@ -50,12 +49,14 @@ class _IgnoreEditorSelectionGestureState
 
   @override
   Widget build(BuildContext context) {
-    return Focus(
-      focusNode: _focusNode,
-      onFocusChange: (value) {
-        // current has focus ，close editor
-        if (value) {
-          editorState.selection = null;
+    return Listener(
+      onPointerDown: (event) {
+        final renderObject = context.findRenderObject();
+        // touch to clear
+        if (renderObject != null && renderObject is RenderBox) {
+          if (renderObject.paintBounds.contains(event.localPosition)) {
+            editorState.selection = null;
+          }
         }
       },
       child: widget.child,


### PR DESCRIPTION
Solve the focus problem caused by monitoring onFocusChange and change to monitoring click events


https://github.com/AppFlowy-IO/appflowy-editor/assets/4517301/bc669f32-d70b-4059-9bf0-484f426291dd

