### PR TITLE
fix:Solve the problem that Chinese ime cannot continue deleting after deleting input content

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -192,6 +192,10 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
         delta is TextEditingDeltaNonTextUpdate) {
       composingTextRange = delta.composing;
     }
+    //Solve the problem that Chinese ime cannot continue deleting after deleting input content
+    if (composingTextRange?.isCollapsed ?? false) {
+      composingTextRange = TextRange.empty;
+    }
   }
 }
 

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -192,7 +192,8 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
         delta is TextEditingDeltaNonTextUpdate) {
       composingTextRange = delta.composing;
     }
-    //Solve the problem that Chinese ime cannot continue deleting after deleting input content
+    
+    // solve the issue where the Chinese IME doesn't continue deleting after the input content has been deleted.
     if (composingTextRange?.isCollapsed ?? false) {
       composingTextRange = TextRange.empty;
     }


### PR DESCRIPTION
Solve the problem that Chinese ime cannot continue deleting after deleting input content

Before

https://github.com/AppFlowy-IO/appflowy-editor/assets/4517301/5d7a684a-c61f-4e82-882a-f86c30f3c76a

After


https://github.com/AppFlowy-IO/appflowy-editor/assets/4517301/2fc1d886-10d8-49c1-a8d2-e7c151936002

