### PR TITLE
feat:Optimize Enter operation

### DIFF
--- a/lib/src/editor/block_component/base_component/insert_newline_in_type_command.dart
+++ b/lib/src/editor/block_component/base_component/insert_newline_in_type_command.dart
@@ -19,6 +19,9 @@ Future<bool> insertNewLineInType(
 
   if (selection.startIndex == 0 && delta.isEmpty) {
     // clear the style
+    if (node != null && node.path.length > 1) {
+      return KeyEventResult.ignored != outdentCommand.execute(editorState);
+    }
     return KeyEventResult.ignored !=
         convertToParagraphCommand.execute(editorState);
   }

--- a/test/editor/block_component/base_component/insert_newline_in_type_command_test.dart
+++ b/test/editor/block_component/base_component/insert_newline_in_type_command_test.dart
@@ -1,0 +1,77 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('InsertNewlineInTypeCommand tests', () {
+    test('bulleted list', () async {
+      final bulletedNode = bulletedListNode(
+        text: 'bulleted list 1',
+        children: [
+          bulletedListNode(text: '1'),
+          bulletedListNode(text: ''),
+        ],
+      );
+      final document = Document.blank()..insert([0], [bulletedNode]);
+
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection.collapsed(Position(path: [0, 1]));
+
+      insertNewLineAfterBulletedList.execute(editorState);
+      Node? node1 = editorState.getNodeAtPath([1]);
+      expect(node1?.type, BulletedListBlockKeys.type);
+
+      insertNewLineAfterBulletedList.execute(editorState);
+      Node? node2 = editorState.getNodeAtPath([1]);
+
+      expect(node2?.type, ParagraphBlockKeys.type);
+    });
+
+    test('todo list', () async {
+      final todoListNodes = todoListNode(
+        checked: false,
+        children: [
+          todoListNode(checked: false),
+          todoListNode(checked: false),
+        ],
+      );
+      final document = Document.blank()..insert([0], [todoListNodes]);
+
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection.collapsed(Position(path: [0, 1]));
+
+      insertNewLineAfterTodoList.execute(editorState);
+      Node? node1 = editorState.getNodeAtPath([1]);
+      expect(node1?.type, TodoListBlockKeys.type);
+
+      insertNewLineAfterTodoList.execute(editorState);
+      Node? node2 = editorState.getNodeAtPath([1]);
+
+      expect(node2?.type, ParagraphBlockKeys.type);
+    });
+
+    test('numbered list', () async {
+      final numberedListNodes = numberedListNode(
+        children: [
+          numberedListNode(),
+          numberedListNode(),
+        ],
+      );
+      final document = Document.blank()..insert([0], [numberedListNodes]);
+
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection.collapsed(Position(path: [0, 1]));
+
+      insertNewLineAfterNumberedList.execute(editorState);
+      Node? node1 = editorState.getNodeAtPath([1]);
+      expect(node1?.type, NumberedListBlockKeys.type);
+
+      insertNewLineAfterNumberedList.execute(editorState);
+      Node? node2 = editorState.getNodeAtPath([1]);
+
+      expect(node2?.type, ParagraphBlockKeys.type);
+    });
+  });
+}

--- a/test/new/service/shortcuts/command_shortcut_events/enter_without_shift_in_text_node_handler_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/enter_without_shift_in_text_node_handler_test.dart
@@ -1,6 +1,7 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../../../infra/testable_editor.dart';
 
 void main() async {
@@ -253,19 +254,19 @@ Future<void> _testListOutdent(WidgetTester tester, String style) async {
   // clear the style
   expect(
     editor.selection,
-    Selection.single(path: [1, 0], startOffset: 0),
+    Selection.single(path: [2], startOffset: 0),
   );
-  expect(editor.nodeAtPath([1, 0])?.type, 'paragraph');
+  expect(editor.nodeAtPath([2])?.type, style);
 
   await editor.pressKey(
     character: '\n',
   );
   expect(
     editor.selection,
-    Selection.single(path: [1, 1], startOffset: 0),
+    Selection.single(path: [2], startOffset: 0),
   );
 
-  expect(editor.nodeAtPath([1, 1])?.type, 'paragraph');
+  expect(editor.nodeAtPath([2])?.type, 'paragraph');
 
   await editor.dispose();
 }


### PR DESCRIPTION
Modify the operation of the Enter key for list type blocks. If it is empty, perform the Shift+Tab operation until it returns to no format.


https://github.com/AppFlowy-IO/appflowy-editor/assets/4517301/8a79f151-50af-4d04-b60d-5ecfbdf34943

