### PR TITLE
feat: parse nested numbered list

### DIFF
--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -81,7 +81,8 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
 
         while (i < lines.length &&
             (lines[i].trimLeft().startsWith('- ') ||
-                lines[i].trimLeft().startsWith('* ')) &&
+                lines[i].trimLeft().startsWith('* ') ||
+                numberedListRegex.hasMatch(lines[i].trimLeft())) &&
             getIndentLevel(lines[i]) > currentIndent) {
           text += '\n${lines[i]}';
           i++;
@@ -134,9 +135,11 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
 
   bool isNestedList(String line1, String line2) {
     if ((line1.trimLeft().startsWith('- ') ||
-            line1.trimLeft().startsWith('* ')) &&
+            line1.trimLeft().startsWith('* ') ||
+            numberedListRegex.hasMatch(line1.trimLeft())) &&
         (line2.trimLeft().startsWith('- ') ||
-            line2.trimLeft().startsWith('* '))) {
+            line2.trimLeft().startsWith('* ') ||
+            numberedListRegex.hasMatch(line2.trimLeft()))) {
       return getIndentLevel(line2) > getIndentLevel(line1);
     }
     return false;

--- a/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
+++ b/test/plugins/markdown/decoder/document_markdown_decoder_test.dart
@@ -735,7 +735,21 @@ void main() async {
         "data": {
           "delta": []
         }
-      }
+      },
+      {
+        "type": "numbered_list",
+        "children": [
+          {"type": "numbered_list", "data": {"delta": [{"insert": " Which"}]}},
+          {"type": "numbered_list", "data": {"delta": [{"insert": " Is"}]}},
+          {"type": "numbered_list", "data": {"delta": [{"insert": " Nested"}]}}
+        ],
+        "data": {"delta": [{"insert": " Numbered List"}]}
+      },
+      {
+        "type": "numbered_list",
+        "data": {"delta": [{"insert": " Back to top level"}]}
+      },
+      {"type": "paragraph", "data": {"delta": []}}
     ]
   }
 }
@@ -824,6 +838,12 @@ void main(){
   - Task Three
 - Task Four
 - Task Five
+
+1. Numbered List
+  1. Which
+  2. Is
+  3. Nested
+2. Back to top level
 ''';
       final result = DocumentMarkdownDecoder().convert(markdown);
       final data = jsonDecode(example4);


### PR DESCRIPTION
Hello :wave:
First of all, I would like to thank you for building this library and taking the time to maintain the editor separately from the application. I have been waiting for a good rich text editor in Flutter for a long time.

Since this is my first contribution to the project, please tell me if I missed any guidelines that I should have followed.
I skimmed the documentation on contributing, but thought I would just get my feet wet and start with a pull request for a small change.

Now on to the actual content of the PR:
The markdown parser doesn't currently handle nested numbered lists.
Nested bullet lists and todo lists work fine, but numbered lists don't.
I made the necessary changes to parse nested numbered lists.
I also modified a test for nested lists to include a numbered list.