### PR TITLE
fix: headingBlockComponentBuilder doesn't use placeholderTextStyle

### DIFF
--- a/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
@@ -154,11 +154,11 @@ class _HeadingBlockComponentWidgetState
               placeholderText: placeholderText,
               placeholderTextSpanDecorator: (textSpan) => textSpan
                   .updateTextStyle(
-                    placeholderTextStyle,
-                  )
-                  .updateTextStyle(
                     widget.textStyleBuilder?.call(level) ??
                         defaultTextStyle(level),
+                  )
+                  .updateTextStyle(
+                    placeholderTextStyle,
                   ),
               textDirection: textDirection,
               cursorColor: editorState.editorStyle.cursorColor,


### PR DESCRIPTION
closes #663 

<img width="458" alt="Screenshot 2024-01-15 at 15 10 00" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/65a6eaa8-c6e5-476a-928f-cc2e0d85187d">
