### PR TITLE
upgraded markdown component

### DIFF
--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -7,7 +7,7 @@ import 'package:appflowy_editor/src/plugins/markdown/decoder/custom_syntaxes/und
 import 'package:markdown/markdown.dart' as md;
 
 class DeltaMarkdownDecoder extends Converter<String, Delta>
-    with md.NodeVisitor {
+    implements md.NodeVisitor {
   final _delta = Delta();
   final Attributes _attributes = {};
   final List<md.InlineSyntax> customInlineSyntaxes;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,29 +25,29 @@ dependencies:
   flutter:
     sdk: flutter
 
-  rich_clipboard: ^1.0.0
-  html: ^0.15.0
-  flutter_svg: ^2.0.6
-  provider: ^6.0.5
-  url_launcher: ^6.1.11
+  rich_clipboard: ^1.0.1
+  html: ^0.15.4
+  flutter_svg: ^2.0.9
+  provider: ^6.1.1
+  url_launcher: ^6.2.3
   logging: ^1.2.0
-  intl_utils: ^2.8.2
-  intl: ^0.18.0
-  markdown: ^7.1.0
+  intl_utils: ^2.8.7
+  intl: ^0.18.1
+  markdown: ^7.2.1
   flutter_localizations:
     sdk: flutter
-  tuple: ^2.0.1
-  collection: ^1.17.0
+  tuple: ^2.0.2
+  collection: ^1.18.0
   nanoid: ^1.0.0
   visibility_detector: ^0.4.0+2
   file_picker: ^6.1.1
-  path: ^1.8.3
-  path_provider: ^2.0.5
+  path: ^1.9.0
+  path_provider: ^2.1.2
   diff_match_patch: ^0.4.1
-  string_validator: ^1.0.0
+  string_validator: ^1.0.2
   universal_html: ^2.2.4
-  keyboard_height_plugin: ^0.0.4
-  numerus: ^2.1.2
+  keyboard_height_plugin: ^0.0.5
+  numerus: ^2.2.0
   device_info_plus: ^9.1.1
 
 dev_dependencies:
@@ -55,8 +55,8 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^3.0.1
   network_image_mock: ^2.1.1
-  mockito: ^5.4.1
-  leak_tracker: 9.0.16
+  mockito: ^5.4.4
+  leak_tracker: ^10.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
I updated the version of the markdown component supported to 7.2.1 from 7.1.0 and fixed the issue where the NodeVisitor mixin was changed to an abstract class.  Also updated a variety of other component versions.