### PR TITLE
feat: enable drag-and-drop functionality for text in the editor

### DIFF
--- a/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
@@ -65,6 +65,8 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
     debugLabel: 'cursor_${widget.node.path}',
   );
 
+  // keep the previous drag and drop selection rects
+  // to avoid unnecessary rebuild
   List<Rect>? prevDragAndDropSelectionRects;
   // keep the previous cursor rect to avoid unnecessary rebuild
   Rect? prevCursorRect;
@@ -92,7 +94,7 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
 
   @override
   Widget build(BuildContext context) {
-    final listenableChild = ValueListenableBuilder(
+    return ValueListenableBuilder(
       key: ValueKey(widget.node.id + widget.supportTypes.toString()),
       valueListenable: widget.listenable,
       builder: ((context, value, child) {
@@ -180,29 +182,19 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
       }),
       child: const SizedBox.shrink(),
     );
-
-    return widget.dragAndDropListenable != null
-        ? ValueListenableBuilder(
-            valueListenable: widget.dragAndDropListenable!,
-            builder: (context, value, child) {
-              return listenableChild;
-            },
-          )
-        : listenableChild;
   }
 
   void _updateSelectionIfNeeded() {
     if (!mounted) {
       return;
     }
+    final selection = widget.listenable.value?.normalized;
+    final path = widget.node.path;
 
     Selection? dragAndDropSelection;
     if (widget.dragAndDropListenable != null) {
       dragAndDropSelection = widget.dragAndDropListenable!.value?.normalized;
     }
-
-    final selection = widget.listenable.value?.normalized;
-    final path = widget.node.path;
 
     if (dragAndDropSelection != null) {
       if (widget.supportTypes.contains(BlockSelectionType.dragAndDrop)) {

--- a/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
@@ -40,6 +40,8 @@ class BlockSelectionArea extends StatefulWidget {
   // get the selection from the listenable
   final ValueListenable<Selection?> listenable;
 
+  // obtain the selection from dragAndDropListenable
+  // if it's `null`, construct the cursor for the drag-and-drop pointer
   final ValueListenable<Selection?>? dragAndDropListenable;
 
   // the color of the cursor

--- a/lib/src/editor/block_component/base_component/selection/block_selection_container.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_container.dart
@@ -8,12 +8,14 @@ class BlockSelectionContainer extends StatelessWidget {
     required this.node,
     required this.delegate,
     required this.listenable,
+    required this.dragAndDropListenable,
     this.cursorColor = Colors.black,
     this.selectionColor = Colors.blue,
     this.blockColor = Colors.blue,
     this.supportTypes = const [
       BlockSelectionType.cursor,
       BlockSelectionType.selection,
+      BlockSelectionType.dragAndDrop,
     ],
     required this.child,
   });
@@ -23,6 +25,8 @@ class BlockSelectionContainer extends StatelessWidget {
 
   // get the selection from the listenable
   final ValueListenable<Selection?> listenable;
+
+  final ValueListenable<Selection?> dragAndDropListenable;
 
   // the color of the cursor
   final Color cursorColor;
@@ -55,6 +59,7 @@ class BlockSelectionContainer extends StatelessWidget {
           node: node,
           delegate: delegate,
           listenable: listenable,
+          dragAndDropListenable: dragAndDropListenable,
           cursorColor: cursorColor,
           selectionColor: selectionColor,
           blockColor: blockColor,

--- a/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
+++ b/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
@@ -120,25 +120,25 @@ class _BulletedListBlockComponentWidgetState
   @override
   bool get shouldCursorBlink => _shouldCursorBlink;
 
-  set shouldCurSorBlink(bool value) {
+  set shouldCursorBlink(bool value) {
     _shouldCursorBlink = value;
   }
 
-  void _onCursorStlyeChange() {
+  void _onCursorStyleChange() {
     cursorStyle = editorState.cursorStyle;
 
-    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+    shouldCursorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override
   void initState() {
     super.initState();
-    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStyleChange);
   }
 
   @override
   void dispose() {
-    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStyleChange);
     super.dispose();
   }
 

--- a/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
+++ b/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
@@ -106,6 +106,42 @@ class _BulletedListBlockComponentWidgetState
   @override
   Node get node => widget.node;
 
+  CursorStyle _cursorStyle = CursorStyle.verticalLine;
+
+  @override
+  CursorStyle get cursorStyle => _cursorStyle;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    _cursorStyle = cursorStyle;
+  }
+
+  bool _shouldCursorBlink = true;
+
+  @override
+  bool get shouldCursorBlink => _shouldCursorBlink;
+
+  set shouldCurSorBlink(bool value) {
+    _shouldCursorBlink = value;
+  }
+
+  void _onCursorStlyeChange() {
+    cursorStyle = editorState.cursorStyle;
+
+    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+  }
+
+  @override
+  void dispose() {
+    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    super.dispose();
+  }
+
   @override
   Widget buildComponent(
     BuildContext context, {
@@ -168,6 +204,7 @@ class _BulletedListBlockComponentWidgetState
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/block_component/divider_block_component/divider_block_component.dart
+++ b/lib/src/editor/block_component/divider_block_component/divider_block_component.dart
@@ -111,6 +111,7 @@ class _DividerBlockComponentWidgetState
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       cursorColor: editorState.editorStyle.cursorColor,
       selectionColor: editorState.editorStyle.selectionColor,

--- a/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
@@ -119,6 +119,42 @@ class _HeadingBlockComponentWidgetState
 
   int get level => widget.node.attributes[HeadingBlockKeys.level] as int? ?? 1;
 
+  CursorStyle _cursorStyle = CursorStyle.verticalLine;
+
+  @override
+  CursorStyle get cursorStyle => _cursorStyle;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    _cursorStyle = cursorStyle;
+  }
+
+  bool _shouldCursorBlink = true;
+
+  @override
+  bool get shouldCursorBlink => _shouldCursorBlink;
+
+  set shouldCurSorBlink(bool value) {
+    _shouldCursorBlink = value;
+  }
+
+  void _onCursorStlyeChange() {
+    cursorStyle = editorState.cursorStyle;
+
+    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+  }
+
+  @override
+  void dispose() {
+    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final textDirection = calculateTextDirection(
@@ -183,6 +219,7 @@ class _HeadingBlockComponentWidgetState
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
@@ -133,25 +133,25 @@ class _HeadingBlockComponentWidgetState
   @override
   bool get shouldCursorBlink => _shouldCursorBlink;
 
-  set shouldCurSorBlink(bool value) {
+  set shouldCursorBlink(bool value) {
     _shouldCursorBlink = value;
   }
 
-  void _onCursorStlyeChange() {
+  void _onCursorStyleChange() {
     cursorStyle = editorState.cursorStyle;
 
-    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+    shouldCursorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override
   void initState() {
     super.initState();
-    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStyleChange);
   }
 
   @override
   void dispose() {
-    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStyleChange);
     super.dispose();
   }
 

--- a/lib/src/editor/block_component/image_block_component/image_block_component.dart
+++ b/lib/src/editor/block_component/image_block_component/image_block_component.dart
@@ -162,6 +162,7 @@ class ImageBlockComponentWidgetState extends State<ImageBlockComponentWidget>
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,
@@ -196,6 +197,7 @@ class ImageBlockComponentWidgetState extends State<ImageBlockComponentWidget>
                   node: node,
                   delegate: this,
                   listenable: editorState.selectionNotifier,
+                  dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
                   cursorColor: editorState.editorStyle.cursorColor,
                   selectionColor: editorState.editorStyle.selectionColor,
                   child: child!,

--- a/lib/src/editor/block_component/image_block_component/image_block_component.dart
+++ b/lib/src/editor/block_component/image_block_component/image_block_component.dart
@@ -197,7 +197,8 @@ class ImageBlockComponentWidgetState extends State<ImageBlockComponentWidget>
                   node: node,
                   delegate: this,
                   listenable: editorState.selectionNotifier,
-                  dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
+                  dragAndDropListenable:
+                      editorState.dragAndDropSelectionNotifier,
                   cursorColor: editorState.editorStyle.cursorColor,
                   selectionColor: editorState.editorStyle.selectionColor,
                   child: child!,

--- a/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
+++ b/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
@@ -112,6 +112,42 @@ class _NumberedListBlockComponentWidgetState
   @override
   Node get node => widget.node;
 
+  CursorStyle _cursorStyle = CursorStyle.verticalLine;
+
+  @override
+  CursorStyle get cursorStyle => _cursorStyle;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    _cursorStyle = cursorStyle;
+  }
+
+  bool _shouldCursorBlink = true;
+
+  @override
+  bool get shouldCursorBlink => _shouldCursorBlink;
+
+  set shouldCurSorBlink(bool value) {
+    _shouldCursorBlink = value;
+  }
+
+  void _onCursorStlyeChange() {
+    cursorStyle = editorState.cursorStyle;
+
+    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+  }
+
+  @override
+  void dispose() {
+    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    super.dispose();
+  }
+
   @override
   Widget buildComponent(
     BuildContext context, {
@@ -175,6 +211,7 @@ class _NumberedListBlockComponentWidgetState
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
+++ b/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
@@ -126,25 +126,25 @@ class _NumberedListBlockComponentWidgetState
   @override
   bool get shouldCursorBlink => _shouldCursorBlink;
 
-  set shouldCurSorBlink(bool value) {
+  set shouldCursorBlink(bool value) {
     _shouldCursorBlink = value;
   }
 
-  void _onCursorStlyeChange() {
+  void _onCursorStyleChange() {
     cursorStyle = editorState.cursorStyle;
 
-    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+    shouldCursorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override
   void initState() {
     super.initState();
-    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStyleChange);
   }
 
   @override
   void dispose() {
-    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStyleChange);
     super.dispose();
   }
 

--- a/lib/src/editor/block_component/paragraph_block_component/paragraph_block_component.dart
+++ b/lib/src/editor/block_component/paragraph_block_component/paragraph_block_component.dart
@@ -125,7 +125,7 @@ class _ParagraphBlockComponentWidgetState
   @override
   bool get shouldCursorBlink => _shouldCursorBlink;
 
-  set shouldCurSorBlink(bool value) {
+  set shouldCursorBlink(bool value) {
     _shouldCursorBlink = value;
   }
 
@@ -133,14 +133,14 @@ class _ParagraphBlockComponentWidgetState
   void initState() {
     super.initState();
     editorState.selectionNotifier.addListener(_onSelectionChange);
-    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStyleChange);
     _onSelectionChange();
   }
 
   @override
   void dispose() {
     editorState.selectionNotifier.removeListener(_onSelectionChange);
-    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStyleChange);
     super.dispose();
   }
 
@@ -160,10 +160,10 @@ class _ParagraphBlockComponentWidgetState
     }
   }
 
-  void _onCursorStlyeChange() {
+  void _onCursorStyleChange() {
     cursorStyle = editorState.cursorStyle;
 
-    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+    shouldCursorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override

--- a/lib/src/editor/block_component/paragraph_block_component/paragraph_block_component.dart
+++ b/lib/src/editor/block_component/paragraph_block_component/paragraph_block_component.dart
@@ -111,16 +111,36 @@ class _ParagraphBlockComponentWidgetState
 
   bool _showPlaceholder = false;
 
+  CursorStyle _cursorStyle = CursorStyle.verticalLine;
+
+  @override
+  CursorStyle get cursorStyle => _cursorStyle;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    _cursorStyle = cursorStyle;
+  }
+
+  bool _shouldCursorBlink = true;
+
+  @override
+  bool get shouldCursorBlink => _shouldCursorBlink;
+
+  set shouldCurSorBlink(bool value) {
+    _shouldCursorBlink = value;
+  }
+
   @override
   void initState() {
     super.initState();
     editorState.selectionNotifier.addListener(_onSelectionChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
     _onSelectionChange();
   }
 
   @override
   void dispose() {
     editorState.selectionNotifier.removeListener(_onSelectionChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
     super.dispose();
   }
 
@@ -138,6 +158,12 @@ class _ParagraphBlockComponentWidgetState
         setState(() => _showPlaceholder = showPlaceholder);
       }
     }
+  }
+
+  void _onCursorStlyeChange() {
+    cursorStyle = editorState.cursorStyle;
+
+    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override
@@ -191,6 +217,7 @@ class _ParagraphBlockComponentWidgetState
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
+++ b/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
@@ -119,25 +119,25 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
   @override
   bool get shouldCursorBlink => _shouldCursorBlink;
 
-  set shouldCurSorBlink(bool value) {
+  set shouldCursorBlink(bool value) {
     _shouldCursorBlink = value;
   }
 
-  void _onCursorStlyeChange() {
+  void _onCursorStyleChange() {
     cursorStyle = editorState.cursorStyle;
 
-    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+    shouldCursorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override
   void initState() {
     super.initState();
-    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStyleChange);
   }
 
   @override
   void dispose() {
-    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStyleChange);
     super.dispose();
   }
 

--- a/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
+++ b/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
@@ -105,6 +105,42 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
   @override
   late final editorState = Provider.of<EditorState>(context, listen: false);
 
+  CursorStyle _cursorStyle = CursorStyle.verticalLine;
+
+  @override
+  CursorStyle get cursorStyle => _cursorStyle;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    _cursorStyle = cursorStyle;
+  }
+
+  bool _shouldCursorBlink = true;
+
+  @override
+  bool get shouldCursorBlink => _shouldCursorBlink;
+
+  set shouldCurSorBlink(bool value) {
+    _shouldCursorBlink = value;
+  }
+
+  void _onCursorStlyeChange() {
+    cursorStyle = editorState.cursorStyle;
+
+    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+  }
+
+  @override
+  void dispose() {
+    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final textDirection = calculateTextDirection(
@@ -163,6 +199,7 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/block_component/rich_text/appflowy_rich_text.dart
+++ b/lib/src/editor/block_component/rich_text/appflowy_rich_text.dart
@@ -108,21 +108,27 @@ class _AppFlowyRichTextState extends State<AppFlowyRichText>
 
   @override
   Widget build(BuildContext context) {
-    final child = MouseRegion(
-      cursor: SystemMouseCursors.text,
-      child: widget.node.delta?.toPlainText().isEmpty ?? true
-          ? Stack(
-              children: [
-                _buildPlaceholderText(context),
-                _buildRichText(context),
-              ],
-            )
-          : _buildRichText(context),
+    final child = ValueListenableBuilder(
+      valueListenable: widget.editorState.mouseCursorStyleNotifier,
+      builder: (context, value, child) {
+        return MouseRegion(
+          cursor: value,
+          child: widget.node.delta?.toPlainText().isEmpty ?? true
+              ? Stack(
+                  children: [
+                    _buildPlaceholderText(context),
+                    _buildRichText(context),
+                  ],
+                )
+              : _buildRichText(context),
+        );
+      },
     );
 
     return BlockSelectionContainer(
       delegate: widget.delegate,
       listenable: widget.editorState.selectionNotifier,
+      dragAndDropListenable: widget.editorState.dragAndDropSelectionNotifier,
       node: widget.node,
       cursorColor: widget.cursorColor,
       selectionColor: widget.selectionColor,

--- a/lib/src/editor/block_component/table_block_component/table_block_component.dart
+++ b/lib/src/editor/block_component/table_block_component/table_block_component.dart
@@ -165,6 +165,7 @@ class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget>
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
+++ b/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
@@ -143,25 +143,25 @@ class _TodoListBlockComponentWidgetState
   @override
   bool get shouldCursorBlink => _shouldCursorBlink;
 
-  set shouldCurSorBlink(bool value) {
+  set shouldCursorBlink(bool value) {
     _shouldCursorBlink = value;
   }
 
-  void _onCursorStlyeChange() {
+  void _onCursorStyleChange() {
     cursorStyle = editorState.cursorStyle;
 
-    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+    shouldCursorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
   }
 
   @override
   void initState() {
     super.initState();
-    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.addListener(_onCursorStyleChange);
   }
 
   @override
   void dispose() {
-    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    editorState.cursorStyleNotifier.removeListener(_onCursorStyleChange);
     super.dispose();
   }
 

--- a/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
+++ b/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
@@ -129,6 +129,42 @@ class _TodoListBlockComponentWidgetState
 
   bool get checked => widget.node.attributes[TodoListBlockKeys.checked];
 
+  CursorStyle _cursorStyle = CursorStyle.verticalLine;
+
+  @override
+  CursorStyle get cursorStyle => _cursorStyle;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    _cursorStyle = cursorStyle;
+  }
+
+  bool _shouldCursorBlink = true;
+
+  @override
+  bool get shouldCursorBlink => _shouldCursorBlink;
+
+  set shouldCurSorBlink(bool value) {
+    _shouldCursorBlink = value;
+  }
+
+  void _onCursorStlyeChange() {
+    cursorStyle = editorState.cursorStyle;
+
+    shouldCurSorBlink = cursorStyle != CursorStyle.dottedVerticalLine;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    editorState.cursorStyleNotifier.addListener(_onCursorStlyeChange);
+  }
+
+  @override
+  void dispose() {
+    editorState.cursorStyleNotifier.removeListener(_onCursorStlyeChange);
+    super.dispose();
+  }
+
   @override
   Widget buildComponent(
     BuildContext context, {
@@ -193,6 +229,7 @@ class _TodoListBlockComponentWidgetState
       node: node,
       delegate: this,
       listenable: editorState.selectionNotifier,
+      dragAndDropListenable: editorState.dragAndDropSelectionNotifier,
       blockColor: editorState.editorStyle.selectionColor,
       supportTypes: const [
         BlockSelectionType.block,

--- a/lib/src/editor/command/selection_commands.dart
+++ b/lib/src/editor/command/selection_commands.dart
@@ -227,7 +227,7 @@ extension SelectionTransform on EditorState {
     }
 
     // Originally, I want to make this function as pure as possible,
-    //  but I have to import the selectable here to compute the selection.
+    // but I have to import the selectable here to compute the selection.
     final start = node.selectable?.start();
     final end = node.selectable?.end();
     final offset = direction == SelectionMoveDirection.forward

--- a/lib/src/editor/command/text_commands.dart
+++ b/lib/src/editor/command/text_commands.dart
@@ -344,6 +344,11 @@ extension TextTransforms on EditorState {
     if (selection == null || selection.isCollapsed) {
       return res;
     }
+
+    if (selection.isForward) {
+      selection = selection.reversed;
+    }
+
     final nodes = getNodesInSelection(selection);
     for (final node in nodes) {
       final delta = node.delta;

--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -145,6 +145,7 @@ class _DesktopSelectionServiceWidgetState
       onPanStart: _onPanStart,
       onPanUpdate: _onPanUpdate,
       onPanEnd: _onPanEnd,
+      onTapUp: _onTapUp,
       onTapDown: _onTapDown,
       onSecondaryTapDown: _onSecondaryTapDown,
       onDoubleTapDown: _onDoubleTapDown,
@@ -353,6 +354,12 @@ class _DesktopSelectionServiceWidgetState
     bottom = rightBottomOffset.dy - negativeVerticalOffset;
 
     return Rect.fromLTRB(left, top, right, bottom);
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    if (_isCursorPointValid) {
+      reset();
+    }
   }
 
   void _onTapDown(TapDownDetails details) {

--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -492,15 +492,10 @@ class _DesktopSelectionServiceWidgetState
     final dy = editorState.service.scrollService?.dy;
 
     if (_isCursorPointValid) {
-      final selection = currentDragAndDropSelection.value;
-      if (selection == null) {
-        return;
-      }
-
       cursorX = details.globalPosition.dx;
       cursorY = details.globalPosition.dy;
 
-      panCursor(details.globalPosition, selection);
+      updateCursorPosition(details.globalPosition);
       return;
     }
 
@@ -668,7 +663,10 @@ class _DesktopSelectionServiceWidgetState
     return min.clamp(start, end);
   }
 
-  void panCursor(Offset offset, Selection selection) {
+  void updateCursorPosition(Offset offset) {
+    final selection = currentDragAndDropSelection.value;
+    if (selection == null) return;
+
     final node = getNodeInOffset(offset);
     final selectable = node?.selectable;
     if (selectable == null) {

--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -314,8 +314,9 @@ class _DesktopSelectionServiceWidgetState
   /// eliminates boundaries around the cursor selection, facilitating
   /// drag and drop of text content without obstruction.
   Rect calculateRect(SelectableMixin<StatefulWidget> selectable) {
-    final rects =
-        selectable.getRectsInSelection(currentDragAndDropSelection.value!);
+    final rects = selectable.getRectsInSelection(
+      currentDragAndDropSelection.value!,
+    );
 
     double left = 0.0, top = 0.0, right = 0.0, bottom = 0.0;
     for (final rect in rects) {
@@ -725,9 +726,8 @@ class _DesktopSelectionServiceWidgetState
       );
     }
 
-    // update the cursor position to the
-    // last node or the cursor point of the
-    // edited [toNode] path after
+    // update the cursor position to the last node or
+    // the cursor point of the edited [toNode] path after
     // the drag and drop operation
     updateSelection(newCursorPosition);
   }

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -41,7 +41,6 @@ enum SelectionUpdateReason {
 enum SelectionType {
   inline,
   block,
-  dragAndDrop,
 }
 
 enum TransactionTime {
@@ -271,7 +270,7 @@ class EditorState {
     final completer = Completer<void>();
 
     if (reason == SelectionUpdateReason.uiEvent) {
-      dragAndDropSelectionType = SelectionType.dragAndDrop;
+      dragAndDropSelectionType = SelectionType.inline;
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) => completer.complete(),
       );

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -132,14 +132,14 @@ class EditorState {
     mouseCursorStyleNotifier.value = cursorStyle;
   }
 
-  /// The selection notifier of the editor.
+  /// The drag and drop selection notifier of the editor.
   final PropertyValueNotifier<Selection?> dragAndDropSelectionNotifier =
       PropertyValueNotifier<Selection?>(null);
 
-  /// The selection of the editor.
+  /// The drag and drop selection of the editor.
   Selection? get dragAndDropSelection => dragAndDropSelectionNotifier.value;
 
-  /// Sets the selection of the editor.
+  /// Sets the drag and drop selection of the editor.
   set dragAndDropSelection(Selection? value) {
     // clear the toggled style when the selection is changed.
     toggledStyle.clear();

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -5,6 +5,7 @@ import 'package:appflowy_editor/src/editor/editor_component/service/scroll/auto_
 import 'package:appflowy_editor/src/history/undo_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' hide UndoManager;
 
 /// the type of this value is bool.
 ///
@@ -40,6 +41,7 @@ enum SelectionUpdateReason {
 enum SelectionType {
   inline,
   block,
+  dragAndDrop,
 }
 
 enum TransactionTime {
@@ -112,12 +114,52 @@ class EditorState {
     selectionNotifier.value = value;
   }
 
+  ValueNotifier<CursorStyle> cursorStyleNotifier =
+      ValueNotifier(CursorStyle.verticalLine);
+
+  CursorStyle get cursorStyle => cursorStyleNotifier.value;
+
+  set cursorStyle(CursorStyle cursorStyle) {
+    cursorStyleNotifier.value = cursorStyle;
+  }
+
+  ValueNotifier<SystemMouseCursor> mouseCursorStyleNotifier =
+      ValueNotifier(SystemMouseCursors.text);
+
+  SystemMouseCursor get mouseCursorStyle => mouseCursorStyleNotifier.value;
+
+  set mouseCursorStyle(SystemMouseCursor cursorStyle) {
+    mouseCursorStyleNotifier.value = cursorStyle;
+  }
+
+  /// The selection notifier of the editor.
+  final PropertyValueNotifier<Selection?> dragAndDropSelectionNotifier =
+      PropertyValueNotifier<Selection?>(null);
+
+  /// The selection of the editor.
+  Selection? get dragAndDropSelection => dragAndDropSelectionNotifier.value;
+
+  /// Sets the selection of the editor.
+  set dragAndDropSelection(Selection? value) {
+    // clear the toggled style when the selection is changed.
+    toggledStyle.clear();
+
+    dragAndDropSelectionNotifier.value = value;
+  }
+
   SelectionType? selectionType;
+  SelectionType? dragAndDropSelectionType;
 
   SelectionUpdateReason _selectionUpdateReason = SelectionUpdateReason.uiEvent;
   SelectionUpdateReason get selectionUpdateReason => _selectionUpdateReason;
 
+  SelectionUpdateReason _dragAndDropSelectionUpdateReason =
+      SelectionUpdateReason.uiEvent;
+  SelectionUpdateReason get dragAndDropSelectionUpdateReason =>
+      _dragAndDropSelectionUpdateReason;
+
   Map? selectionExtraInfo;
+  Map? dragAndDropSelectionExtraInfo;
 
   // Service reference.
   final service = EditorService();
@@ -217,6 +259,63 @@ class EditorState {
     _selectionUpdateReason = reason;
 
     this.selection = selection;
+
+    return completer.future;
+  }
+
+  Future<void> updateDragAndDropSelectionWithReason(
+    Selection? selection, {
+    SelectionUpdateReason reason = SelectionUpdateReason.transaction,
+    Map? extraInfo,
+  }) async {
+    final completer = Completer<void>();
+
+    if (reason == SelectionUpdateReason.uiEvent) {
+      dragAndDropSelectionType = SelectionType.dragAndDrop;
+      WidgetsBinding.instance.addPostFrameCallback(
+        (timeStamp) => completer.complete(),
+      );
+    }
+
+    // broadcast to other users here
+    dragAndDropSelectionExtraInfo = extraInfo;
+    _dragAndDropSelectionUpdateReason = reason;
+
+    dragAndDropSelection = selection;
+
+    return completer.future;
+  }
+
+  Future<void> updateMouseCursorStyle(
+    SystemMouseCursor cursorStyle, {
+    SelectionUpdateReason reason = SelectionUpdateReason.transaction,
+  }) async {
+    final completer = Completer<void>();
+
+    if (reason == SelectionUpdateReason.uiEvent) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (timeStamp) => completer.complete(),
+      );
+    }
+
+    mouseCursorStyle = cursorStyle;
+
+    return completer.future;
+  }
+
+  Future<void> updateCursorStyle(
+    CursorStyle cursorStyle, {
+    SelectionUpdateReason reason = SelectionUpdateReason.transaction,
+  }) async {
+    final completer = Completer<void>();
+
+    if (reason == SelectionUpdateReason.uiEvent) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (timeStamp) => completer.complete(),
+      );
+    }
+
+    this.cursorStyle = cursorStyle;
 
     return completer.future;
   }

--- a/lib/src/render/selection/cursor.dart
+++ b/lib/src/render/selection/cursor.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:appflowy_editor/src/render/selection/dashed_cursor_painter.dart';
 import 'package:appflowy_editor/src/render/selection/selectable.dart';
 import 'package:flutter/material.dart';
 
@@ -76,6 +77,12 @@ class CursorState extends State<Cursor> {
         return Container(
           color: color,
         );
+      case CursorStyle.dottedVerticalLine:
+        return DashedCursor(
+          color: color,
+          strokeWidth: 2.0,
+          strokeCap: StrokeCap.round,
+        );
       case CursorStyle.borderLine:
         return Container(
           decoration: BoxDecoration(
@@ -88,7 +95,7 @@ class CursorState extends State<Cursor> {
           width: size.width,
           height: size.height,
           color: color.withOpacity(0.2),
-        );
+        ); 
     }
   }
 }

--- a/lib/src/render/selection/cursor.dart
+++ b/lib/src/render/selection/cursor.dart
@@ -95,7 +95,7 @@ class CursorState extends State<Cursor> {
           width: size.width,
           height: size.height,
           color: color.withOpacity(0.2),
-        ); 
+        );
     }
   }
 }

--- a/lib/src/render/selection/cursor_widget.dart
+++ b/lib/src/render/selection/cursor_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:appflowy_editor/src/render/selection/dashed_cursor_painter.dart';
 import 'package:appflowy_editor/src/render/selection/selectable.dart';
 import 'package:flutter/material.dart';
 
@@ -86,8 +87,10 @@ class CursorWidgetState extends State<CursorWidget> {
           color: color,
         );
       case CursorStyle.dottedVerticalLine:
-        return Container(
+        return DashedCursor(
           color: color,
+          strokeWidth: 2.0,
+          strokeCap: StrokeCap.round,
         );
       case CursorStyle.borderLine:
         return Container(

--- a/lib/src/render/selection/cursor_widget.dart
+++ b/lib/src/render/selection/cursor_widget.dart
@@ -85,6 +85,10 @@ class CursorWidgetState extends State<CursorWidget> {
         return Container(
           color: color,
         );
+      case CursorStyle.dottedVerticalLine:
+        return Container(
+          color: color,
+        );
       case CursorStyle.borderLine:
         return Container(
           decoration: BoxDecoration(

--- a/lib/src/render/selection/dashed_cursor_painter.dart
+++ b/lib/src/render/selection/dashed_cursor_painter.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class DashedCursor extends StatelessWidget {
+  const DashedCursor({
+    super.key,
+    required this.color,
+    required this.strokeCap,
+    required this.strokeWidth,
+  });
+
+  final Color color;
+  final double strokeWidth;
+  final StrokeCap strokeCap;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: DashedCursorPainter(
+        color: color,
+        strokeCap: strokeCap,
+        strokeWidth: strokeWidth,
+      ),
+    );
+  }
+}
+
+class DashedCursorPainter extends CustomPainter {
+  DashedCursorPainter({
+    required this.color,
+    required this.strokeCap,
+    required this.strokeWidth,
+  });
+
+  final Color color;
+  final double strokeWidth;
+  final StrokeCap strokeCap;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth;
+    //..strokeCap = strokeCap;
+
+    double height = size.height + 2;
+    for (double i = 0; i < height; i += 5) {
+      canvas.drawLine(
+        Offset(size.width, i),
+        Offset(size.width, i + 2.5),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(DashedCursorPainter oldDelegate) {
+    return color != oldDelegate.color ||
+        strokeCap != oldDelegate.strokeCap ||
+        strokeWidth != oldDelegate.strokeWidth;
+  }
+}

--- a/lib/src/render/selection/selectable.dart
+++ b/lib/src/render/selection/selectable.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 enum CursorStyle {
   verticalLine,
+  dottedVerticalLine,
   borderLine,
   cover,
 }

--- a/lib/src/service/selection/selection_gesture.dart
+++ b/lib/src/service/selection/selection_gesture.dart
@@ -10,6 +10,7 @@ class SelectionGestureDetector extends StatefulWidget {
   const SelectionGestureDetector({
     super.key,
     this.child,
+    this.onTapUp,
     this.onTapDown,
     this.onDoubleTapDown,
     this.onTripleTapDown,
@@ -25,6 +26,7 @@ class SelectionGestureDetector extends StatefulWidget {
 
   final Widget? child;
 
+  final GestureTapUpCallback? onTapUp;
   final GestureTapDownCallback? onTapDown;
   final GestureTapDownCallback? onDoubleTapDown;
   final GestureTapDownCallback? onTripleTapDown;
@@ -70,6 +72,7 @@ class SelectionGestureDetectorState extends State<SelectionGestureDetector> {
             GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
           () => TapGestureRecognizer(),
           (recognizer) {
+            recognizer.onTapUp = widget.onTapUp;
             recognizer.onTapDown = _tapDownDelegate;
             recognizer.onSecondaryTapDown = widget.onSecondaryTapDown;
           },

--- a/test/new/block_component/table_block_component/table_action_test.dart
+++ b/test/new/block_component/table_block_component/table_action_test.dart
@@ -44,6 +44,7 @@ void main() async {
         },
       );
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('remove row', (tester) async {
@@ -79,6 +80,7 @@ void main() async {
       );
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('remove the last column', (tester) async {
@@ -100,6 +102,7 @@ void main() async {
 
       expect(tester.editor.document.isEmpty, isTrue);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('remove the last row', (tester) async {
@@ -122,6 +125,7 @@ void main() async {
 
       expect(tester.editor.document.isEmpty, isTrue);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('duplicate column', (tester) async {
@@ -151,6 +155,7 @@ void main() async {
         );
       }
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('duplicate row', (tester) async {
@@ -180,6 +185,7 @@ void main() async {
         );
       }
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('add column', (tester) async {
@@ -211,6 +217,7 @@ void main() async {
       );
       expect(tableNode.getColWidth(2), tableNode.config.colDefaultWidth);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('add row', (tester) async {
@@ -244,6 +251,7 @@ void main() async {
       var cell12 = getCellNode(tableNode.node, 1, 2)!;
       expect(tableNode.getRowHeight(2), cell12.children.first.rect.height + 8);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('set row bg color', (tester) async {
@@ -275,6 +283,7 @@ void main() async {
         );
       }
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('add column respect row bg color', (tester) async {
@@ -314,6 +323,7 @@ void main() async {
         color,
       );
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('add row respect column bg color', (tester) async {

--- a/test/new/block_component/table_block_component/table_block_component_test.dart
+++ b/test/new/block_component/table_block_component/table_block_component_test.dart
@@ -28,6 +28,7 @@ void main() async {
         ParagraphBlockKeys.type,
       );
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     /*testWidgets('table delete action', (tester) async {

--- a/test/new/block_component/table_block_component/table_commands_test.dart
+++ b/test/new/block_component/table_block_component/table_commands_test.dart
@@ -39,6 +39,7 @@ void main() async {
       expect(selection.start.path, cell01.childAtIndexOrNull(0)!.path);
       expect(selection.start.offset, 0);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('enter key on last cell', (tester) async {
@@ -68,6 +69,7 @@ void main() async {
       expect(selection.start.offset, 0);
       expect(editor.documentRootLen, 2);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('backspace on beginning of cell', (tester) async {
@@ -96,6 +98,7 @@ void main() async {
       expect(selection.start.path, cell10.childAtIndexOrNull(0)!.path);
       expect(selection.start.offset, 0);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('backspace on multiple cell selection', (tester) async {
@@ -178,6 +181,7 @@ void main() async {
       expect(editor.document.last!.delta?.toPlainText(), 'ting');
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('backspace on whole table in selection', (tester) async {
@@ -215,6 +219,7 @@ void main() async {
       expect(editor.document.last!.delta?.toPlainText(), 'Sting');
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('up arrow key move to above row with same column',
@@ -259,6 +264,7 @@ void main() async {
       expect(selection.start.path, cell00.childAtIndexOrNull(0)!.path);
       expect(selection.start.offset, 2);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('down arrow key move to down row with same column',
@@ -303,6 +309,7 @@ void main() async {
       expect(selection.start.path, cell01.childAtIndexOrNull(0)!.path);
       expect(selection.start.offset, 2);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('arrowLeft key on beginning of a cell', (tester) async {
@@ -349,6 +356,7 @@ void main() async {
       expect(selection.start.offset, 0);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('arrowLeft key on middle of a cell', (tester) async {
@@ -379,6 +387,7 @@ void main() async {
       expect(selection.start.offset, 0);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('arrowRight key on beginning of a cell', (tester) async {
@@ -409,6 +418,7 @@ void main() async {
       expect(selection.start.offset, 1);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('arrowRight key on end of a cell', (tester) async {
@@ -457,6 +467,7 @@ void main() async {
       expect(selection.start.offset, 2);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('tab key navigates to next cell', (tester) async {
@@ -520,6 +531,7 @@ void main() async {
       expect(selection.start.offset, 0);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('shift+tab key navigates to the previous cell', (tester) async {
@@ -586,6 +598,7 @@ void main() async {
       expect(selection.start.offset, 0);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/test/new/block_component/table_block_component/table_view_test.dart
+++ b/test/new/block_component/table_block_component/table_view_test.dart
@@ -46,6 +46,7 @@ void main() async {
       expect(tableNode.getRowHeight(1), row1beforeHeight);
       expect(tableNode.getRowHeight(1) < tableNode.getRowHeight(0), true);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('row height changing base on column width', (tester) async {
@@ -86,6 +87,7 @@ void main() async {
 
       expect(tableNode.getRowHeight(0), row0beforeHeight);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/test/new/block_component/todo_list_block_component/todo_list_power_toggle_test.dart
+++ b/test/new/block_component/todo_list_block_component/todo_list_power_toggle_test.dart
@@ -57,6 +57,7 @@ void main() async {
       expect(n3.attributes[TodoListBlockKeys.checked], true);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/test/new/infra/testable_editor.dart
+++ b/test/new/infra/testable_editor.dart
@@ -177,7 +177,7 @@ class TestableEditor {
     _ime = null;
     // Workaround: to wait all the debounce calls expire.
     //  https://github.com/flutter/flutter/issues/11181#issuecomment-568737491
-    await tester.pumpAndSettle(const Duration(seconds: 1));
+    //await tester.pumpAndSettle(const Duration(seconds: 1));
   }
 
   void addNode(Node node) {

--- a/test/new/service/shortcuts/command_shortcut_events/checkbox_event_handler_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/checkbox_event_handler_test.dart
@@ -53,6 +53,7 @@ void main() async {
       expect(node.attributes[TodoListBlockKeys.checked], false);
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets(
@@ -103,6 +104,7 @@ void main() async {
       }
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets(
@@ -152,6 +154,7 @@ void main() async {
       }
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/test/new/service/shortcuts/command_shortcut_events/copy_paste_handler_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/copy_paste_handler_test.dart
@@ -49,6 +49,7 @@ void main() async {
 
     testWidgets('update selection and execute cut command', (tester) async {
       await _testCutHandle(tester, Document.fromJson(cutData));
+      await tester.pumpAndSettle();
     });
   });
 }
@@ -72,6 +73,7 @@ Future<void> _testCutHandle(
   );
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testHandleCopy(WidgetTester tester, Document document) async {
@@ -92,6 +94,7 @@ Future<void> _testHandleCopy(WidgetTester tester, Document document) async {
   expect(clipBoardData.text, text);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testSameNodeCopyPaste(
@@ -121,6 +124,7 @@ Future<void> _testSameNodeCopyPaste(
   );
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 // Future<void> _testNestedNodeCopyPaste(

--- a/test/new/service/shortcuts/command_shortcut_events/format_style_handler_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/format_style_handler_test.dart
@@ -213,4 +213,5 @@ Future<void> _testUpdateTextStyleByCommandX(
   }
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }

--- a/test/new/service/shortcuts/command_shortcut_events/markdown_commands_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/markdown_commands_test.dart
@@ -179,4 +179,5 @@ Future<void> _testUpdateTextStyleByCommandX(
   }
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }

--- a/test/new/service/shortcuts/command_shortcut_events/paste_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/paste_command_test.dart
@@ -57,6 +57,7 @@ void main() async {
 
         AppFlowyClipboard.mockSetData(null);
         await editor.dispose();
+        await tester.pumpAndSettle();
       },
     );
 
@@ -118,6 +119,7 @@ Future<void> _testHandleCopyMultiplePaste(
     thirdParagraph,
   );
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testHandleCopyPaste(
@@ -146,6 +148,7 @@ Future<void> _testHandleCopyPaste(
   expect(editor.document.toJson(), plainTextJson);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 const paragraphData = {

--- a/test/new/service/shortcuts/command_shortcut_events/redo_undo_handler_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/redo_undo_handler_test.dart
@@ -60,6 +60,7 @@ Future<void> _testRedoWithoutUndo(WidgetTester tester) async {
   expect(editor.documentRootLen, 3);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testWithTextFormattingBold(WidgetTester tester) async {
@@ -113,6 +114,7 @@ Future<void> _testWithTextFormattingBold(WidgetTester tester) async {
   expect(result, true);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testWithTextFormattingItalics(WidgetTester tester) async {
@@ -165,6 +167,7 @@ Future<void> _testWithTextFormattingItalics(WidgetTester tester) async {
   expect(allItalics, true);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testWithTextFormattingUnderline(WidgetTester tester) async {
@@ -217,6 +220,7 @@ Future<void> _testWithTextFormattingUnderline(WidgetTester tester) async {
   expect(allUnderline, true);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _testBackspaceUndoRedo(
@@ -248,6 +252,7 @@ Future<void> _testBackspaceUndoRedo(
   expect(editor.documentRootLen, 2);
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _pressUndoCommand(TestableEditor editor) async {

--- a/test/new/service/shortcuts/command_shortcut_events/toggle_color_commands_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/toggle_color_commands_test.dart
@@ -138,4 +138,5 @@ Future<void> _testUpdateTextColorByCommandX(
   }
 
   await editor.dispose();
+  await tester.pumpAndSettle();
 }

--- a/test/new/service/shortcuts/command_shortcut_events/white_space_handler_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/white_space_handler_test.dart
@@ -270,6 +270,7 @@ void main() async {
         expect(node.delta!.toPlainText(), 'AppFlowy');
 
         await editor.dispose();
+        await tester.pumpAndSettle();
       });
 
       testWidgets('AppFlowy > nothing changes', (tester) async {

--- a/test/service/scroll_service_test.dart
+++ b/test/service/scroll_service_test.dart
@@ -27,6 +27,7 @@ void main() async {
       );
       expect(itemFinder, findsOneWidget);
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/test/service/selection_service_test.dart
+++ b/test/service/selection_service_test.dart
@@ -159,6 +159,7 @@ void main() async {
       );
 
       await editor.dispose();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('Block selection and then single tap', (tester) async {


### PR DESCRIPTION
I made this PR after coming across the issue [Drag & drop content #3980](https://github.com/AppFlowy-IO/AppFlowy/issues/3980). It restricts dragging and dropping block components, allowing only the movement of plain text.

This feature allows users to select text and drag it to a preferred location within the editor. The implementation ensures that only the plain text of the selection is copied, without including the  node `delta` or any of `node` data associated
with the selected text. Instead, it **'adapts to the node'** it is going to be placed in.


https://github.com/AppFlowy-IO/appflowy-editor/assets/68953739/362de205-1b51-49d9-b3ec-325f3ffe4540
