### PR TITLE
fix: upgrade markdown to 7.2.1

### DIFF
--- a/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/delta_markdown_decoder.dart
@@ -7,7 +7,7 @@ import 'package:appflowy_editor/src/plugins/markdown/decoder/custom_syntaxes/und
 import 'package:markdown/markdown.dart' as md;
 
 class DeltaMarkdownDecoder extends Converter<String, Delta>
-    with md.NodeVisitor {
+    implements md.NodeVisitor {
   final _delta = Delta();
   final Attributes _attributes = {};
   final List<md.InlineSyntax> customInlineSyntaxes;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ version: 2.3.0
 homepage: https://github.com/AppFlowy-IO/appflowy-editor
 
 topics:
- - ui
- - widgets
- - editor
- - appflowy
+  - ui
+  - widgets
+  - editor
+  - appflowy
 
 platforms:
   android:
@@ -33,7 +33,7 @@ dependencies:
   logging: ^1.2.0
   intl_utils: ^2.8.2
   intl: ^0.18.0
-  markdown: ^7.1.0
+  markdown: ^7.2.1
   flutter_localizations:
     sdk: flutter
   tuple: ^2.0.1


### PR DESCRIPTION
Closes: #678 

Resolves an issue where the local markdown version is higher than `7.1.0` which causes an API mismatch.