### PR TITLE
feat: Add contentInsertionConfiguration to editor and text input service

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   highlight: ^0.7.0
   http: ^1.1.0
   show_fps: ^1.0.6
+  path: ^1.8.0
 
 dev_dependencies:
   flutter_test:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   highlight: ^0.7.0
   http: ^1.1.0
   show_fps: ^1.0.6
-  path: ^1.8.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/editor/editor_component/service/editor.dart
+++ b/lib/src/editor/editor_component/service/editor.dart
@@ -23,6 +23,7 @@ class AppFlowyEditor extends StatefulWidget {
     List<CharacterShortcutEvent>? characterShortcutEvents,
     List<CommandShortcutEvent>? commandShortcutEvents,
     List<List<ContextMenuItem>>? contextMenuItems,
+    this.contentInsertionConfiguration,
     this.editable = true,
     this.autoFocus = false,
     this.focusedSelection,
@@ -157,6 +158,9 @@ class AppFlowyEditor extends StatefulWidget {
   /// only works on iOS or Android.
   final bool showMagnifier;
 
+  /// {@macro flutter.widgets.editableText.contentInsertionConfiguration}
+  final ContentInsertionConfiguration? contentInsertionConfiguration;
+
   @override
   State<AppFlowyEditor> createState() => _AppFlowyEditorState();
 }
@@ -260,6 +264,7 @@ class _AppFlowyEditorState extends State<AppFlowyEditor> {
         characterShortcutEvents: widget.characterShortcutEvents,
         commandShortcutEvents: widget.commandShortcutEvents,
         focusNode: widget.focusNode,
+        contentInsertionConfiguration: widget.contentInsertionConfiguration,
         child: child,
       ),
     );

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -13,6 +13,7 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
     required super.onReplace,
     required super.onNonTextUpdate,
     required super.onPerformAction,
+    super.contentInsertionConfiguration,
     super.onFloatingCursor,
   });
 
@@ -171,7 +172,12 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
   }
 
   @override
-  void insertContent(KeyboardInsertedContent content) {}
+  void insertContent(KeyboardInsertedContent content) {
+    assert(contentInsertionConfiguration?.allowedMimeTypes
+            .contains(content.mimeType) ??
+        false);
+    contentInsertionConfiguration?.onContentInserted.call(content);
+  }
 
   void _updateComposing(TextEditingDelta delta) {
     if (delta is! TextEditingDeltaNonTextUpdate) {

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -173,9 +173,11 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
 
   @override
   void insertContent(KeyboardInsertedContent content) {
-    assert(contentInsertionConfiguration?.allowedMimeTypes
-            .contains(content.mimeType) ??
-        false);
+    assert(
+      contentInsertionConfiguration?.allowedMimeTypes
+              .contains(content.mimeType) ??
+          false,
+    );
     contentInsertionConfiguration?.onContentInserted.call(content);
   }
 

--- a/lib/src/editor/editor_component/service/ime/text_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/text_input_service.dart
@@ -9,6 +9,7 @@ abstract class TextInputService {
     required this.onNonTextUpdate,
     required this.onPerformAction,
     this.onFloatingCursor,
+    this.contentInsertionConfiguration,
   });
 
   Future<void> Function(TextEditingDeltaInsertion insertion) onInsert;
@@ -18,6 +19,8 @@ abstract class TextInputService {
       onNonTextUpdate;
   Future<void> Function(TextInputAction action) onPerformAction;
   Future<void> Function(RawFloatingCursorPoint point)? onFloatingCursor;
+
+  final ContentInsertionConfiguration? contentInsertionConfiguration;
 
   TextRange? get composingTextRange;
   bool get attached;

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -14,9 +14,11 @@ class KeyboardServiceWidget extends StatefulWidget {
     this.commandShortcutEvents = const [],
     this.characterShortcutEvents = const [],
     this.focusNode,
+    this.contentInsertionConfiguration,
     required this.child,
   });
 
+  final ContentInsertionConfiguration? contentInsertionConfiguration;
   final FocusNode? focusNode;
   final List<CommandShortcutEvent> commandShortcutEvents;
   final List<CharacterShortcutEvent> characterShortcutEvents;
@@ -86,6 +88,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
         point,
         editorState,
       ),
+      contentInsertionConfiguration: widget.contentInsertionConfiguration,
     );
 
     focusNode = widget.focusNode ?? FocusNode(debugLabel: 'keyboard service');
@@ -236,6 +239,9 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
           textCapitalization: TextCapitalization.sentences,
           inputAction: TextInputAction.newline,
           keyboardAppearance: Theme.of(context).brightness,
+          allowedMimeTypes: widget.contentInsertionConfiguration == null
+              ? const <String>[]
+              : widget.contentInsertionConfiguration!.allowedMimeTypes,
         ),
       );
       // disable shortcuts when the IME active

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -239,9 +239,8 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
           textCapitalization: TextCapitalization.sentences,
           inputAction: TextInputAction.newline,
           keyboardAppearance: Theme.of(context).brightness,
-          allowedMimeTypes: widget.contentInsertionConfiguration == null
-              ? const <String>[]
-              : widget.contentInsertionConfiguration!.allowedMimeTypes,
+          allowedMimeTypes:
+              widget.contentInsertionConfiguration?.allowedMimeTypes ?? [],
         ),
       );
       // disable shortcuts when the IME active

--- a/test/editor/editor_component/ime/non_delta_input_service_test.dart
+++ b/test/editor/editor_component/ime/non_delta_input_service_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:appflowy_editor/src/editor/editor_component/service/ime/non_delta_input_service.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -74,6 +77,31 @@ void main() {
       // Perform action
       inputService.performAction(TextInputAction.newline);
       expect(onPerformAction, true);
+    });
+
+    test('content insertion configuration is handled', () {
+      final completer = Completer<bool>();
+      final config = ContentInsertionConfiguration(
+        allowedMimeTypes: ['mimeType'],
+        onContentInserted: (value) => completer.complete(true),
+      );
+      final inputService = NonDeltaTextInputService(
+        onInsert: (_) async {},
+        onDelete: (_) async {},
+        onReplace: (_) async {},
+        onNonTextUpdate: (_) async {},
+        onPerformAction: (_) async {},
+        contentInsertionConfiguration: config,
+      );
+
+      inputService.insertContent(
+        const KeyboardInsertedContent(
+          mimeType: 'mimeType',
+          uri: 'uri',
+        ),
+      );
+
+      expect(completer.future, completion(true));
     });
   });
 }


### PR DESCRIPTION
### Description
This PR Adds support for  `contentInsertionConfiguration` attribute that allows the usage of Android's [image keyboard](https://developer.android.com/develop/ui/views/touch-and-input/image-keyboard) to Flutter.

See: https://api.flutter.dev/flutter/material/TextField/contentInsertionConfiguration.html

### Impact

This will allow the handling of more complex clipboard contents pastes (like images), or insertion of gifs and stickers

Linked issue: https://github.com/AppFlowy-IO/appflowy-editor/issues/646