### PR TITLE
fix: debounce of desktop IME (#696)

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -102,7 +102,7 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
       debounceKey,
       PlatformExtension.isMobile
           ? const Duration(milliseconds: 10)
-          : Duration.zero,
+          : const Duration(microseconds: 1),
       () {
         currentTextEditingValue = value;
         apply(deltas);


### PR DESCRIPTION
debounce for some IME, such as sogou Chinese input method.