### PR TITLE
fix: Slash command menu bad positioning in Web Version

### DIFF
--- a/lib/src/editor/block_component/table_block_component/table_action_menu.dart
+++ b/lib/src/editor/block_component/table_block_component/table_action_menu.dart
@@ -122,7 +122,7 @@ void showActionMenu(
       );
     },
   ).build();
-  Overlay.of(context).insert(overlay!);
+  Overlay.of(context, rootOverlay: true).insert(overlay!);
 }
 
 Widget _menuItem(
@@ -192,5 +192,5 @@ void _showColorMenu(
       );
     },
   ).build();
-  Overlay.of(context).insert(overlay!);
+  Overlay.of(context, rootOverlay: true).insert(overlay!);
 }

--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -392,7 +392,7 @@ class _DesktopSelectionServiceWidgetState
     );
 
     _contextMenuAreas.add(contextMenu);
-    Overlay.of(context)?.insert(contextMenu);
+    Overlay.of(context, rootOverlay: true)?.insert(contextMenu);
   }
 
   Node? _getNodeInOffset(

--- a/lib/src/editor/find_replace_menu/find_menu_service.dart
+++ b/lib/src/editor/find_replace_menu/find_menu_service.dart
@@ -109,7 +109,7 @@ class FindReplaceMenu implements FindReplaceService {
       },
     );
 
-    Overlay.of(context).insert(_findReplaceMenuEntry!);
+    Overlay.of(context, rootOverlay: true).insert(_findReplaceMenuEntry!);
   }
 
   void _onSelectionChange() {

--- a/lib/src/editor/selection_menu/selection_menu_service.dart
+++ b/lib/src/editor/selection_menu/selection_menu_service.dart
@@ -129,7 +129,7 @@ class SelectionMenu extends SelectionMenuService {
       },
     );
 
-    Overlay.of(context).insert(_selectionMenuEntry!);
+    Overlay.of(context, rootOverlay: true).insert(_selectionMenuEntry!);
 
     editorState.service.keyboardService?.disable(showCursor: true);
     editorState.service.scrollService?.disable();
@@ -294,7 +294,7 @@ final List<SelectionMenuItem> standardSelectionMenuItems = [
     ),
     keywords: ['image'],
     handler: (editorState, menuService, context) {
-      final container = Overlay.of(context);
+      final container = Overlay.of(context, rootOverlay: true);
       showImageMenu(container, editorState, menuService);
     },
   ),

--- a/lib/src/editor/toolbar/desktop/floating_toolbar.dart
+++ b/lib/src/editor/toolbar/desktop/floating_toolbar.dart
@@ -179,7 +179,7 @@ class _FloatingToolbarState extends State<FloatingToolbar>
         );
       },
     );
-    Overlay.of(context).insert(_toolbarContainer!);
+    Overlay.of(context, rootOverlay: true).insert(_toolbarContainer!);
   }
 
   Widget _buildToolbar(BuildContext context) {

--- a/lib/src/editor/toolbar/desktop/items/color/color_menu.dart
+++ b/lib/src/editor/toolbar/desktop/items/color/color_menu.dart
@@ -77,5 +77,5 @@ void showColorMenu(
       );
     },
   ).build();
-  Overlay.of(context).insert(overlay!);
+  Overlay.of(context, rootOverlay: true).insert(overlay!);
 }

--- a/lib/src/editor/toolbar/desktop/items/link/link_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/link/link_toolbar_item.dart
@@ -111,7 +111,7 @@ void showLinkMenu(
     },
   ).build();
 
-  Overlay.of(context).insert(overlay!);
+  Overlay.of(context, rootOverlay: true).insert(overlay!);
 }
 
 // get a proper position for link menu

--- a/lib/src/editor/toolbar/mobile/mobile_floating_toolbar/mobile_floating_toolbar.dart
+++ b/lib/src/editor/toolbar/mobile/mobile_floating_toolbar/mobile_floating_toolbar.dart
@@ -178,7 +178,7 @@ class _MobileFloatingToolbarState extends State<MobileFloatingToolbar>
         );
       },
     );
-    Overlay.of(context).insert(_toolbarContainer!);
+    Overlay.of(context, rootOverlay: true).insert(_toolbarContainer!);
     _isToolbarVisible = true;
   }
 

--- a/test/customer/editor_on_overlay_test.dart
+++ b/test/customer/editor_on_overlay_test.dart
@@ -68,6 +68,6 @@ class _MyHomePageState extends State<MyHomePage> {
       },
     );
 
-    Overlay.of(context).insert(overlayEntry);
+    Overlay.of(context, rootOverlay: true).insert(overlayEntry);
   }
 }


### PR DESCRIPTION
## Description:
While developing with AppFlowy editor, I encountered the following bug in the web version. I have integrated the AppFlowy editor into my app as shown in the image. On the left side, the editor is positioned between a sidebar and a header. This placement causes a displacement of the command menu. The slippage occurs because the menu is inserted relative to its container, rather than being positioned absolutely within the web page.

<img width="2447" alt="Screenshot 2024-02-08 at 16 04 57" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/23644210/f1d0882b-febb-4c6f-a7a3-8bf310a6d666">

## Expected Behavior:
The command menu should be positioned correctly without any slippage, even when the editor is placed between a sidebar and a header.

## Fix:
To resolve this issue, I modified Overlay.of(context) to Overlay.of(context, rootOverlay: true). Additionally, this fix also addresses issue #545.

Please review and consider implementing this fix in the next release. Let me know if you need any further clarification or information. Thank you!
