### PR TITLE
fIx: TableActionHandler editorState.editable  [Bug]  (issue (#717) )

### DIFF
--- a/lib/src/editor/block_component/table_block_component/table_action_handler.dart
+++ b/lib/src/editor/block_component/table_block_component/table_action_handler.dart
@@ -43,7 +43,8 @@ class _TableActionHandlerState extends State<TableActionHandler> {
       transform: widget.transform,
       height: widget.height,
       child: Visibility(
-        visible: (widget.visible || _visible || _menuShown) && widget.editorState.editable,
+        visible: (widget.visible || _visible || _menuShown) &&
+            widget.editorState.editable,
         child: MouseRegion(
           onEnter: (_) => setState(() => _visible = true),
           onExit: (_) => setState(() => _visible = false),

--- a/lib/src/editor/block_component/table_block_component/table_action_handler.dart
+++ b/lib/src/editor/block_component/table_block_component/table_action_handler.dart
@@ -43,7 +43,7 @@ class _TableActionHandlerState extends State<TableActionHandler> {
       transform: widget.transform,
       height: widget.height,
       child: Visibility(
-        visible: widget.visible || _visible || _menuShown,
+        visible: (widget.visible || _visible || _menuShown) && widget.editorState.editable,
         child: MouseRegion(
           onEnter: (_) => setState(() => _visible = true),
           onExit: (_) => setState(() => _visible = false),


### PR DESCRIPTION
fIx: Table Icon visible on hover in Editable and causes exception when clicked  [Bug]   (issue (#717) )

* fix:  Check visible Widget TableActionHandler when widget.editorState.editable == true

* Update:  lib/src/editor/block_component/table_block_component/table_action_handler.dart