### PR TITLE
fix: transfer the whole line into link when text contains url (#693)

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command/paste_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/paste_command.dart
@@ -112,20 +112,44 @@ extension on EditorState {
     final nodes = plainText
         .split('\n')
         .map(
-          (e) => e
+          (paragraph) => paragraph
             ..replaceAll(r'\r', '')
             ..trimRight(),
         )
-        .map((e) {
-          // parse the url content
-          final Attributes attributes = {};
-          if (_hrefRegex.hasMatch(e)) {
-            attributes[AppFlowyRichTextKeys.href] = e;
+        .map((paragraph) {
+          Delta delta = Delta();
+          if (_hrefRegex.hasMatch(paragraph)) {
+            final firstMatch = _hrefRegex.firstMatch(paragraph);
+            if (firstMatch != null) {
+              int startPos = firstMatch.start;
+              int endPos = firstMatch.end;
+              final String? url = firstMatch.group(0);
+              if (url != null) {
+                /// insert the text before the link
+                if (startPos > 0) {
+                  delta.insert(paragraph.substring(0, startPos));
+                }
+
+                /// insert the link
+                delta.insert(
+                  paragraph.substring(startPos, endPos),
+                  attributes: {AppFlowyRichTextKeys.href: url},
+                );
+
+                /// insert the text after the link
+                if (endPos < paragraph.length) {
+                  delta.insert(paragraph.substring(endPos));
+                }
+              }
+            }
+          } else {
+            delta.insert(paragraph);
           }
-          return Delta()..insert(e, attributes: attributes);
+          return delta;
         })
-        .map((e) => paragraphNode(delta: e))
+        .map((paragraph) => paragraphNode(delta: paragraph))
         .toList();
+
     if (nodes.isEmpty) {
       return;
     }

--- a/test/new/service/shortcuts/command_shortcut_events/paste_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/paste_command_test.dart
@@ -61,6 +61,38 @@ void main() async {
     );
 
     testWidgets(
+      'Copy text contains link',
+      (tester) async {
+        final editor = tester.editor..addParagraph(initialText: '');
+        await editor.startTesting();
+        await editor.updateSelection(
+          Selection.collapsed(Position(path: [0], offset: 0)),
+        );
+
+        const textWithLink = 'click https://appflowy.io/ jump to appflowy';
+        AppFlowyClipboard.mockSetData(
+          const AppFlowyClipboardData(text: textWithLink),
+        );
+
+        pasteCommand.execute(editor.editorState);
+        await tester.pumpAndSettle();
+
+        final delta = editor.nodeAtPath([0])!.delta!;
+        expect(delta.toPlainText(), textWithLink);
+        expect(
+          delta.everyAttributes(
+            (element) =>
+                element[AppFlowyRichTextKeys.href] == 'https://appflowy.io/',
+          ),
+          false,
+        );
+
+        AppFlowyClipboard.mockSetData(null);
+        await editor.dispose();
+      },
+    );
+
+    testWidgets(
         'Presses Command + A in small document and copy text and paste text',
         (tester) async {
       await _testHandleCopyPaste(tester, Document.fromJson(paragraphData));


### PR DESCRIPTION
### bug
https://github.com/AppFlowy-IO/appflowy-editor/issues/693

### fix approach

1. detect the text with url regrex
2. if there is a url exist, split the text into three parts. The first part and the final part may not exist.add url attribute for the url part.
3. if there is no url exist,just return the text.

### test status
unit test: all pass.