### PR TITLE
fix: incorrect cursor movement behaviour

### DIFF
--- a/lib/src/extensions/position_extension.dart
+++ b/lib/src/extensions/position_extension.dart
@@ -147,7 +147,9 @@ extension PositionExtension on Position {
     //   skipped because `remainingMultilineHeight` would be 0.
     Offset newOffset = caretOffset;
     Position? newPosition;
-    for (var y = minFontSize; y < remainingMultilineHeight + minFontSize; y += minFontSize) {
+    for (var y = minFontSize;
+        y < remainingMultilineHeight + minFontSize;
+        y += minFontSize) {
       newOffset = caretOffset.translate(0, upwards ? -y : y);
 
       newPosition =
@@ -174,7 +176,10 @@ extension PositionExtension on Position {
     final nodeHeightOffset = nodeRenderBox.localToGlobal(Offset(0, nodeHeight));
 
     // Clamp the new offset to the node's bounds.
-    newOffset = Offset(newOffset.dx, math.min(newOffset.dy, nodeHeightOffset.dy));
+    newOffset = Offset(
+      newOffset.dx,
+      math.min(newOffset.dy, nodeHeightOffset.dy),
+    );
 
     newPosition =
         editorState.service.selectionService.getPositionInOffset(newOffset);

--- a/lib/src/extensions/position_extension.dart
+++ b/lib/src/extensions/position_extension.dart
@@ -71,17 +71,9 @@ extension PositionExtension on Position {
     bool upwards = true,
   }) {
     final node = editorState.document.nodeAtPath(path);
-    if (node == null) {
-      return this;
-    }
-
-    final nodeRenderBox = node.renderBox;
-    if (nodeRenderBox == null) {
-      return this;
-    }
-
-    final nodeSelectable = node.selectable;
-    if (nodeSelectable == null) {
+    final nodeRenderBox = node?.renderBox;
+    final nodeSelectable = node?.selectable;
+    if (node == null || nodeRenderBox == null || nodeSelectable == null) {
       return this;
     }
 

--- a/lib/src/extensions/position_extension.dart
+++ b/lib/src/extensions/position_extension.dart
@@ -99,9 +99,7 @@ extension PositionExtension on Position {
       caretRect = rects.reduce(
         (current, next) => current.bottom > next.bottom ? current : next,
       );
-      // No need to check `upwards` because `editorSelection.isBackward`
-      // implies `upwards` is `false`.
-      caretOffset = caretRect.bottomRight;
+      caretOffset = upwards ? caretRect.topRight : caretRect.bottomRight;
     } else {
       caretRect = rects.reduce(
         (current, next) => current.top <= next.top ? current : next,
@@ -191,19 +189,9 @@ extension PositionExtension on Position {
     // If a new position has not been found, it means that the current node
     // is not visible on the screen. It seems happens only if upwards is true (?)
     // In this case, we can manually get the previous/next node position.
-    final List<int> neighbourPath;
-    final List<int> nodePath;
-    int offset;
-    if (upwards) {
-      neighbourPath = editorSelection.start.path.previous;
-      nodePath = editorSelection.start.path;
-      offset = editorSelection.startIndex;
-    } else {
-      neighbourPath = editorSelection.end.path.next;
-      nodePath = editorSelection.end.path;
-      offset = editorSelection.endIndex;
-    }
-
+    int offset = editorSelection.end.offset;
+    final List<int> nodePath = editorSelection.end.path;
+    final List<int> neighbourPath = upwards ? nodePath.previous : nodePath.next;
     if (neighbourPath.isNotEmpty && !neighbourPath.equals(nodePath)) {
       final neighbour = editorState.document.nodeAtPath(neighbourPath);
       final selectable = neighbour?.selectable;

--- a/lib/src/extensions/position_extension.dart
+++ b/lib/src/extensions/position_extension.dart
@@ -1,7 +1,8 @@
 import 'dart:math' as math;
 
-import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
+
+import 'package:appflowy_editor/appflowy_editor.dart';
 
 enum SelectionRange {
   character,
@@ -90,28 +91,28 @@ extension PositionExtension on Position {
       return null;
     }
 
+    final Rect caretRect = rects.reduce((current, next) {
+      if (editorSelection.isBackward) {
+        return current.bottom > next.bottom ? current : next;
+      }
+      return current.top <= next.top ? current : next;
+    });
+
     // The offset of outermost part of the caret.
     // Either the top if moving upwards, or the bottom if moving downwards.
-    final Offset caretOffset;
-
-    final Rect caretRect;
-    if (editorSelection.isBackward) {
-      caretRect = rects.reduce(
-        (current, next) => current.bottom > next.bottom ? current : next,
-      );
-      caretOffset = upwards ? caretRect.topRight : caretRect.bottomRight;
-    } else {
-      caretRect = rects.reduce(
-        (current, next) => current.top <= next.top ? current : next,
-      );
-      caretOffset = upwards ? caretRect.topLeft : caretRect.bottomLeft;
-    }
+    final Offset caretOffset = editorSelection.isBackward
+        ? upwards
+            ? caretRect.topRight
+            : caretRect.bottomRight
+        : upwards
+            ? caretRect.topLeft
+            : caretRect.bottomLeft;
 
     final nodeConfig = editorState.service.rendererService
         .blockComponentBuilder(node.type)
         ?.configuration;
     if (nodeConfig == null) {
-      // This should not happen.
+      assert(nodeConfig != null, 'Block Configuration should not be null');
       return this;
     }
 
@@ -123,7 +124,7 @@ extension PositionExtension on Position {
 
     // Minimum (acceptable) font size
     // Consider augmenting this value to increase performance.
-    const minFontSize = 1.0;
+    const double minFontSize = 1.0;
 
     // If the current node is not multiline, this will be ~= 0
     // so the loop will be skipped.
@@ -145,7 +146,7 @@ extension PositionExtension on Position {
     //   skipped because `remainingMultilineHeight` would be 0.
     Offset newOffset = caretOffset;
     Position? newPosition;
-    for (var y = minFontSize;
+    for (double y = minFontSize;
         y < remainingMultilineHeight + minFontSize;
         y += minFontSize) {
       newOffset = caretOffset.translate(0, upwards ? -y : y);


### PR DESCRIPTION
fixes #745 
Previously the `moveVertical` function only moved the cursor 'node to node' without taking into consideration multiline nodes or some portion of a line with different fontSize (ex: a paragraph with size 16 but with a bolded word with size 32). This was caused by the PR #657 that closes #656 and #589.