### PR TITLE
feat: combine diff operations

### DIFF
--- a/lib/src/core/document/diff.dart
+++ b/lib/src/core/document/diff.dart
@@ -43,5 +43,64 @@ List<Operation> diffNodes(Node oldNode, Node newNode) {
     operations.add(DeleteOperation(oldChild.path, [oldChild]));
   });
 
+  // Combine the operation in operations
+
+  // 1. Insert operations can be combined if they are continuous
+  final combinedOperations = <Operation>[];
+  if (operations.isNotEmpty &&
+      operations.every((element) => element is InsertOperation)) {
+    operations.sorted((a, b) => a.path <= b.path ? -1 : 1);
+    for (var i = 0; i < operations.length; i++) {
+      final op = operations[i];
+      if (combinedOperations.isEmpty) {
+        combinedOperations.add(op);
+      } else {
+        if (op.path.equals(operations[i - 1].path.next)) {
+          final lastOp = combinedOperations.removeLast();
+          combinedOperations.add(
+            InsertOperation(
+              lastOp.path,
+              [
+                ...(lastOp as InsertOperation).nodes,
+                ...(op as InsertOperation).nodes,
+              ],
+            ),
+          );
+        } else {
+          combinedOperations.add(op);
+        }
+      }
+    }
+    return combinedOperations;
+  }
+
+  // 2. Delete operations can be combined if they are continuous
+  if (operations.isNotEmpty &&
+      operations.every((element) => element is DeleteOperation)) {
+    operations.sorted((a, b) => a.path <= b.path ? -1 : 1);
+    for (var i = 0; i < operations.length; i++) {
+      final op = operations[i];
+      if (combinedOperations.isEmpty) {
+        combinedOperations.add(op);
+      } else {
+        if (op.path.equals(operations[i - 1].path.next)) {
+          final lastOp = combinedOperations.removeLast();
+          combinedOperations.add(
+            DeleteOperation(
+              lastOp.path,
+              [
+                ...(lastOp as DeleteOperation).nodes,
+                ...(op as DeleteOperation).nodes,
+              ],
+            ),
+          );
+        } else {
+          combinedOperations.add(op);
+        }
+      }
+    }
+    return combinedOperations;
+  }
+
   return operations;
 }

--- a/test/core/document/diff_test.dart
+++ b/test/core/document/diff_test.dart
@@ -103,5 +103,85 @@ void main() async {
         expectation,
       );
     });
+
+    test('continuous insert ', () async {
+      final id1 = nanoid(6);
+      final id2 = nanoid(6);
+      final id3 = nanoid(6);
+      final id4 = nanoid(6);
+      final id5 = nanoid(6);
+      final documentA = Document.blank()
+        ..insert(
+          [0],
+          [buildNodeWithId(id1, 'Hello AppFlowy!')],
+        );
+      final documentB = Document.blank()
+        ..insert([
+          0,
+        ], [
+          buildNodeWithId(id1, 'Hello AppFlowy!'),
+          buildNodeWithId(id2, '1'),
+          buildNodeWithId(id3, '2'),
+          buildNodeWithId(id4, '3'),
+          buildNodeWithId(id5, '4'),
+        ]);
+
+      final ops = diffDocuments(documentA, documentB);
+      expect(ops.length, 1);
+      final op = ops.first;
+      expect(op, isA<InsertOperation>());
+      expect((op as InsertOperation).path, [1]);
+      expect(
+        op.nodes.map((e) => e.delta!.toPlainText()),
+        ['1', '2', '3', '4'],
+      );
+
+      final expectation = jsonEncode(documentB.toJson());
+      expect(
+        jsonEncode((await apply(documentA, ops)).toJson()),
+        expectation,
+      );
+    });
+
+    test('continuous delete ', () async {
+      final id1 = nanoid(6);
+      final id2 = nanoid(6);
+      final id3 = nanoid(6);
+      final id4 = nanoid(6);
+      final id5 = nanoid(6);
+      final documentA = Document.blank()
+        ..insert(
+          [0],
+          [
+            buildNodeWithId(id1, 'Hello AppFlowy!'),
+            buildNodeWithId(id2, '1'),
+            buildNodeWithId(id3, '2'),
+            buildNodeWithId(id4, '3'),
+            buildNodeWithId(id5, '4'),
+          ],
+        );
+      final documentB = Document.blank()
+        ..insert([
+          0,
+        ], [
+          buildNodeWithId(id1, 'Hello AppFlowy!'),
+        ]);
+
+      final ops = diffDocuments(documentA, documentB);
+      expect(ops.length, 1);
+      final op = ops.first;
+      expect(op, isA<DeleteOperation>());
+      expect((op as DeleteOperation).path, [1]);
+      expect(
+        op.nodes.map((e) => e.delta!.toPlainText()),
+        ['1', '2', '3', '4'],
+      );
+
+      final expectation = jsonEncode(documentB.toJson());
+      expect(
+        jsonEncode((await apply(documentA, ops)).toJson()),
+        expectation,
+      );
+    });
   });
 }


### PR DESCRIPTION
Combine consecutive insert or delete operations. 

For example, 'insert p1, v1; insert p2, v2; ...' should be combined into 'insert p1, [v1, v2, ...]'.
