### PR TITLE
Fix wayland + fcitx5 input bug

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_on_replace_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_replace_impl.dart
@@ -5,6 +5,8 @@ import 'package:appflowy_editor/src/editor/editor_component/service/ime/characte
 import 'package:appflowy_editor/src/editor/editor_component/service/ime/delta_input_impl.dart';
 import 'package:flutter/services.dart';
 
+var oldValueStartElementIsSpace = false;
+
 Future<void> onReplace(
   TextEditingDeltaReplacement replacement,
   EditorState editorState,
@@ -46,8 +48,8 @@ Future<void> onReplace(
     final node = editorState.getNodesInSelection(selection).first;
     final transaction = editorState.transaction;
     final start = replacement.replacedRange.start;
-    final length = replacement.replacedRange.end - start;
-
+    final length = replacement.replacedRange.end - start + (oldValueStartElementIsSpace ? 1 : 0);
+    oldValueStartElementIsSpace = replacement.replacementText.startsWith(" ");
     transaction.replaceText(node, start, length, replacement.replacementText);
     await editorState.apply(transaction);
   } else {

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -228,7 +228,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
 
   void _attachTextInputService(Selection selection) {
     final textEditingValue = _getCurrentTextEditingValue(selection);
-    if (textEditingValue != null) {
+    if (textEditingValue != null && textEditingValue.composing.isCollapsed) {
       textInputService.attach(
         textEditingValue,
         TextInputConfiguration(


### PR DESCRIPTION
我不知道keyboard_service_widget.dart文件修改的作用，我的参考：https://github.com/AppFlowy-IO/AppFlowy/commit/f5cc6521fbcad8564c7193b705a5e5429b6d8e82
delta_input_on_replace_impl.dart内如果replacement开头出现空行，则无法正常处理输入法，但是replacement在non_delta_input_service.dart的apply方法内执行了format方法，导致无法在delta_input_on_replace_impl.dart内判断开头时是否是空格
但是用方向键移动插入指针到前面的字符不会产生响应，就像我下面这个视频展示的一样

https://github.com/AppFlowy-IO/AppFlowy/assets/31309149/b44039f7-c26e-49bf-a8a5-0c96e48ac3ec

但我不懂dart和flutter,不知如何修复，并且delta_input_on_replace_impl.dart的修复一定不符合规范和运行逻辑，我希望能帮我修好。
这是我的修改：[068b7948ab8380f3c7ef655f9891a4f92a8ba518](https://github.com/XGX1/appflowy-editor/commit/068b7948ab8380f3c7ef655f9891a4f92a8ba518)

可以的话我希望能修复输入问题，插入指针移动问题需要修复的话，也可以联系我，我能够提供测试设备和环境。

修复fcitx5和wayland下无法输入中文问题

我的英文不好，用中文回答了十分抱歉。