### PR TITLE
fix: improve link menu position

### DIFF
--- a/lib/src/editor/toolbar/desktop/items/link/link_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/link/link_toolbar_item.dart
@@ -132,6 +132,7 @@ void showLinkMenu(
     _menuWidth,
     rect.left,
     rect.right,
+    true,
   );
 
   final editorHeight = editorState.renderBox!.size.height;
@@ -142,6 +143,7 @@ void showLinkMenu(
     linkText != null ? _hasTextHeight : _noTextHeight,
     rect.top,
     rect.bottom,
+    false,
   );
 
   return (left, top, right, bottom);
@@ -156,11 +158,14 @@ void showLinkMenu(
   int menuLength,
   double rectStart,
   double rectEnd,
+  bool isHorizontal,
 ) {
   final threshold = editorOffsetD + editorLength - _menuWidth;
   double? start, end;
   if (offsetD > threshold) {
     end = editorOffsetD + editorLength - rectStart - 5;
+  } else if (isHorizontal) {
+    start = rectStart;
   } else {
     start = rectEnd + 5;
   }


### PR DESCRIPTION
before

<img width="881" alt="Screenshot 2024-05-02 at 10 36 04" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/c645d5b8-0aa1-4ba4-8b68-8845efa27b15">

after

<img width="769" alt="Screenshot 2024-05-02 at 10 35 46" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/6289d4c2-2efc-41c7-b22e-92258d8e21a8">
