### PR TITLE
fix: cursor height is not consistent

### DIFF
--- a/lib/src/editor/block_component/rich_text/appflowy_rich_text.dart
+++ b/lib/src/editor/block_component/rich_text/appflowy_rich_text.dart
@@ -348,6 +348,10 @@ class _AppFlowyRichTextState extends State<AppFlowyRichText>
       textDirection: textDirection(),
       textScaler:
           TextScaler.linear(widget.editorState.editorStyle.textScaleFactor),
+      strutStyle: StrutStyle(
+        height: widget.lineHeight,
+        forceStrutHeight: true,
+      ),
     );
   }
 
@@ -369,6 +373,10 @@ class _AppFlowyRichTextState extends State<AppFlowyRichText>
       textDirection: textDirection(),
       textScaler:
           TextScaler.linear(widget.editorState.editorStyle.textScaleFactor),
+      strutStyle: StrutStyle(
+        height: widget.lineHeight,
+        forceStrutHeight: true,
+      ),
     );
   }
 
@@ -418,6 +426,10 @@ class _AppFlowyRichTextState extends State<AppFlowyRichText>
           textDirection: textDirection(),
           textScaler:
               TextScaler.linear(widget.editorState.editorStyle.textScaleFactor),
+          strutStyle: StrutStyle(
+            height: widget.lineHeight,
+            forceStrutHeight: true,
+          ),
         );
       },
     );


### PR DESCRIPTION
To retrieve consistent cursor height after upgrading to Flutter 3.22, set forceStrutHeight to true. 

closes https://github.com/AppFlowy-IO/appflowy-editor/issues/804