### PR TITLE
feat: optimize flutter version fetch in the ci file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.22.0"
+          flutter-version-file: pubspec.yaml
           cache: true
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: subosito/flutter-action@v2.16.0
+      - uses: penkzhou/flutter-action@v2.16.1
         with:
           channel: "stable"
           flutter-version-file: pubspec.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@v2.16.0
         with:
           channel: "stable"
           flutter-version-file: pubspec.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ platforms:
 
 environment:
   sdk: ">=3.1.5 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: "3.22.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
make the flutter version in the ci file as same as in the `pubspec.yaml` file. 
This allows keeping the Flutter version in sync between the two config files, reducing duplication and manual work when upgrading versions.