### PR TITLE
fix: mobile toolbar UI shift

### DIFF
--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -97,7 +97,10 @@ class _HomePageState extends State<HomePage> {
         surfaceTintColor: Colors.transparent,
         title: const Text('AppFlowy Editor'),
       ),
-      body: SafeArea(child: _widgetBuilder(context)),
+      body: SafeArea(
+        maintainBottomViewPadding: true,
+        child: _widgetBuilder(context),
+      ),
     );
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,20 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:example/home_page.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  if (defaultTargetPlatform == TargetPlatform.android) {
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge, overlays: []);
+    SystemChrome.setSystemUIOverlayStyle(
+      const SystemUiOverlayStyle(systemNavigationBarColor: Colors.transparent),
+    );
+  }
+
   runApp(const MyApp());
 }
 

--- a/lib/src/editor/toolbar/mobile/mobile_toolbar_v2.dart
+++ b/lib/src/editor/toolbar/mobile/mobile_toolbar_v2.dart
@@ -385,7 +385,7 @@ class _MobileToolbarState extends State<_MobileToolbar>
           valueListenable: showMenuNotifier,
           builder: (_, showingMenu, __) {
             return SizedBox(
-              height: height,
+              height: height + MediaQuery.of(context).viewPadding.bottom,
               child: (showingMenu && selectedMenuIndex != null)
                   ? MobileToolbarItemMenu(
                       editorState: widget.editorState,


### PR DESCRIPTION
close https://github.com/AppFlowy-IO/appflowy-editor/issues/815

set the `maintainBottomViewPadding` to `true`. This ensures that any bottom padding (like the one provided by MediaQuery) is maintained when the keyboard is displayed.

<img width="505" alt="Screenshot 2024-06-11 at 09 29 54" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/aa5b6086-3b2b-4121-b941-fb5a0c38f8df">
