### PR TITLE
fix: content jumping down and scrolling getting locked.

### DIFF
--- a/lib/src/editor/find_replace_menu/find_replace_widget.dart
+++ b/lib/src/editor/find_replace_menu/find_replace_widget.dart
@@ -47,10 +47,6 @@ class FindAndReplaceMenuWidget extends StatefulWidget {
 }
 
 class _FindAndReplaceMenuWidgetState extends State<FindAndReplaceMenuWidget> {
-  final focusNode = FocusNode();
-  final replaceFocusNode = FocusNode();
-  final findController = TextEditingController();
-  final replaceController = TextEditingController();
   String queriedPattern = '';
   bool showRegexButton = true;
   bool showCaseSensitiveButton = true;

--- a/lib/src/editor/find_replace_menu/search_service_v3.dart
+++ b/lib/src/editor/find_replace_menu/search_service_v3.dart
@@ -11,9 +11,9 @@ class SearchServiceV3 {
 
   final EditorState editorState;
 
-  //matchWrappers.value will contain a list of matchWrappers of the matched patterns
-  //the position here consists of the match and the node path of
-  //matched pattern. We will use this to traverse between the matched patterns.
+  // matchWrappers.value will contain a list of matchWrappers of the matched patterns
+  // the position here consists of the match and the node path of
+  // matched pattern. We will use this to traverse between the matched patterns.
   ValueNotifier<List<MatchWrapper>> matchWrappers = ValueNotifier([]);
   SearchAlgorithm searchAlgorithm = DartBuiltIn();
   String targetString = '';
@@ -36,15 +36,11 @@ class SearchServiceV3 {
   int _selectedIndex = 0;
   int get selectedIndex => _selectedIndex;
   set selectedIndex(int index) {
-    _prevSelectedIndex = _selectedIndex;
     _selectedIndex = matchWrappers.value.isEmpty
         ? -1
         : index.clamp(0, matchWrappers.value.length - 1);
     currentSelectedIndex.value = _selectedIndex;
   }
-
-  // only used for scrolling to the first or the last match.
-  int _prevSelectedIndex = 0;
 
   ValueNotifier<int> currentSelectedIndex = ValueNotifier(0);
 
@@ -151,17 +147,6 @@ class SearchServiceV3 {
     Pattern pattern,
   ) {
     final selection = matchWrappers.value[selectedIndex].selection;
-
-    // https://github.com/google/flutter.widgets/issues/151
-    // there's a bug in the scrollable_positioned_list package
-    // we can't scroll to the index without animation.
-    // so we just scroll the position if the index is the first or the last.
-    final length = matchWrappers.value.length - 1;
-    if (_prevSelectedIndex != selectedIndex &&
-        ((_prevSelectedIndex == length && selectedIndex == 0) ||
-            (_prevSelectedIndex == 0 && selectedIndex == length))) {
-      editorState.scrollService?.jumpTo(selection.start.path.first);
-    }
 
     editorState.updateSelectionWithReason(
       selection,


### PR DESCRIPTION
Partially solves: [#5491](https://github.com/AppFlowy-IO/AppFlowy/issues/5491)

- Removes code that triggers `jumpTo()` call. This can be removed since, making a selection implicitly causes the editor to scroll to the new selection.
- Remove unused variables

Preview:
- For given user sample (small text)
https://github.com/AppFlowy-IO/appflowy-editor/assets/47064215/7c5093b7-6c08-4dd8-bbf5-9145a92cb40a

- For long text sample
https://github.com/AppFlowy-IO/appflowy-editor/assets/47064215/d55713c1-991c-4e79-b053-23d632e58414

Additional Context:
https://github.com/AppFlowy-IO/AppFlowy/issues/5491#issuecomment-2166388521

