### PR TITLE
[fix] Fixed the issue where the handwriting input method was unusable…

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -188,8 +188,10 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
           start: composingTextRange!.start,
           end: delta.composing.end,
         );
+        return;
       } else {
         composingTextRange = delta.composing;
+        return;
       }
     }
 
@@ -198,12 +200,11 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
             PlatformExtension.isMacOS) &&
         delta is TextEditingDeltaNonTextUpdate) {
       composingTextRange = delta.composing;
+      return;
     }
 
     // solve the issue where the Chinese IME doesn't continue deleting after the input content has been deleted.
-    if (composingTextRange?.isCollapsed ?? false) {
-      composingTextRange = TextRange.empty;
-    }
+    composingTextRange = TextRange.empty;
   }
 }
 

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -164,7 +164,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
   /// handle hardware keyboard
   KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
     if ((event is! KeyDownEvent && event is! KeyRepeatEvent) ||
-        !enableShortcuts) {
+        (!enableShortcuts && !backspaceCommand.canRespondToRawKeyEvent(event))) {
       if (textInputService.composingTextRange != TextRange.empty) {
         return KeyEventResult.skipRemainingHandlers;
       }


### PR DESCRIPTION
Fixed the issue where the handwriting input method was unusable on iOS and unable to delete on Android.

My users reported a bug in the handwriting input feature, and I've fixed it.


https://github.com/AppFlowy-IO/appflowy-editor/assets/16030568/635e9215-60c6-4535-818e-3f86cf70d6bf

