### PR TITLE
fix: underscore markdown syntax assertion

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/character/format_single_character/format_single_character.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/character/format_single_character/format_single_character.dart
@@ -51,6 +51,11 @@ bool handleFormatByWrappingWithSingleCharacter({
     return false;
   }
 
+  // 4. If the last character index is greater that current cursor position, we should skip the single character formatting.
+  if (lastCharIndex >= selection.end.offset) {
+    return false;
+  }
+
   // If none of the above exclusive conditions are satisfied, we should format the text to [formatStyle].
   // 1. Delete the previous 'Character'.
   // 2. Update the style of the text surrounded by the two 'Character's to [formatStyle].


### PR DESCRIPTION
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: RangeError (end): Invalid value: Not in inclusive range 4..5: -1
#0      RangeError.checkValidRange (dart:core/errors.dart:365:9)
#1      _StringBase.substring (dart:core-patch/string_patch.dart:418:27)
#2      _OpIterator.next (package:appflowy_editor/src/core/document/text_delta.dart:591:23)
#3      Delta.compose (package:appflowy_editor/src/core/document/text_delta.dart:277:33)
#4      TextTransaction.compose.<anonymous closure> (package:appflowy_editor/src/core/transform/transaction.dart:568:59)
#5      ListBase.fold (dart:collection/list.dart:202:22)
#6      TextTransaction.compose (package:appflowy_editor/src/core/transform/transaction.dart:568:22)
#7      Transaction.operations (package:appflowy_editor/src/core/transform/transaction.dart:22:7)
#8      EditorState._applyTransactionInLocal (package:appflowy_editor/src/editor_state.dart:549:34)
#9      EditorState.apply (package:appflowy_editor/src/editor_state.dart:307:7)
#10     handleFormatByWrappingWithSingleCharacter (package:appflowy_editor/src/editor/editor_component/service/shortcuts/character/format_single_character/format_single_character.dart:107:15)
#11     formatUnderscoreToItalic.<anonymous closure> (package:appflowy_editor/src/editor/editor_component/service/shortcuts/character/format_single_character/format_italic.dart:17:35)
#12     executeCharacterShortcutEvent (package:appflowy_editor/src/editor/editor_component/service/ime/character_shortcut_event_helper.dart:14:36)
<asynchronous suspension>
#13     onInsert (package:appflowy_editor/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart:16:21)
<asynchronous suspension>
#14     KeyboardServiceWidgetState.initState.<anonymous closure> (package:appflowy_editor/src/editor/editor_component/service/keyboard_service_widget.dart:65:38)
<asynchronous suspension>
#15     NonDeltaTextInputService.apply (package:appflowy_editor/src/editor/editor_component/service/ime/non_delta_input_service.dart:49:9)
<asynchronous suspension>
```