### PR TITLE
chore: remove macos runner 11 in test ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   desktop:
     strategy:
       matrix:
-        os: [macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019]
+        os: [macos-14, macos-13, macos-12, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The macos 11 runner has been removed in github action.

https://github.com/actions/runner-images/issues/9255