### PR TITLE
fix: document from markdown contains html escape text

### DIFF
--- a/example/lib/pages/markdown/markdown_code_block_parser.dart
+++ b/example/lib/pages/markdown/markdown_code_block_parser.dart
@@ -40,12 +40,10 @@ class MarkdownCodeBlockParserV2 extends CustomMarkdownParser {
       language = languageClass.substring('language-'.length);
     }
 
-    final deltaDecoder = DeltaMarkdownDecoder();
-
     return [
       codeBlockNode(
         language: language,
-        delta: deltaDecoder.convertNodes(code.children),
+        delta: Delta()..insert(code.textContent.trimRight()),
       ),
     ];
   }

--- a/example/test/markdown_code_block_parser_test.dart
+++ b/example/test/markdown_code_block_parser_test.dart
@@ -1,0 +1,47 @@
+import 'package:appflowy_editor/src/plugins/markdown/decoder/document_markdown_decoder.dart';
+import 'package:example/pages/markdown/markdown_code_block_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  group('markdown_heading_parser.dart', () {
+    final parser = DocumentMarkdownDecoder(
+      markdownElementParsers: [
+        const MarkdownCodeBlockParserV2(),
+      ],
+    );
+
+    test('contains quote syntax', () {
+      const codeBlockMarkdown = '''```python
+# Example of using the GTD class
+gtd_system = GTD()
+gtd_system.capture("Write a blog post")
+gtd_system.capture("Prepare presentation for Monday")
+gtd_system.capture("Plan vacation")
+gtd_system.clarify()
+gtd_system.review()
+gtd_system.engage()
+```''';
+
+      final result = parser.convert(codeBlockMarkdown);
+      final codeBlock = result.root.children.first;
+      expect(codeBlock.toJson(), {
+        'type': 'code',
+        'data': {
+          'language': 'python',
+          'delta': [
+            {
+              'insert': '''# Example of using the GTD class
+gtd_system = GTD()
+gtd_system.capture("Write a blog post")
+gtd_system.capture("Prepare presentation for Monday")
+gtd_system.capture("Plan vacation")
+gtd_system.clarify()
+gtd_system.review()
+gtd_system.engage()''',
+            },
+          ],
+        },
+      });
+    });
+  });
+}

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -22,6 +22,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
         ...inlineSyntaxes,
         UnderlineInlineSyntax(),
       ],
+      encodeHtml: false,
     ).parse(input);
     final document = Document.blank();
 


### PR DESCRIPTION
Remove the html escape text when parsing markdown to document.

<img width="670" alt="Screenshot 2024-07-11 at 17 59 42" src="https://github.com/AppFlowy-IO/appflowy-editor/assets/11863087/b3c18fcb-f5c8-476c-81d6-28db4b2e5ea4">
