### PR TITLE
feat: scrolling floating toolbar

### DIFF
--- a/lib/src/editor/toolbar/desktop/floating_toolbar.dart
+++ b/lib/src/editor/toolbar/desktop/floating_toolbar.dart
@@ -169,20 +169,27 @@ class _FloatingToolbarState extends State<FloatingToolbar>
     if (top <= floatingToolbarHeight || (left == 0 && right == 0)) {
       return;
     }
+
+    Size screenSize = MediaQuery.of(context).size;
+    double maxWidth = screenSize.width - (left ?? 0) - (right ?? 0) - 20;
+
     _toolbarContainer = OverlayEntry(
       builder: (context) {
         return Positioned(
           top: max(0, top) - floatingToolbarHeight,
           left: left,
           right: right,
-          child: _buildToolbar(context),
+          child: _buildToolbar(context, maxWidth),
         );
       },
     );
     Overlay.of(context, rootOverlay: true).insert(_toolbarContainer!);
   }
 
-  Widget _buildToolbar(BuildContext context) {
+  Widget _buildToolbar(BuildContext context, double maxWidth) {
+    if (_toolbarWidget?.maxWidth != maxWidth) {
+      _toolbarWidget = null;
+    }
     _toolbarWidget ??= FloatingToolbarWidget(
       items: widget.items,
       editorState: editorState,
@@ -192,6 +199,7 @@ class _FloatingToolbarState extends State<FloatingToolbar>
       toolbarElevation: widget.style.toolbarElevation,
       toolbarShadowColor: widget.style.toolbarShadowColor,
       textDirection: widget.textDirection ?? Directionality.of(context),
+      maxWidth: maxWidth,
     );
     return _toolbarWidget!;
   }

--- a/lib/src/editor/toolbar/desktop/floating_toolbar_widget.dart
+++ b/lib/src/editor/toolbar/desktop/floating_toolbar_widget.dart
@@ -21,6 +21,7 @@ class FloatingToolbarWidget extends StatefulWidget {
     required this.items,
     required this.editorState,
     required this.textDirection,
+    this.maxWidth,
   });
 
   final List<ToolbarItem> items;
@@ -31,6 +32,7 @@ class FloatingToolbarWidget extends StatefulWidget {
   final Color? toolbarShadowColor;
   final EditorState editorState;
   final TextDirection textDirection;
+  final double? maxWidth;
 
   @override
   State<FloatingToolbarWidget> createState() => _FloatingToolbarWidgetState();
@@ -50,28 +52,36 @@ class _FloatingToolbarWidgetState extends State<FloatingToolbarWidget> {
       elevation: widget.toolbarElevation,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8.0),
-        child: SizedBox(
-          height: floatingToolbarHeight,
-          child: Row(
-            key: floatingToolbarContainerKey,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            textDirection: widget.textDirection,
-            children: activeItems
-                .mapIndexed(
-                  (index, item) => Center(
-                    key: Key(
-                      '${floatingToolbarItemPrefixKey}_${item.id}_$index',
-                    ),
-                    child: item.builder!(
-                      context,
-                      widget.editorState,
-                      widget.toolbarActiveColor,
-                      widget.toolbarIconColor,
-                    ),
-                  ),
-                )
-                .toList(growable: false),
+        child: ConstrainedBox(
+          constraints:
+              BoxConstraints(maxWidth: widget.maxWidth ?? double.infinity),
+          child: SizedBox(
+            height: floatingToolbarHeight,
+            // width: widget.width,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                key: floatingToolbarContainerKey,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                textDirection: widget.textDirection,
+                children: activeItems
+                    .mapIndexed(
+                      (index, item) => Center(
+                        key: Key(
+                          '${floatingToolbarItemPrefixKey}_${item.id}_$index',
+                        ),
+                        child: item.builder!(
+                          context,
+                          widget.editorState,
+                          widget.toolbarActiveColor,
+                          widget.toolbarIconColor,
+                        ),
+                      ),
+                    )
+                    .toList(growable: false),
+              ),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
The toolbar is inconveniently hidden when the window is small, so I modified it to scroll.

![scrolltoolbar](https://github.com/user-attachments/assets/205f86b1-94f1-45ae-b697-dde6c77d4e75)
