### PR TITLE
fate: magnifier should be fully displayed at the edge of the editor w…

### DIFF
--- a/lib/src/editor/editor_component/service/editor.dart
+++ b/lib/src/editor/editor_component/service/editor.dart
@@ -238,6 +238,7 @@ class _AppFlowyEditorState extends State<AppFlowyEditor> {
       value: editorState,
       child: FocusScope(
         child: Overlay(
+          clipBehavior: Clip.none,
           initialEntries: [
             OverlayEntry(
               builder: (context) => services!,

--- a/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
@@ -120,6 +120,7 @@ class _MobileSelectionServiceWidgetState
   @override
   Widget build(BuildContext context) {
     final stack = Stack(
+      clipBehavior: Clip.none,
       children: [
         widget.child,
 


### PR DESCRIPTION
magnifier should be fully displayed at the edge of the editor without being cropped, just like the TextFiled magnifier