### PR TITLE
fix: refine drop target position

### DIFF
--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -441,10 +441,14 @@ class _DesktopSelectionServiceWidgetState
     final startRect = blockRect.topLeft;
     final endRect = blockRect.bottomLeft;
 
-    final startDistance = (startRect - offset).distance;
-    final endDistance = (endRect - offset).distance;
+    final renderBox = selectable.context.findRenderObject() as RenderBox;
+    final globalStartRect = renderBox.localToGlobal(startRect);
+    final globalEndRect = renderBox.localToGlobal(endRect);
 
-    final isCloserToStart = startDistance < endDistance;
+    final topDistance = (globalStartRect - offset).distanceSquared;
+    final bottomDistance = (globalEndRect - offset).distanceSquared;
+
+    final isCloserToStart = topDistance < bottomDistance;
 
     _dropTargetEntry = OverlayEntry(
       builder: (context) {


### PR DESCRIPTION
It seems I forgot to translate the offsets to global coordinates of the selectable rect, so the `isCloserToStart` was not correct. Now there's a point halfway in a block in the Y-axis where the drop target will move to the next node, which is more smooth.