### PR TITLE
feat: allow optional icon builder for selection menu items

### DIFF
--- a/lib/src/editor/selection_menu/selection_menu_widget.dart
+++ b/lib/src/editor/selection_menu/selection_menu_widget.dart
@@ -23,10 +23,9 @@ class SelectionMenuItem {
       if (deleteSlash) {
         _deleteSlash(editorState);
       }
-      // WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+
       handler(editorState, menuService, context);
       onSelected?.call();
-      // });
     };
   }
 
@@ -86,10 +85,15 @@ class SelectionMenuItem {
   /// has been inserted.
   factory SelectionMenuItem.node({
     required String Function() getName,
-    required IconData iconData,
     required List<String> keywords,
     required Node Function(EditorState editorState, BuildContext context)
         nodeBuilder,
+    IconData? iconData,
+    Widget Function(
+      EditorState editorState,
+      bool onSelected,
+      SelectionMenuStyle style,
+    )? iconBuilder,
     bool Function(EditorState editorState, Node node)? insertBefore,
     bool Function(EditorState editorState, Node node)? replace,
     Selection? Function(
@@ -99,15 +103,27 @@ class SelectionMenuItem {
       bool insertedBefore,
     )? updateSelection,
   }) {
+    // the iconData and iconBuilder are mutually exclusive
+    assert(iconData == null || iconBuilder == null);
+    assert(iconData != null || iconBuilder != null);
+
     return SelectionMenuItem(
       getName: getName,
-      icon: (editorState, onSelected, style) => Icon(
-        iconData,
-        color: onSelected
-            ? style.selectionMenuItemSelectedIconColor
-            : style.selectionMenuItemIconColor,
-        size: 18.0,
-      ),
+      icon: (editorState, onSelected, style) {
+        if (iconData != null) {
+          Icon(
+            iconData,
+            color: onSelected
+                ? style.selectionMenuItemSelectedIconColor
+                : style.selectionMenuItemIconColor,
+            size: 18.0,
+          );
+        } else if (iconBuilder != null) {
+          return iconBuilder.call(editorState, onSelected, style);
+        }
+
+        return const SizedBox.shrink();
+      },
       keywords: keywords,
       handler: (editorState, _, context) {
         final selection = editorState.selection;


### PR DESCRIPTION
Use `iconBuilder` in SelectionMenuItem.node to customize your own icon.

