### PR TITLE
fix: enable converting multilne to list

### DIFF
--- a/lib/src/editor/toolbar/desktop/items/bulleted_list_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/bulleted_list_toolbar_item.dart
@@ -5,7 +5,7 @@ const _kBulletedListItemId = 'editor.bulleted_list';
 final ToolbarItem bulletedListItem = ToolbarItem(
   id: _kBulletedListItemId,
   group: 3,
-  isActive: onlyShowInSingleSelectionAndTextType,
+  isActive: onlyShowInTextType,
   builder: (context, editorState, highlightColor, iconColor, tooltipBuilder) {
     final selection = editorState.selection!;
     final node = editorState.getNodeAtPath(selection.start.path)!;

--- a/lib/src/editor/toolbar/desktop/items/numbered_list_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/numbered_list_toolbar_item.dart
@@ -5,7 +5,7 @@ const _kNumberedListItemId = 'editor.numbered_list';
 final ToolbarItem numberedListItem = ToolbarItem(
   id: _kNumberedListItemId,
   group: 3,
-  isActive: onlyShowInSingleSelectionAndTextType,
+  isActive: onlyShowInTextType,
   builder: (context, editorState, highlightColor, iconColor, tooltipBuilder) {
     final selection = editorState.selection!;
     final node = editorState.getNodeAtPath(selection.start.path)!;

--- a/test/new/toolbar/desktop/floating_toolbar_test.dart
+++ b/test/new/toolbar/desktop/floating_toolbar_test.dart
@@ -77,5 +77,30 @@ void main() async {
 
       await editor.dispose();
     });
+
+    testWidgets('select multiple line should show bullet and number list item',
+        (tester) async {
+      final editor = tester.editor..addParagraphs(3, initialText: text);
+      await editor.startTesting(withFloatingToolbar: true);
+
+      final selection = Selection(
+        start: Position(path: [0], offset: 7),
+        end: Position(path: [2], offset: 3),
+      );
+      await editor.updateSelection(selection);
+
+      final floatingToolbar = find.byType(FloatingToolbarWidget);
+      final bulletListItem = find.byWidgetPredicate(
+        (w) => w is SVGIconItemWidget && w.iconName == 'toolbar/bulleted_list',
+      );
+      final numberListItem = find.byWidgetPredicate(
+        (w) => w is SVGIconItemWidget && w.iconName == 'toolbar/numbered_list',
+      );
+      expect(floatingToolbar, findsOneWidget);
+      expect(bulletListItem, findsOneWidget);
+      expect(numberListItem, findsOneWidget);
+
+      await editor.dispose();
+    });
   });
 }


### PR DESCRIPTION
currently, it's only possible to convert a single line to a bullet or numbered list.
changed the active check function to also show list items in toolbar when multiple text lines are selected.

closes https://github.com/AppFlowy-IO/AppFlowy/issues/3181