### PR TITLE
fix:chinese input

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math';
 
 import 'package:appflowy_editor/appflowy_editor.dart';
@@ -191,6 +192,11 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
               end: delta.composing.end,
             )
           : delta.composing;
+    }
+
+    // solve the issue where the Chinese IME doesn't continue deleting after the input content has been deleted.
+    if (Platform.isMacOS && (composingTextRange?.isCollapsed ?? false)) {
+      composingTextRange = TextRange.empty;
     }
   }
 }


### PR DESCRIPTION
Closed https://github.com/AppFlowy-IO/AppFlowy/issues/6165
@LucasXu0 View records found to be handwritten input method can not input the solution to the problem deleted
I did not find this problem in the macos test, please inform me of the reason for deletion