### PR TITLE
fix: enable shortcuts if composing text range is collapsed

### DIFF
--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -242,7 +242,9 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
         ),
       );
       // disable shortcuts when the IME active
-      enableShortcuts = textEditingValue.composing == TextRange.empty;
+      //  or the composing text range is collapsed.
+      enableShortcuts = textEditingValue.composing == TextRange.empty ||
+          textEditingValue.composing.isCollapsed;
     } else {
       enableShortcuts = true;
     }


### PR DESCRIPTION
Closed https://github.com/AppFlowy-IO/AppFlowy/issues/6165

When using the Chinese IME on macOS, if deleting all the composing text, it still returns a non-empty composing range, which will cause the shortcuts to be disabled.

```
flutter: delta change: TextEditingDeltaReplacement#c4ccc(oldText: zhong, textReplaced: zhong, replacementText: 中, replacedRange: TextRange(start: 0, end: 5), selection: TextSelection.collapsed(offset: 1, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: -1, end: -1))
flutter: delta change: TextEditingDeltaInsertion#dd21f(oldText: 中, textInserted: j, insertionOffset: 1, selection: TextSelection.collapsed(offset: 2, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: 1, end: 2))
flutter: delta change: TextEditingDeltaInsertion#1d046(oldText: 中j, textInserted: i, insertionOffset: 2, selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: 1, end: 3))
flutter: delta change: TextEditingDeltaDeletion#e1928(oldText: 中ji, textDeleted: i, deletedRange: TextRange(start: 2, end: 3), selection: TextSelection.collapsed(offset: 2, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: 1, end: 2))
flutter: delta change: TextEditingDeltaDeletion#b83a0(oldText: 中j, textDeleted: j, deletedRange: TextRange(start: 1, end: 2), selection: TextSelection.collapsed(offset: 1, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: 1, end: 1))
```