### PR TITLE
feat: support more link types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,16 @@ jobs:
   desktop:
     strategy:
       matrix:
-        os: [macos-14, macos-13, macos-12, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019]
+        os:
+          [
+            macos-14,
+            macos-13,
+            ubuntu-24.04,
+            ubuntu-22.04,
+            ubuntu-20.04,
+            windows-2022,
+            windows-2019,
+          ]
 
     runs-on: ${{ matrix.os }}
 

--- a/lib/src/editor/toolbar/desktop/items/link/link_menu.dart
+++ b/lib/src/editor/toolbar/desktop/items/link/link_menu.dart
@@ -1,8 +1,8 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/editor/toolbar/desktop/items/utils/overlay_util.dart';
+import 'package:appflowy_editor/src/editor/util/link_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:string_validator/string_validator.dart';
 
 class LinkMenu extends StatefulWidget {
   const LinkMenu({
@@ -116,7 +116,7 @@ class _LinkMenuState extends State<LinkMenu> {
           ),
         ),
         validator: (value) {
-          if (value == null || value.isEmpty || !isURL(value)) {
+          if (value == null || value.isEmpty || !isUri(value)) {
             return AppFlowyEditorL10n.current.incorrectLink;
           }
           return null;

--- a/lib/src/editor/toolbar/desktop/items/link/link_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/link/link_toolbar_item.dart
@@ -1,7 +1,7 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/editor/toolbar/desktop/items/link/link_menu.dart';
+import 'package:appflowy_editor/src/editor/util/link_util.dart';
 import 'package:flutter/material.dart';
-import 'package:string_validator/string_validator.dart';
 
 const _menuWidth = 300;
 const _hasTextHeight = 244;
@@ -95,7 +95,7 @@ void showLinkMenu(
           await safeLaunchUrl(linkText);
         },
         onSubmitted: (text) async {
-          if (isURL(text)) {
+          if (isUri(text)) {
             await editorState.formatDelta(selection, {
               BuiltInAttributeKey.href: text,
             });

--- a/lib/src/editor/util/link_util.dart
+++ b/lib/src/editor/util/link_util.dart
@@ -1,11 +1,15 @@
 import 'package:string_validator/string_validator.dart';
 
 bool isUri(String text) {
-  return isURL(text) || isMailTo(text);
+  return isURL(text) || isMailTo(text) || isFile(text);
 }
 
 bool isMailTo(String text) {
   const mailToPrefix = 'mailto:';
   return text.startsWith(mailToPrefix) &&
       isEmail(text.substring(mailToPrefix.length));
+}
+
+bool isFile(String text) {
+  return text.startsWith('file:/');
 }

--- a/lib/src/editor/util/link_util.dart
+++ b/lib/src/editor/util/link_util.dart
@@ -1,15 +1,8 @@
 import 'package:string_validator/string_validator.dart';
 
 bool isUri(String text) {
-  return isURL(text) || isMailTo(text) || isFile(text);
-}
-
-bool isMailTo(String text) {
-  const mailToPrefix = 'mailto:';
-  return text.startsWith(mailToPrefix) &&
-      isEmail(text.substring(mailToPrefix.length));
-}
-
-bool isFile(String text) {
-  return text.startsWith('file:/');
+  final lowerText = text.toLowerCase();
+  return isURL(text) || 
+         lowerText.startsWith('mailto:') || 
+         lowerText.startsWith('file:');
 }

--- a/lib/src/editor/util/link_util.dart
+++ b/lib/src/editor/util/link_util.dart
@@ -1,0 +1,11 @@
+import 'package:string_validator/string_validator.dart';
+
+bool isUri(String text) {
+  return isURL(text) || isMailTo(text);
+}
+
+bool isMailTo(String text) {
+  const mailToPrefix = 'mailto:';
+  return text.startsWith(mailToPrefix) &&
+      isEmail(text.substring(mailToPrefix.length));
+}

--- a/lib/src/editor/util/link_util.dart
+++ b/lib/src/editor/util/link_util.dart
@@ -2,7 +2,7 @@ import 'package:string_validator/string_validator.dart';
 
 bool isUri(String text) {
   final lowerText = text.toLowerCase();
-  return isURL(text) || 
-         lowerText.startsWith('mailto:') || 
-         lowerText.startsWith('file:');
+  return isURL(text) ||
+      lowerText.startsWith('mailto:') ||
+      lowerText.startsWith('file:');
 }


### PR DESCRIPTION
According to https://github.com/AppFlowy-IO/AppFlowy/issues/5146 I added support of `mailto` and `file` URIs.

It's also possible to use built-in [Uri.tryParse](https://api.flutter.dev/flutter/dart-core/Uri/tryParse.html) to support any URI, but I'm not sure if this is a good idea since it allows any schema (e.g. `javascript` too) and probably should be validated more. 

So for now I left it simple.