### PR TITLE
feat: Allow configuring the auto scroll edge offset

### DIFF
--- a/lib/src/editor/editor_component/service/editor.dart
+++ b/lib/src/editor/editor_component/service/editor.dart
@@ -17,7 +17,7 @@ KeepEditorFocusNotifier keepEditorFocusNotifier = KeepEditorFocusNotifier();
 
 /// The default value of the auto scroll edge offset on mobile
 /// The editor will scroll when the cursor is close to the edge of the screen
-double appFlowyEditorAutoScrollEdgeOffset = 220.0;
+const double appFlowyEditorAutoScrollEdgeOffset = 220.0;
 
 class AppFlowyEditor extends StatefulWidget {
   AppFlowyEditor({
@@ -45,6 +45,7 @@ class AppFlowyEditor extends StatefulWidget {
     this.disableKeyboardService = false,
     this.disableScrollService = false,
     this.disableAutoScroll = false,
+    this.autoScrollEdgeOffset = appFlowyEditorAutoScrollEdgeOffset,
   })  : blockComponentBuilders =
             blockComponentBuilders ?? standardBlockComponentBuilderMap,
         characterShortcutEvents =
@@ -216,6 +217,10 @@ class AppFlowyEditor extends StatefulWidget {
   ///
   final bool disableAutoScroll;
 
+  /// The edge offset of the auto scroll.
+  ///
+  final double autoScrollEdgeOffset;
+
   @override
   State<AppFlowyEditor> createState() => _AppFlowyEditorState();
 }
@@ -362,6 +367,7 @@ class _AppFlowyEditorState extends State<AppFlowyEditor> {
     editorState.enableAutoComplete = widget.enableAutoComplete;
     editorState.autoCompleteTextProvider = widget.autoCompleteTextProvider;
     editorState.disableAutoScroll = widget.disableAutoScroll;
+    editorState.autoScrollEdgeOffset = widget.autoScrollEdgeOffset;
   }
 
   BlockComponentRendererService get _renderer => BlockComponentRenderer(

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -108,7 +108,7 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
         return Future.delayed(duration, () {
           startAutoScroll(
             endTouchPoint,
-            edgeOffset: appFlowyEditorAutoScrollEdgeOffset,
+            edgeOffset: editorState.autoScrollEdgeOffset,
             duration: Duration.zero,
           );
         });

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -99,6 +99,9 @@ class EditorState {
   /// Whether the editor should disable auto scroll.
   bool disableAutoScroll = false;
 
+  /// The edge offset of the auto scroll.
+  double autoScrollEdgeOffset = appFlowyEditorAutoScrollEdgeOffset;
+
   /// The style of the editor.
   late EditorStyle editorStyle;
 


### PR DESCRIPTION
When using the `MobileFloatingToolbar` with a markdown editor not in full screen design (e.g. if a docked footer is present on the screen), the default auto scroll edge might not work and would lead to the following assertion error:

```
  assert(
      globalRect.size.width >= _dragTargetRelatedToScrollOrigin.size.width &&
          globalRect.size.height >=
              _dragTargetRelatedToScrollOrigin.size.height,
      'Drag target size is larger than scrollable size, which may cause bouncing',
    );
```

In this case it might be useful to allow configuring the edge offset.