### PR TITLE
fix: backquote key will cause crash when using Frence IME

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart
@@ -12,15 +12,20 @@ Future<void> onInsert(
 
   final textInserted = insertion.textInserted;
 
-  // character shortcut events
-  final execution = await executeCharacterShortcutEvent(
-    editorState,
-    textInserted,
-    characterShortcutEvents,
-  );
+  // In France, the backtick key is used to toggle a character style.
+  // We should prevent the execution of character shortcut events when the
+  // composing range is not collapsed.
+  if (insertion.composing.isCollapsed) {
+    // execute character shortcut events
+    final execution = await executeCharacterShortcutEvent(
+      editorState,
+      textInserted,
+      characterShortcutEvents,
+    );
 
-  if (execution) {
-    return;
+    if (execution) {
+      return;
+    }
   }
 
   var selection = editorState.selection;

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
@@ -5,7 +5,10 @@ import 'package:flutter/services.dart';
 Future<void> onNonTextUpdate(
   TextEditingDeltaNonTextUpdate nonTextUpdate,
   EditorState editorState,
+  List<CharacterShortcutEvent> characterShortcutEvents,
 ) async {
+  AppFlowyEditorLog.input.debug('onNonTextUpdate: $nonTextUpdate');
+
   // update the selection on Windows
   //
   // when typing characters with CJK IME on Windows, a non-text update is sent

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -79,6 +79,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       onNonTextUpdate: (nonTextUpdate) async => await onNonTextUpdate(
         nonTextUpdate,
         editorState,
+        widget.characterShortcutEvents,
       ),
       onPerformAction: (action) async => await onPerformAction(
         action,

--- a/test/editor/editor_component/ime/delta_input_on_non_text_update_impl_test.dart
+++ b/test/editor/editor_component/ime/delta_input_on_non_text_update_impl_test.dart
@@ -14,6 +14,7 @@ void main() {
           composing: TextRange(start: 0, end: 3),
         ),
         EditorState.blank(),
+        [],
       );
     });
   });


### PR DESCRIPTION
'`' in the French IME can trigger a character style convention. It can't be parsed as inline code in this case.



closes https://github.com/AppFlowy-IO/AppFlowy/issues/5299