### PR TITLE
feat: support moving a block to become a child of another block

### DIFF
--- a/example/lib/pages/drag_to_reorder_editor.dart
+++ b/example/lib/pages/drag_to_reorder_editor.dart
@@ -325,13 +325,8 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
   ) {
     final node = data.targetNode;
     final selectable = node.selectable;
-
-    if (selectable == null) {
-      return null;
-    }
-
-    final renderBox = selectable.context.findRenderObject() as RenderBox?;
-    if (renderBox == null) {
+    final renderBox = selectable?.context.findRenderObject() as RenderBox?;
+    if (selectable == null || renderBox == null) {
       return null;
     }
 

--- a/example/lib/pages/drag_to_reorder_editor.dart
+++ b/example/lib/pages/drag_to_reorder_editor.dart
@@ -3,6 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
+enum HorizontalPosition { left, center, right }
+
+enum VerticalPosition { top, middle, bottom }
+
 class DragToReorderEditor extends StatefulWidget {
   const DragToReorderEditor({
     super.key,
@@ -156,6 +160,7 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
         onDragUpdate: (details) {
           editorState.selectionService.renderDropTargetForOffset(
             details.globalPosition,
+            builder: _buildDropArea,
           );
 
           globalPosition = details.globalPosition;
@@ -192,6 +197,16 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
   Future<void> _moveNodeToNewPosition(Node node, Path? acceptedPath) async {
     if (acceptedPath == null) {
       debugPrint('acceptedPath is null');
+      return;
+    }
+
+    if (node.path.equals(acceptedPath)) {
+      debugPrint('node($node) is already at path($acceptedPath)');
+      return;
+    }
+
+    if (node.path.isAncestorOf(acceptedPath)) {
+      debugPrint('node($node) is ancestor of path($acceptedPath)');
       return;
     }
 
@@ -235,5 +250,115 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
         child: child,
       ),
     );
+  }
+
+  Widget _buildDropArea(BuildContext context, DragAreaBuilderData data) {
+    final node = data.targetNode;
+    final selectable = node.selectable;
+
+    if (selectable == null) {
+      return const SizedBox.shrink();
+    }
+
+    final renderBox = selectable.context.findRenderObject() as RenderBox?;
+    if (renderBox == null) {
+      return const SizedBox.shrink();
+    }
+
+    final position = _getPosition(context, data);
+
+    if (position == null) {
+      return const SizedBox.shrink();
+    }
+
+    final (verticalPosition, horizontalPosition, globalBlockRect) = position;
+
+    // 44 is the width of the drag indicator
+    const indicatorWidth = 44.0;
+    final width = globalBlockRect.width - indicatorWidth;
+
+    Widget child = Container(
+      height: 2,
+      width: width,
+      color: Colors.red,
+    );
+
+    if (horizontalPosition == HorizontalPosition.right) {
+      const breakWidth = 22.0;
+      const padding = 8.0;
+      child = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            height: 2,
+            width: breakWidth,
+            color: Colors.red,
+          ),
+          const SizedBox(width: padding),
+          Container(
+            height: 2,
+            width: width - breakWidth - padding,
+            color: Colors.red,
+          ),
+        ],
+      );
+    }
+
+    return Positioned(
+      top: verticalPosition == VerticalPosition.top
+          ? globalBlockRect.top
+          : globalBlockRect.bottom,
+      left: globalBlockRect.left + 22,
+      child: child,
+    );
+  }
+
+  (VerticalPosition, HorizontalPosition, Rect)? _getPosition(
+    BuildContext context,
+    DragAreaBuilderData data,
+  ) {
+    final node = data.targetNode;
+    final selectable = node.selectable;
+
+    if (selectable == null) {
+      return null;
+    }
+
+    final renderBox = selectable.context.findRenderObject() as RenderBox?;
+    if (renderBox == null) {
+      return null;
+    }
+
+    final globalBlockOffset = renderBox.localToGlobal(Offset.zero);
+    final globalBlockRect = globalBlockOffset & renderBox.size;
+    final dragOffset = data.dragOffset;
+
+    // Check if the dragOffset is within the globalBlockRect
+    final isInside = globalBlockRect.contains(dragOffset);
+
+    if (!isInside) {
+      return null;
+    }
+
+    // Determine the relative position
+    HorizontalPosition horizontalPosition;
+    VerticalPosition verticalPosition;
+
+    // Horizontal position
+    if (dragOffset.dx < globalBlockRect.left + 44) {
+      horizontalPosition = HorizontalPosition.left;
+    } else {
+      // ignore the middle here, it's not used in this example
+      horizontalPosition = HorizontalPosition.right;
+    }
+
+    // Vertical position
+    if (dragOffset.dy < globalBlockRect.top + globalBlockRect.height / 2) {
+      verticalPosition = VerticalPosition.top;
+    } else {
+      verticalPosition = VerticalPosition.bottom;
+    }
+
+    return (verticalPosition, horizontalPosition, globalBlockRect);
   }
 }

--- a/example/lib/pages/drag_to_reorder_editor.dart
+++ b/example/lib/pages/drag_to_reorder_editor.dart
@@ -188,7 +188,8 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
 
           _moveNodeToNewPosition(
             widget.blockComponentContext.node,
-            acceptedPath,
+            data?.cursorNode?.path,
+            globalPosition!,
           );
         },
         child: const MouseRegion(
@@ -202,20 +203,45 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
     );
   }
 
-  Future<void> _moveNodeToNewPosition(Node node, Path? acceptedPath) async {
-    final shouldIgnoreDrop = _shouldIgnoreDrop(node, acceptedPath);
-    if (acceptedPath == null || shouldIgnoreDrop) {
+  Future<void> _moveNodeToNewPosition(
+    Node node,
+    Path? acceptedPath,
+    Offset dragOffset,
+  ) async {
+    if (acceptedPath == null) return;
+
+    final editorState = context.read<EditorState>();
+    final targetNode = editorState.getNodeAtPath(acceptedPath);
+    if (targetNode == null) return;
+
+    final position = _getPosition(context, targetNode, dragOffset);
+    if (position == null) return;
+
+    final (verticalPosition, horizontalPosition, _) = position;
+    Path newPath = targetNode.path;
+
+    // Determine the new path based on drop position
+    // For VerticalPosition.top, we keep the target node's path
+    if (verticalPosition == VerticalPosition.bottom) {
+      newPath = horizontalPosition == HorizontalPosition.left
+          ? newPath.next // Insert after target node
+          : newPath.child(0); // Insert as first child of target node
+    }
+
+    // Check if the drop should be ignored
+    if (_shouldIgnoreDrop(node, newPath)) {
       debugPrint(
-        'the move action should be ignored, drag node($node), accepted path($acceptedPath)',
+        'Drop ignored: node($node, ${node.path}), path($acceptedPath)',
       );
       return;
     }
 
-    debugPrint('move node($node, ${node.path}) to path($acceptedPath)');
+    final realNode = widget.blockComponentContext.node;
+    debugPrint('Moving node($realNode, ${realNode.path}) to path($newPath)');
 
-    final editorState = context.read<EditorState>();
+    // Perform the node move operation
     final transaction = editorState.transaction;
-    transaction.moveNode(acceptedPath, widget.blockComponentContext.node);
+    transaction.moveNode(newPath, realNode);
     await editorState.apply(transaction);
   }
 
@@ -252,130 +278,140 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
       ),
     );
   }
+}
 
-  Widget _buildDropArea(
-    BuildContext context,
-    DragAreaBuilderData data,
-    Node dragNode,
-  ) {
-    final targetNode = data.targetNode;
+Widget _buildDropArea(
+  BuildContext context,
+  DragAreaBuilderData data,
+  Node dragNode,
+) {
+  final targetNode = data.targetNode;
 
-    final shouldIgnoreDrop = _shouldIgnoreDrop(dragNode, targetNode.path);
-    if (shouldIgnoreDrop) {
-      return const SizedBox.shrink();
-    }
+  final shouldIgnoreDrop = _shouldIgnoreDrop(dragNode, targetNode.path);
+  if (shouldIgnoreDrop) {
+    return const SizedBox.shrink();
+  }
 
-    final selectable = targetNode.selectable;
-    final renderBox = selectable?.context.findRenderObject() as RenderBox?;
-    if (selectable == null || renderBox == null) {
-      return const SizedBox.shrink();
-    }
+  final selectable = targetNode.selectable;
+  final renderBox = selectable?.context.findRenderObject() as RenderBox?;
+  if (selectable == null || renderBox == null) {
+    return const SizedBox.shrink();
+  }
 
-    final position = _getPosition(context, data);
+  final position = _getPosition(
+    context,
+    targetNode,
+    data.dragOffset,
+  );
 
-    if (position == null) {
-      return const SizedBox.shrink();
-    }
+  if (position == null) {
+    return const SizedBox.shrink();
+  }
 
-    final (verticalPosition, horizontalPosition, globalBlockRect) = position;
+  final (verticalPosition, horizontalPosition, globalBlockRect) = position;
 
-    // 44 is the width of the drag indicator
-    const indicatorWidth = 44.0;
-    final width = globalBlockRect.width - indicatorWidth;
+  // 44 is the width of the drag indicator
+  const indicatorWidth = 44.0;
+  final width = globalBlockRect.width - indicatorWidth;
 
-    Widget child = Container(
-      height: 2,
-      width: width,
-      color: Colors.red,
-    );
+  Widget child = Container(
+    height: 2,
+    width: width,
+    color: Colors.red,
+  );
 
-    if (horizontalPosition == HorizontalPosition.right) {
-      const breakWidth = 22.0;
-      const padding = 8.0;
-      child = Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            height: 2,
-            width: breakWidth,
-            color: Colors.red,
-          ),
-          const SizedBox(width: padding),
-          Container(
-            height: 2,
-            width: width - breakWidth - padding,
-            color: Colors.red,
-          ),
-        ],
-      );
-    }
-
-    return Positioned(
-      top: verticalPosition == VerticalPosition.top
-          ? globalBlockRect.top
-          : globalBlockRect.bottom,
-      left: globalBlockRect.left + 22,
-      child: child,
+  if (horizontalPosition == HorizontalPosition.right) {
+    const breakWidth = 22.0;
+    const padding = 8.0;
+    child = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          height: 2,
+          width: breakWidth,
+          color: Colors.red,
+        ),
+        const SizedBox(width: padding),
+        Container(
+          height: 2,
+          width: width - breakWidth - padding,
+          color: Colors.red,
+        ),
+      ],
     );
   }
 
-  (VerticalPosition, HorizontalPosition, Rect)? _getPosition(
-    BuildContext context,
-    DragAreaBuilderData data,
-  ) {
-    final node = data.targetNode;
-    final selectable = node.selectable;
-    final renderBox = selectable?.context.findRenderObject() as RenderBox?;
-    if (selectable == null || renderBox == null) {
-      return null;
-    }
+  return Positioned(
+    top: verticalPosition == VerticalPosition.top
+        ? globalBlockRect.top
+        : globalBlockRect.bottom,
+    left: globalBlockRect.left + 22,
+    child: child,
+  );
+}
 
-    final globalBlockOffset = renderBox.localToGlobal(Offset.zero);
-    final globalBlockRect = globalBlockOffset & renderBox.size;
-    final dragOffset = data.dragOffset;
-
-    // Check if the dragOffset is within the globalBlockRect
-    final isInside = globalBlockRect.contains(dragOffset);
-
-    if (!isInside) {
-      return null;
-    }
-
-    // Determine the relative position
-    HorizontalPosition horizontalPosition;
-    VerticalPosition verticalPosition;
-
-    // Horizontal position
-    if (dragOffset.dx < globalBlockRect.left + 44) {
-      horizontalPosition = HorizontalPosition.left;
-    } else {
-      // ignore the middle here, it's not used in this example
-      horizontalPosition = HorizontalPosition.right;
-    }
-
-    // Vertical position
-    if (dragOffset.dy < globalBlockRect.top + globalBlockRect.height / 2) {
-      verticalPosition = VerticalPosition.top;
-    } else {
-      verticalPosition = VerticalPosition.bottom;
-    }
-
-    return (verticalPosition, horizontalPosition, globalBlockRect);
+(VerticalPosition, HorizontalPosition, Rect)? _getPosition(
+  BuildContext context,
+  Node dragTargetNode,
+  Offset dragOffset,
+) {
+  final selectable = dragTargetNode.selectable;
+  final renderBox = selectable?.context.findRenderObject() as RenderBox?;
+  if (selectable == null || renderBox == null) {
+    return null;
   }
 
-  bool _shouldIgnoreDrop(Node dragNode, Path? targetPath) {
-    if (targetPath == null) {
-      return true;
-    }
+  final globalBlockOffset = renderBox.localToGlobal(Offset.zero);
+  final globalBlockRect = globalBlockOffset & renderBox.size;
 
-    if (dragNode.path.equals(targetPath)) {
-      return true;
-    }
+  // Check if the dragOffset is within the globalBlockRect
+  final isInside = globalBlockRect.contains(dragOffset);
 
-    if (dragNode.path.isAncestorOf(targetPath)) {
-      return true;
-    }
-
-    return false;
+  if (!isInside) {
+    debugPrint(
+      'the drag offset is not inside the block, dragOffset($dragOffset), globalBlockRect($globalBlockRect)',
+    );
+    return null;
   }
+
+  debugPrint(
+    'the drag offset is inside the block, dragOffset($dragOffset), globalBlockRect($globalBlockRect)',
+  );
+
+  // Determine the relative position
+  HorizontalPosition horizontalPosition;
+  VerticalPosition verticalPosition;
+
+  // Horizontal position
+  if (dragOffset.dx < globalBlockRect.left + 44) {
+    horizontalPosition = HorizontalPosition.left;
+  } else {
+    // ignore the middle here, it's not used in this example
+    horizontalPosition = HorizontalPosition.right;
+  }
+
+  // Vertical position
+  if (dragOffset.dy < globalBlockRect.top + globalBlockRect.height / 2) {
+    verticalPosition = VerticalPosition.top;
+  } else {
+    verticalPosition = VerticalPosition.bottom;
+  }
+
+  return (verticalPosition, horizontalPosition, globalBlockRect);
+}
+
+bool _shouldIgnoreDrop(Node dragNode, Path? targetPath) {
+  if (targetPath == null) {
+    return true;
+  }
+
+  if (dragNode.path.equals(targetPath)) {
+    return true;
+  }
+
+  if (dragNode.path.isAncestorOf(targetPath)) {
+    return true;
+  }
+
+  return false;
 }

--- a/example/lib/pages/drag_to_reorder_editor.dart
+++ b/example/lib/pages/drag_to_reorder_editor.dart
@@ -266,12 +266,8 @@ class _DragToReorderActionState extends State<DragToReorderAction> {
     }
 
     final selectable = targetNode.selectable;
-    if (selectable == null) {
-      return const SizedBox.shrink();
-    }
-
-    final renderBox = selectable.context.findRenderObject() as RenderBox?;
-    if (renderBox == null) {
+    final renderBox = selectable?.context.findRenderObject() as RenderBox?;
+    if (selectable == null || renderBox == null) {
       return const SizedBox.shrink();
     }
 

--- a/lib/src/core/document/path.dart
+++ b/lib/src/core/document/path.dart
@@ -111,7 +111,7 @@ extension PathExtensions on Path {
     return Path.from(this, growable: true)..removeLast();
   }
 
-  bool isParentOf(Path other) {
+  bool isAncestorOf(Path other) {
     if (isEmpty) {
       return true;
     }

--- a/lib/src/core/document/path.dart
+++ b/lib/src/core/document/path.dart
@@ -82,6 +82,10 @@ extension PathExtensions on Path {
       ..add(last + n);
   }
 
+  Path child(int index) {
+    return Path.from(this, growable: true)..add(index);
+  }
+
   Path get previous {
     Path previousPath = Path.from(this, growable: true);
     if (isEmpty) {

--- a/lib/src/core/transform/operation.dart
+++ b/lib/src/core/transform/operation.dart
@@ -258,9 +258,9 @@ Operation? transformOperation(Operation a, Operation b) {
     return b.copyWith(path: newPath);
   } else if (a is DeleteOperation) {
     if (b is DeleteOperation) {
-      if (a.path.isParentOf(b.path)) {
+      if (a.path.isAncestorOf(b.path)) {
         return null; // a is parent of b, we can just delete a and ignore b.
-      } else if (b.path.isParentOf(a.path)) {
+      } else if (b.path.isAncestorOf(a.path)) {
         return a.copyWith(path: b.path);
       }
     }

--- a/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
@@ -833,7 +833,7 @@ class _MobileSelectionServiceWidgetState
   }
 
   @override
-  void renderDropTargetForOffset(Offset offset) {
+  void renderDropTargetForOffset(Offset offset, {DragAreaBuilder? builder}) {
     // Do nothing on mobile
   }
 

--- a/lib/src/editor/editor_component/service/selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection_service.dart
@@ -1,9 +1,23 @@
-import 'package:flutter/material.dart' hide Overlay, OverlayEntry;
-
 import 'package:appflowy_editor/src/core/document/node.dart';
 import 'package:appflowy_editor/src/core/location/position.dart';
 import 'package:appflowy_editor/src/core/location/selection.dart';
 import 'package:appflowy_editor/src/editor/editor_component/service/selection/mobile_selection_service.dart';
+import 'package:flutter/material.dart' hide Overlay, OverlayEntry;
+
+class DragAreaBuilderData {
+  DragAreaBuilderData({
+    required this.targetNode,
+    required this.dragOffset,
+  });
+
+  final Node targetNode;
+  final Offset dragOffset;
+}
+
+typedef DragAreaBuilder = Widget Function(
+  BuildContext context,
+  DragAreaBuilderData data,
+);
 
 /// [AppFlowySelectionService] is responsible for processing
 /// the [Selection] changes and updates.
@@ -89,7 +103,12 @@ abstract class AppFlowySelectionService {
   ///
   /// Should call [removeDropTarget] to remove the line once drop is done.
   ///
-  void renderDropTargetForOffset(Offset offset);
+  /// If [builder] is provided, the line will be drawn by [builder].
+  /// Otherwise, the line will be drawn by default [DropTargetStyle].
+  void renderDropTargetForOffset(
+    Offset offset, {
+    DragAreaBuilder? builder,
+  });
 
   /// Removes the horizontal line drawn by [renderDropTargetForOffset].
   ///

--- a/lib/src/editor/editor_component/service/selection_service_widget.dart
+++ b/lib/src/editor/editor_component/service/selection_service_widget.dart
@@ -124,8 +124,8 @@ class _SelectionServiceWidgetState extends State<SelectionServiceWidget>
   void removeDropTarget() => forward.removeDropTarget();
 
   @override
-  void renderDropTargetForOffset(Offset offset) =>
-      forward.renderDropTargetForOffset(offset);
+  void renderDropTargetForOffset(Offset offset, {DragAreaBuilder? builder}) =>
+      forward.renderDropTargetForOffset(offset, builder: builder);
 
   @override
   DropTargetRenderData? getDropTargetRenderData(Offset offset) =>

--- a/test/core/document/path_test.dart
+++ b/test/core/document/path_test.dart
@@ -74,6 +74,6 @@ void main() async {
     const p1 = [1, 0, 1];
     const p2 = [1, 0];
 
-    expect(p2.isParentOf(p1), true);
+    expect(p2.isAncestorOf(p1), true);
   });
 }


### PR DESCRIPTION
Expose the `builder` parameters in `renderDropTargetForOffset` function to allow developers to customize the drag area widget.




https://github.com/user-attachments/assets/2ee8de7d-ffe3-48c1-9cc3-3248d78b3ed8



