### PR TITLE
feat: listen on delete_backward changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,7 @@ jobs:
   desktop:
     strategy:
       matrix:
-        os:
-          [
-            macos-14,
-            macos-13,
-            ubuntu-24.04,
-            ubuntu-22.04,
-            ubuntu-20.04,
-            windows-2022,
-            windows-2019,
-          ]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -6,6 +6,9 @@ import 'package:appflowy_editor/src/editor/editor_component/service/ime/text_inp
 import 'package:appflowy_editor/src/editor/util/platform_extension.dart';
 import 'package:flutter/services.dart';
 
+// string from flutter callback
+const String _deleteBackwardSelectorName = 'deleteBackward:';
+
 class NonDeltaTextInputService extends TextInputService with TextInputClient {
   NonDeltaTextInputService({
     required super.onInsert,
@@ -168,6 +171,35 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
   @override
   void performSelector(String selectorName) {
     AppFlowyEditorLog.editor.debug('performSelector: $selectorName');
+
+    final currentTextEditingValue = this.currentTextEditingValue?.unformat();
+    if (currentTextEditingValue == null) {
+      return;
+    }
+
+    if (selectorName == _deleteBackwardSelectorName) {
+      final oldText = currentTextEditingValue.text;
+      final selection = currentTextEditingValue.selection;
+      final deleteRange = selection.isCollapsed
+          ? TextRange(
+              start: selection.start - 1,
+              end: selection.end,
+            )
+          : selection;
+      final deleteSelection = TextSelection(
+        baseOffset: selection.baseOffset - 1,
+        extentOffset: selection.extentOffset - 1,
+      );
+      // valid the result
+      onDelete(
+        TextEditingDeltaDeletion(
+          oldText: oldText,
+          deletedRange: deleteRange,
+          selection: deleteSelection,
+          composing: TextRange.empty,
+        ),
+      );
+    }
   }
 
   @override
@@ -227,6 +259,14 @@ extension on TextEditingValue {
       text: text,
       selection: selection,
       composing: composing,
+    );
+  }
+
+  TextEditingValue unformat() {
+    return TextEditingValue(
+      text: text << _len,
+      selection: selection << _len,
+      composing: composing << _len,
     );
   }
 }

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -221,6 +221,10 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       if (editorState.selectionUpdateReason == SelectionUpdateReason.uiEvent) {
         focusNode.requestFocus();
         AppFlowyEditorLog.editor.debug('keyboard service - request focus');
+      } else {
+        AppFlowyEditorLog.editor.debug(
+          'keyboard service - selection changed: $selection',
+        );
       }
     }
 


### PR DESCRIPTION
In some cases, the `onDelete` command doesn't trigger as expected, but at that time, Flutter will call `performSelector` instead.