### PR TITLE
feat: support formatting text when the composing range is not collapsed

### DIFF
--- a/example/lib/pages/editor.dart
+++ b/example/lib/pages/editor.dart
@@ -96,7 +96,7 @@ class _EditorState extends State<Editor> {
 
                   editorState.logConfiguration
                     ..handler = debugPrint
-                    ..level = AppFlowyEditorLogLevel.off;
+                    ..level = AppFlowyEditorLogLevel.all;
 
                   editorState.transactionStream.listen((event) {
                     if (event.$1 == TransactionTime.after) {

--- a/lib/src/core/location/selection.dart
+++ b/lib/src/core/location/selection.dart
@@ -121,4 +121,11 @@ class Selection {
       'end': end.toJson(),
     };
   }
+
+  Selection shift(int offset) {
+    return copyWith(
+      start: start.copyWith(offset: start.offset + offset),
+      end: end.copyWith(offset: end.offset + offset),
+    );
+  }
 }

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/editor/util/platform_extension.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 Future<void> onNonTextUpdate(
@@ -14,6 +15,10 @@ Future<void> onNonTextUpdate(
   // when typing characters with CJK IME on Windows, a non-text update is sent
   // with the selection range.
   final selection = editorState.selection;
+
+  if (await _checkIfBacktickPressed(editorState, nonTextUpdate)) {
+    return;
+  }
 
   if (PlatformExtension.isWindows) {
     if (selection != null &&
@@ -49,4 +54,73 @@ Future<void> onNonTextUpdate(
       );
     }
   }
+}
+
+Future<bool> _checkIfBacktickPressed(
+  EditorState editorState,
+  TextEditingDeltaNonTextUpdate nonTextUpdate,
+) async {
+  // if the composing range is not empty, it means the user is typing a text,
+  // so we don't need to handle the backtick pressed event
+  if (!nonTextUpdate.composing.isCollapsed) {
+    return false;
+  }
+
+  // if the selection is not collapsed, it means the user is not typing a text,
+  // so we need to handle the backtick pressed event
+  if (!nonTextUpdate.selection.isCollapsed) {
+    return false;
+  }
+
+  final selection = editorState.selection;
+  if (selection == null || !selection.isCollapsed) {
+    AppFlowyEditorLog.input.debug('selection is null or not collapsed');
+    return false;
+  }
+
+  final node = editorState.getNodesInSelection(selection).firstOrNull;
+  if (node == null) {
+    AppFlowyEditorLog.input.debug('node is null');
+    return false;
+  }
+
+  // get last character of the node
+  final lastCharacter = node.delta?.toPlainText().characters.lastOrNull;
+  if (lastCharacter != '`') {
+    AppFlowyEditorLog.input.debug('last character is not backtick');
+    return false;
+  }
+
+  // check if the text should be formatted
+  final (shouldApplyFormat, _) = checkSingleCharacterFormatShouldBeApplied(
+    editorState: editorState,
+    // check before the last character
+    selection: selection.shift(-1),
+    character: '`',
+    formatStyle: FormatStyleByWrappingWithSingleChar.code,
+  );
+
+  if (!shouldApplyFormat) {
+    AppFlowyEditorLog.input.debug('should not apply format');
+    return false;
+  }
+
+  final transaction = editorState.transaction;
+  transaction.deleteText(node, node.delta!.toPlainText().length - 1, 1);
+  await editorState.apply(transaction);
+
+  // remove the last backtick, and try to format the text to code block
+  final isFormatted = handleFormatByWrappingWithSingleCharacter(
+    editorState: editorState,
+    character: '`',
+    formatStyle: FormatStyleByWrappingWithSingleChar.code,
+  );
+
+  if (!isFormatted) {
+    AppFlowyEditorLog.input.debug('format failed');
+    // revert the transaction
+    editorState.undoManager.undo();
+  }
+
+  return true;
 }


### PR DESCRIPTION
Before that, we only supported formatting text when the selection was collapsed and the composing range was collapsed. 

For some IMEs, especially those combining backtick with other characters to input a new character, the composing range is not collapsed before formatting text. 

Solution: Check if the newly input character is formattable, even if the composing range is not collapsed. If so, format it; otherwise, ignore it.


https://github.com/user-attachments/assets/84c0aa44-b59d-4693-8df7-2d0ed39a475a


