### PR TITLE
feat: support skipping slice attributes

### DIFF
--- a/lib/src/core/transform/transaction.dart
+++ b/lib/src/core/transform/transaction.dart
@@ -197,6 +197,7 @@ extension TextTransaction on Transaction {
     String text, {
     Attributes? attributes,
     Attributes? toggledAttributes,
+    bool sliceAttributes = true,
   }) {
     final delta = node.delta;
     if (delta == null) {
@@ -210,7 +211,9 @@ extension TextTransaction on Transaction {
       return;
     }
 
-    final newAttributes = attributes ?? delta.sliceAttributes(index) ?? {};
+    final newAttributes = attributes ??
+        (sliceAttributes ? delta.sliceAttributes(index) : {}) ??
+        {};
 
     if (toggledAttributes != null) {
       newAttributes.addAll(toggledAttributes);

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart
@@ -81,6 +81,4 @@ Future<void> onInsert(
     )
     ..afterSelection = afterSelection;
   await editorState.apply(transaction);
-
-  editorState.sliceUpcomingAttributes = true;
 }

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_insert_impl.dart
@@ -24,6 +24,7 @@ Future<void> onInsert(
     );
 
     if (execution) {
+      editorState.sliceUpcomingAttributes = false;
       return;
     }
   }
@@ -76,7 +77,10 @@ Future<void> onInsert(
       selection.startIndex,
       textInserted,
       toggledAttributes: editorState.toggledStyle,
+      sliceAttributes: editorState.sliceUpcomingAttributes,
     )
     ..afterSelection = afterSelection;
-  return editorState.apply(transaction);
+  await editorState.apply(transaction);
+
+  editorState.sliceUpcomingAttributes = true;
 }

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -123,6 +123,9 @@ class EditorState {
       _toggledStyle.clear();
     }
 
+    // reset slice flag
+    sliceUpcomingAttributes = true;
+
     selectionNotifier.value = value;
   }
 

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -183,6 +183,12 @@ class EditorState {
     toggledStyleNotifier.value = {..._toggledStyle};
   }
 
+  /// Whether the upcoming attributes should be sliced.
+  ///
+  /// If the value is true, the upcoming attributes will be sliced.
+  /// If the value is false, the upcoming attributes will be skipped.
+  bool sliceUpcomingAttributes = true;
+
   final UndoManager undoManager = UndoManager();
 
   Transaction get transaction {

--- a/test/customer/slice_attributes_test.dart
+++ b/test/customer/slice_attributes_test.dart
@@ -1,0 +1,66 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../new/infra/testable_editor.dart';
+
+void main() async {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  // input `Hello` World
+  // only the `Hello` has the code style
+  testWidgets('skip attributes if pressing space', (tester) async {
+    final editor = tester.editor..addEmptyParagraph();
+    await editor.startTesting();
+    await tester.pumpAndSettle();
+
+    final selection = Selection.collapsed(Position(path: [0]));
+    await editor.updateSelection(selection);
+    const text = '`Hello` World';
+    for (var i = 0; i < text.length; i++) {
+      await editor.ime.typeText(text[i]);
+    }
+
+    final node = editor.editorState.getNodeAtPath([0]);
+    final delta = node?.delta;
+    expect(delta?.toPlainText(), 'Hello World');
+    expect(delta?.toJson(), [
+      {
+        'insert': 'Hello',
+        'attributes': {'code': true},
+      },
+      {'insert': ' World'},
+    ]);
+  });
+
+  testWidgets('keep attributes if pressing backspace', (tester) async {
+    final editor = tester.editor..addEmptyParagraph();
+    await editor.startTesting();
+    await tester.pumpAndSettle();
+
+    final selection = Selection.collapsed(Position(path: [0]));
+    await editor.updateSelection(selection);
+    const text1 = '`Hello` ';
+    for (var i = 0; i < text1.length; i++) {
+      await editor.ime.typeText(text1[i]);
+    }
+
+    await tester.editor.pressKey(key: LogicalKeyboardKey.backspace);
+
+    const text2 = 'World';
+    for (var i = 0; i < text2.length; i++) {
+      await editor.ime.typeText(text2[i]);
+    }
+
+    final node = editor.editorState.getNodeAtPath([0]);
+    final delta = node?.delta;
+    expect(delta?.toJson(), [
+      {
+        'insert': 'HelloWorld',
+        'attributes': {'code': true},
+      },
+    ]);
+  });
+}


### PR DESCRIPTION
Skip formatting for continued input after space key press

Example:

`**Hello**` + press space key +  `World` will become **Hello**  World
``**Hello**`` + press space key + press backspace key + `World` will become **HelloWorld** 