### PR TITLE
feat: add keyboard service interceptor to prevent default ops execution

### DIFF
--- a/lib/src/editor/editor_component/service/keyboard_service.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// [AppFlowyKeyboardService] is responsible for processing shortcut keys,
 ///   like command, shift, control keys.
@@ -41,4 +42,48 @@ abstract class AppFlowyKeyboardService {
   ///
   /// Used in mobile
   void enableKeyBoard(Selection selection);
+
+  /// Register interceptor
+  void registerInterceptor(AppFlowyKeyboardServiceInterceptor interceptor);
+
+  /// Unregister interceptor
+  void unregisterInterceptor(AppFlowyKeyboardServiceInterceptor interceptor);
+}
+
+/// [AppFlowyKeyboardServiceInterceptor] is used to intercept the keyboard service.
+///
+/// If the interceptor returns `true`, the keyboard service will not perform
+/// the built-in operation.
+abstract class AppFlowyKeyboardServiceInterceptor {
+  /// Intercept insert operation
+  Future<bool> interceptInsert(TextEditingDeltaInsertion insertion) async {
+    return false;
+  }
+
+  /// Intercept delete operation
+  Future<bool> interceptDelete(TextEditingDeltaDeletion deletion) async {
+    return false;
+  }
+
+  /// Intercept replace operation
+  Future<bool> interceptReplace(TextEditingDeltaReplacement replacement) async {
+    return false;
+  }
+
+  /// Intercept non-text update operation
+  Future<bool> interceptNonTextUpdate(
+    TextEditingDeltaNonTextUpdate nonTextUpdate,
+  ) async {
+    return false;
+  }
+
+  /// Intercept perform action operation
+  Future<bool> interceptPerformAction(TextInputAction action) async {
+    return false;
+  }
+
+  /// Intercept floating cursor operation
+  Future<bool> interceptFloatingCursor(RawFloatingCursorPoint point) async {
+    return false;
+  }
 }

--- a/lib/src/editor/editor_component/service/keyboard_service.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service.dart
@@ -56,34 +56,53 @@ abstract class AppFlowyKeyboardService {
 /// the built-in operation.
 abstract class AppFlowyKeyboardServiceInterceptor {
   /// Intercept insert operation
-  Future<bool> interceptInsert(TextEditingDeltaInsertion insertion) async {
+  Future<bool> interceptInsert(
+    TextEditingDeltaInsertion insertion,
+    EditorState editorState,
+    List<CharacterShortcutEvent> characterShortcutEvents,
+  ) async {
     return false;
   }
 
   /// Intercept delete operation
-  Future<bool> interceptDelete(TextEditingDeltaDeletion deletion) async {
+  Future<bool> interceptDelete(
+    TextEditingDeltaDeletion deletion,
+    EditorState editorState,
+  ) async {
     return false;
   }
 
   /// Intercept replace operation
-  Future<bool> interceptReplace(TextEditingDeltaReplacement replacement) async {
+  Future<bool> interceptReplace(
+    TextEditingDeltaReplacement replacement,
+    EditorState editorState,
+    List<CharacterShortcutEvent> characterShortcutEvents,
+  ) async {
     return false;
   }
 
   /// Intercept non-text update operation
   Future<bool> interceptNonTextUpdate(
     TextEditingDeltaNonTextUpdate nonTextUpdate,
+    EditorState editorState,
+    List<CharacterShortcutEvent> characterShortcutEvents,
   ) async {
     return false;
   }
 
   /// Intercept perform action operation
-  Future<bool> interceptPerformAction(TextInputAction action) async {
+  Future<bool> interceptPerformAction(
+    TextInputAction action,
+    EditorState editorState,
+  ) async {
     return false;
   }
 
   /// Intercept floating cursor operation
-  Future<bool> interceptFloatingCursor(RawFloatingCursorPoint point) async {
+  Future<bool> interceptFloatingCursor(
+    RawFloatingCursorPoint point,
+    EditorState editorState,
+  ) async {
     return false;
   }
 }

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -332,10 +332,19 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
     return NonDeltaTextInputService(
       onInsert: (insertion) async {
         for (final interceptor in interceptors) {
-          if (await interceptor.interceptInsert(insertion)) {
+          final result = await interceptor.interceptInsert(
+            insertion,
+            editorState,
+            widget.characterShortcutEvents,
+          );
+          if (result) {
+            AppFlowyEditorLog.input.info(
+              'keyboard service onInsert - intercepted by interceptor: $interceptor',
+            );
             return;
           }
         }
+
         await onInsert(
           insertion,
           editorState,
@@ -344,10 +353,18 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       },
       onDelete: (deletion) async {
         for (final interceptor in interceptors) {
-          if (await interceptor.interceptDelete(deletion)) {
+          final result = await interceptor.interceptDelete(
+            deletion,
+            editorState,
+          );
+          if (result) {
+            AppFlowyEditorLog.input.info(
+              'keyboard service onDelete - intercepted by interceptor: $interceptor',
+            );
             return;
           }
         }
+
         await onDelete(
           deletion,
           editorState,
@@ -355,10 +372,19 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       },
       onReplace: (replacement) async {
         for (final interceptor in interceptors) {
-          if (await interceptor.interceptReplace(replacement)) {
+          final result = await interceptor.interceptReplace(
+            replacement,
+            editorState,
+            widget.characterShortcutEvents,
+          );
+          if (result) {
+            AppFlowyEditorLog.input.info(
+              'keyboard service onReplace - intercepted by interceptor: $interceptor',
+            );
             return;
           }
         }
+
         await onReplace(
           replacement,
           editorState,
@@ -367,10 +393,19 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       },
       onNonTextUpdate: (nonTextUpdate) async {
         for (final interceptor in interceptors) {
-          if (await interceptor.interceptNonTextUpdate(nonTextUpdate)) {
+          final result = await interceptor.interceptNonTextUpdate(
+            nonTextUpdate,
+            editorState,
+            widget.characterShortcutEvents,
+          );
+          if (result) {
+            AppFlowyEditorLog.input.info(
+              'keyboard service onNonTextUpdate - intercepted by interceptor: $interceptor',
+            );
             return;
           }
         }
+
         await onNonTextUpdate(
           nonTextUpdate,
           editorState,
@@ -379,10 +414,18 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       },
       onPerformAction: (action) async {
         for (final interceptor in interceptors) {
-          if (await interceptor.interceptPerformAction(action)) {
+          final result = await interceptor.interceptPerformAction(
+            action,
+            editorState,
+          );
+          if (result) {
+            AppFlowyEditorLog.input.info(
+              'keyboard service onPerformAction - intercepted by interceptor: $interceptor',
+            );
             return;
           }
         }
+
         await onPerformAction(
           action,
           editorState,
@@ -390,10 +433,18 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       },
       onFloatingCursor: (point) async {
         for (final interceptor in interceptors) {
-          if (await interceptor.interceptFloatingCursor(point)) {
+          final result = await interceptor.interceptFloatingCursor(
+            point,
+            editorState,
+          );
+          if (result) {
+            AppFlowyEditorLog.input.info(
+              'keyboard service onFloatingCursor - intercepted by interceptor: $interceptor',
+            );
             return;
           }
         }
+
         await onFloatingCursorUpdate(
           point,
           editorState,


### PR DESCRIPTION
Provide a keyboard service interceptor to allow developers to override or inject built-in keyboard operations.

```dart
abstract class AppFlowyKeyboardServiceInterceptor {
  /// Intercept insert operation
  Future<bool> interceptInsert(
    TextEditingDeltaInsertion insertion,
    EditorState editorState,
    List<CharacterShortcutEvent> characterShortcutEvents,
  ) async {
    return false;
  }

  /// Intercept delete operation
  Future<bool> interceptDelete(
    TextEditingDeltaDeletion deletion,
    EditorState editorState,
  ) async {
    return false;
  }

  /// Intercept replace operation
  Future<bool> interceptReplace(
    TextEditingDeltaReplacement replacement,
    EditorState editorState,
    List<CharacterShortcutEvent> characterShortcutEvents,
  ) async {
    return false;
  }

  /// Intercept non-text update operation
  Future<bool> interceptNonTextUpdate(
    TextEditingDeltaNonTextUpdate nonTextUpdate,
    EditorState editorState,
    List<CharacterShortcutEvent> characterShortcutEvents,
  ) async {
    return false;
  }

  /// Intercept perform action operation
  Future<bool> interceptPerformAction(
    TextInputAction action,
    EditorState editorState,
  ) async {
    return false;
  }

  /// Intercept floating cursor operation
  Future<bool> interceptFloatingCursor(
    RawFloatingCursorPoint point,
    EditorState editorState,
  ) async {
    return false;
  }
}
```