### PR TITLE
feat: add 'delete line' command shortcut

### DIFF
--- a/lib/src/editor/block_component/base_component/delete_line_command.dart
+++ b/lib/src/editor/block_component/base_component/delete_line_command.dart
@@ -1,0 +1,43 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+
+/// Delete the current line
+///
+/// - support
+///   - desktop
+///   - web
+///
+final CommandShortcutEvent deleteLineCommand = CommandShortcutEvent(
+  key: 'delete line',
+  getDescription: () => 'Delete the current line',
+  command: 'ctrl+x',
+  macOSCommand: 'cmd+x',
+  handler: _deleteLineCommandHandler,
+);
+
+// when the selection is collapsed, press cmd+x(or ctrl+x) should delete the current line
+CommandShortcutEventHandler _deleteLineCommandHandler = (editorState) {
+  final selection = editorState.selection;
+  if (selection == null || !selection.isCollapsed) {
+    return KeyEventResult.ignored;
+  }
+  final node = editorState.getNodeAtPath(selection.end.path);
+  if (node == null) {
+    return KeyEventResult.ignored;
+  }
+
+  final nextNode = node.next;
+  Selection? afterSelection;
+  if (nextNode != null && nextNode.delta != null) {
+    afterSelection = Selection.collapsed(
+      Position(path: node.path, offset: nextNode.delta?.length ?? 0),
+    );
+  }
+
+  final transaction = editorState.transaction
+    ..deleteNode(node)
+    ..afterSelection = afterSelection;
+  editorState.apply(transaction);
+
+  return KeyEventResult.handled;
+};

--- a/lib/src/editor/block_component/block_component.dart
+++ b/lib/src/editor/block_component/block_component.dart
@@ -6,6 +6,7 @@ export 'base_component/block_component_action_wrapper.dart';
 export 'base_component/block_component_configuration.dart';
 // base
 export 'base_component/convert_to_paragraph_command.dart';
+export 'base_component/delete_line_command.dart';
 export 'base_component/indent_command.dart';
 export 'base_component/insert_newline_in_type_command.dart';
 export 'base_component/markdown_format_helper.dart';

--- a/lib/src/editor/block_component/standard_block_components.dart
+++ b/lib/src/editor/block_component/standard_block_components.dart
@@ -148,6 +148,9 @@ final List<CommandShortcutEvent> standardCommandShortcutEvents = [
   //
   selectAllCommand,
 
+  // delete line
+  deleteLineCommand,
+
   // copy paste and cut
   copyCommand,
   ...pasteCommands,

--- a/test/new/service/shortcuts/command_shortcut_events/delete_line_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/delete_line_command_test.dart
@@ -1,0 +1,59 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../util/util.dart';
+
+void main() async {
+  group('deleteLineCommand', () {
+    group('delete current line if the selection is collapsed', () {
+      const text = 'Welcome to AppFlowy Editor 🔥!';
+
+      test('delete in collapsed selection when the index > 0', () async {
+        final document = Document.blank().addParagraphs(
+          2,
+          builder: (index) => Delta()..insert('${index + 1}. $text'),
+        );
+        final editorState = EditorState(document: document);
+
+        final selection = Selection.collapsed(
+          Position(path: [0], offset: text.length),
+        );
+        editorState.selection = selection;
+
+        final result = deleteLineCommand.execute(editorState);
+        expect(result, KeyEventResult.handled);
+
+        final after = editorState.getNodeAtPath([0])!;
+        expect(after.delta!.toPlainText(), '2. $text');
+      });
+
+      test('do nothing if the selection is not collapsed', () async {
+        final document = Document.blank().addParagraphs(
+          2,
+          builder: (index) => Delta()..insert('${index + 1}. $text'),
+        );
+        final editorState = EditorState(document: document);
+
+        final selection = Selection(
+          start: Position(path: [0], offset: 0),
+          end: Position(path: [0], offset: text.length),
+        );
+        editorState.selection = selection;
+
+        final result = deleteLineCommand.execute(editorState);
+        expect(result, KeyEventResult.ignored);
+
+        expect(
+          editorState.getNodeAtPath([0])!.delta!.toPlainText(),
+          '1. $text',
+        );
+        expect(
+          editorState.getNodeAtPath([1])!.delta!.toPlainText(),
+          '2. $text',
+        );
+        expect(editorState.selection, selection);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Press Cmd (on Mac) or Ctrl (on Windows/Linux) + X will:

- [x] If the selection is collapsed, delete the current line.
- [x] If the selection is not collapsed, do nothing.

related to https://github.com/AppFlowy-IO/AppFlowy/issues/6425