### PR TITLE
feat: implement custom pan gesture to avoid delay offset update

### DIFF
--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -288,14 +288,15 @@ class _DesktopSelectionServiceWidgetState
   void _onPanStart(DragStartDetails details) {
     clearSelection();
 
-    final canPanStart = _interceptors
-        .every((interceptor) => interceptor.canPanStart?.call(details) ?? true);
+    final canPanStart = _interceptors.every(
+      (interceptor) => interceptor.canPanStart?.call(details) ?? true,
+    );
 
     if (!canPanStart) {
       return;
     }
 
-    _panStartOffset = details.globalPosition.translate(-5.0, 0);
+    _panStartOffset = details.globalPosition;
     _panStartScrollDy = editorState.service.scrollService?.dy;
 
     _panStartPosition = getNodeInOffset(_panStartOffset!)


### PR DESCRIPTION
By default, the `panStart` callback from `PanGestureRecognizer` won't be triggered immediately after dragging starts. It will be delayed, causing the start offset point to not match the real offset point on the screen. For example, when you start dragging from offset(0,0) horizontally, the panStart callback may trigger at offset(2, 0), which causes the start selection calculation to be incorrect.

The solution is to implement a custom `PanGesture` which triggers the `panStart` call immediately without any delay.

### preview
https://github.com/user-attachments/assets/c9344c58-c17f-4f91-be24-267760025ea9

