### PR TITLE
fix: only notify ui of selection change if it actually changed

### DIFF
--- a/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/desktop_selection_service.dart
@@ -1,9 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/editor/editor_component/service/selection/mobile_selection_service.dart';
 import 'package:appflowy_editor/src/editor/editor_component/service/selection/shared.dart';
 import 'package:appflowy_editor/src/service/selection/selection_gesture.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 class DesktopSelectionServiceWidget extends StatefulWidget {
@@ -333,7 +334,10 @@ class _DesktopSelectionServiceWidgetState
       final start = _panStartPosition!;
       final end = last.getSelectionInRange(panStartOffset, panEndOffset).end;
       final selection = Selection(start: start, end: end);
-      updateSelection(selection);
+
+      if (selection != currentSelection.value) {
+        updateSelection(selection);
+      }
     }
 
     editorState.service.scrollService?.startAutoScroll(


### PR DESCRIPTION
Just a minor thing I noticed, if I have an empty node and I'm dragging horizontally, I could see the cursor blinking fast as if the selection updates all the time, but we shouldn't notify about the update unless the selection actually did change.