### PR TITLE
fix: do not highlight inactive items on empty selection

### DIFF
--- a/lib/src/editor/toolbar/desktop/items/color/highlight_color_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/color/highlight_color_toolbar_item.dart
@@ -13,6 +13,10 @@ ToolbarItem buildHighlightColorItem({List<ColorOption>? colorOptions}) {
       final selection = editorState.selection!;
       final nodes = editorState.getNodesInSelection(selection);
       final isHighlight = nodes.allSatisfyInSelection(selection, (delta) {
+        if (delta.everyAttributes((attr) => attr.isEmpty)) {
+          return false;
+        }
+
         return delta.everyAttributes((attributes) {
           highlightColorHex = attributes[AppFlowyRichTextKeys.backgroundColor];
           return highlightColorHex != null;

--- a/lib/src/editor/toolbar/desktop/items/color/text_color_toolbar_item.dart
+++ b/lib/src/editor/toolbar/desktop/items/color/text_color_toolbar_item.dart
@@ -14,8 +14,12 @@ ToolbarItem buildTextColorItem({
       final selection = editorState.selection!;
       final nodes = editorState.getNodesInSelection(selection);
       final isHighlight = nodes.allSatisfyInSelection(selection, (delta) {
-        return delta.everyAttributes((attributes) {
-          textColorHex = attributes[AppFlowyRichTextKeys.textColor];
+        if (delta.everyAttributes((attr) => attr.isEmpty)) {
+          return false;
+        }
+
+        return delta.everyAttributes((attr) {
+          textColorHex = attr[AppFlowyRichTextKeys.textColor];
           return (textColorHex != null);
         });
       });

--- a/lib/src/editor/toolbar/desktop/items/format_toolbar_items.dart
+++ b/lib/src/editor/toolbar/desktop/items/format_toolbar_items.dart
@@ -41,11 +41,12 @@ class _FormatToolbarItem extends ToolbarItem {
           ) {
             final selection = editorState.selection!;
             final nodes = editorState.getNodesInSelection(selection);
-            final isHighlight = nodes.allSatisfyInSelection(selection, (delta) {
-              return delta.everyAttributes(
-                (attributes) => attributes[name] == true,
-              );
-            });
+            final isHighlight = nodes.allSatisfyInSelection(
+              selection,
+              (delta) =>
+                  delta.isNotEmpty &&
+                  delta.everyAttributes((attr) => attr[name] == true),
+            );
 
             final child = SVGIconItemWidget(
               iconName: 'toolbar/$name',

--- a/lib/src/render/toolbar/toolbar_item.dart
+++ b/lib/src/render/toolbar/toolbar_item.dart
@@ -1,5 +1,6 @@
-import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart' hide Overlay, OverlayEntry;
+
+import 'package:appflowy_editor/appflowy_editor.dart';
 
 typedef ToolbarItemEventHandler = void Function(
   EditorState editorState,
@@ -102,7 +103,6 @@ bool onlyShowInTextType(EditorState editorState) {
   }
   final nodes = editorState.getNodesInSelection(selection);
   return nodes.every(
-    (element) =>
-        element.delta != null && toolbarItemWhiteList.contains(element.type),
+    (node) => node.delta != null && toolbarItemWhiteList.contains(node.type),
   );
 }


### PR DESCRIPTION
Closes: [#1681](https://github.com/AppFlowy-IO/AppFlowy/issues/1681)

This is simply an improvement to the behavior, there is nothing to "apply" formatting options on, so should we even show these options? We can improve that later..

## Before:

https://github.com/user-attachments/assets/d38511a3-fe40-4979-8f69-b34a565f5c03


## After:

https://github.com/user-attachments/assets/622505e3-40dc-41b4-afe1-b8fe3d0c3b65

