### PR TITLE
fix: html decoder ignores h4-h6 tags

### DIFF
--- a/lib/src/plugins/html/html_document.dart
+++ b/lib/src/plugins/html/html_document.dart
@@ -46,6 +46,7 @@ class AppFlowyEditorHTMLCodec extends Codec<Document, String> {
   Converter<String, Document> get decoder => DocumentHTMLDecoder();
 
   @override
-  Converter<Document, String> get encoder =>
-      DocumentHTMLEncoder(encodeParsers: encodeParsers);
+  Converter<Document, String> get encoder => DocumentHTMLEncoder(
+        encodeParsers: encodeParsers,
+      );
 }

--- a/lib/src/plugins/html/html_document_decoder.dart
+++ b/lib/src/plugins/html/html_document_decoder.dart
@@ -77,6 +77,12 @@ class DocumentHTMLDecoder extends Converter<String, Document> {
         return _parseHeadingElement(element, level: 2);
       case HTMLTags.h3:
         return _parseHeadingElement(element, level: 3);
+      case HTMLTags.h4:
+        return _parseHeadingElement(element, level: 4);
+      case HTMLTags.h5:
+        return _parseHeadingElement(element, level: 5);
+      case HTMLTags.h6:
+        return _parseHeadingElement(element, level: 6);
       case HTMLTags.unorderedList:
         return _parseUnOrderListElement(element);
       case HTMLTags.orderedList:

--- a/test/plugins/html/html_document_test.dart
+++ b/test/plugins/html/html_document_test.dart
@@ -304,4 +304,22 @@ void main() {
       ],
     );
   });
+
+  test('sample 11', () {
+    const html = '''
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h3>
+<h4>Heading 4</h4>
+<h5>Heading 5</h5>
+<h6>Heading 6</h6>
+''';
+    final document = htmlToDocument(html);
+    for (var i = 1; i <= 6; i++) {
+      final node = document.nodeAtPath([i - 1]);
+      expect(node!.type, HeadingBlockKeys.type);
+      expect(node.delta!.toPlainText(), 'Heading $i');
+      expect(node.attributes[HeadingBlockKeys.level], i);
+    }
+  });
 }


### PR DESCRIPTION
closes https://github.com/AppFlowy-IO/appflowy-editor/issues/913
Support decoding H4-H6 when parsing HTML.

