### PR TITLE
fix: markdown parser doesn't recognize softline breaks

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -56,7 +56,7 @@ dependency_overrides:
     git:
       url: https://github.com/AppFlowy-IO/AppFlowy-plugins.git
       path: "packages/appflowy_editor_plugins"
-      ref: "b228456"
+      ref: "2d3d4fb"
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -21,7 +21,6 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       inlineSyntaxes: [
         ...inlineSyntaxes,
         UnderlineInlineSyntax(),
-        md.SoftLineBreakSyntax(),
       ],
       encodeHtml: false,
     ).parse(input);

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -21,18 +21,17 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       inlineSyntaxes: [
         ...inlineSyntaxes,
         UnderlineInlineSyntax(),
+        md.SoftLineBreakSyntax(),
       ],
       encodeHtml: false,
     ).parse(input);
+
     final document = Document.blank();
-
     final nodes = mdNodes
-        .map((mdNode) => _parseNode(mdNode))
-        .toList()
+        .map((e) => _parseNode(e))
         .whereNotNull()
-        .toList()
-        .flattened;
-
+        .flattened
+        .toList(growable: false); // avoid lazy evaluation
     if (nodes.isNotEmpty) {
       document.insert([0], nodes);
     }

--- a/lib/src/plugins/markdown/decoder/parser/markdown_paragraph_parser.dart
+++ b/lib/src/plugins/markdown/decoder/parser/markdown_paragraph_parser.dart
@@ -28,11 +28,26 @@ class MarkdownParagraphParserV2 extends CustomMarkdownParser {
       }
     }
 
-    final deltaDecoder = DeltaMarkdownDecoder();
-    return [
-      paragraphNode(
-        delta: deltaDecoder.convertNodes(element.children),
-      ),
-    ];
+    if (ec == null || ec.isEmpty) {
+      // return empty paragraph node if there is no children
+      return [
+        paragraphNode(),
+      ];
+    }
+
+    final nodes = <Node>[];
+    for (final child in ec) {
+      if (child is! md.Text) {
+        nodes.addAll(parseElementChildren([child], parsers));
+        continue;
+      }
+      final deltaDecoder = DeltaMarkdownDecoder();
+      nodes.add(
+        paragraphNode(
+          delta: deltaDecoder.convertNodes([child]),
+        ),
+      );
+    }
+    return nodes;
   }
 }

--- a/test/plugins/markdown/document_markdown_test.dart
+++ b/test/plugins/markdown/document_markdown_test.dart
@@ -12,6 +12,14 @@ void main() {
       expect(document.toJson(), data);
     });
 
+    test('soft line break with two spaces', () {
+      const markdown = 'first line  \nsecond line';
+      final document = markdownToDocument(markdown);
+      expect(document.root.children.length, 2);
+      expect(document.root.children[0].delta?.toPlainText(), 'first line');
+      expect(document.root.children[1].delta?.toPlainText(), 'second line');
+    });
+
     test('documentToMarkdown()', () {
       final document = markdownToDocument(markdownDocument);
       final markdown = documentToMarkdown(document);


### PR DESCRIPTION
closes https://github.com/AppFlowy-IO/appflowy-editor/issues/912

<img width="577" alt="Screenshot 2024-10-15 at 21 52 28" src="https://github.com/user-attachments/assets/1e5d6f9b-aab9-4b85-9e6e-df3baf54dc3a">
