### PR TITLE
feat: custom slice function

### DIFF
--- a/example/lib/pages/editor.dart
+++ b/example/lib/pages/editor.dart
@@ -32,6 +32,13 @@ class _EditorState extends State<Editor> {
   WordCountService? wordCountService;
 
   @override
+  void initState() {
+    super.initState();
+
+    appflowyEditorSliceAttributes = sliceAttributes;
+  }
+
+  @override
   void didUpdateWidget(covariant Editor oldWidget) {
     if (oldWidget.jsonString != widget.jsonString) {
       editorState = null;
@@ -154,6 +161,62 @@ class _EditorState extends State<Editor> {
           ),
         ),
       ],
+    );
+  }
+
+  Attributes? sliceAttributes(Delta delta, int index) {
+    if (index < 0) {
+      return null;
+    }
+
+    // if the index == 0, slice the attributes from the next position.
+    if (index == 0 && delta.isNotEmpty) {
+      final attributes = delta.slice(index, index + 1).firstOrNull?.attributes;
+      if (attributes == null) {
+        return null;
+      }
+
+      if (!isSupportSliced(attributes)) {
+        return null;
+      }
+
+      return attributes;
+    }
+
+    // if the index is not 0, slice the attributes from the previous position.
+    final prevAttributes =
+        delta.slice(index - 1, index).firstOrNull?.attributes;
+    if (prevAttributes == null) {
+      return null;
+    }
+    // if the prevAttributes doesn't include the code, return it.
+    // Otherwise, check if the nextAttributes includes the code.
+    if (!prevAttributes.keys.any(
+      (element) => element == AppFlowyRichTextKeys.code,
+    )) {
+      return prevAttributes;
+    }
+
+    // check if the nextAttributes includes the code.
+    final nextAttributes =
+        delta.slice(index, index + 1).firstOrNull?.attributes;
+    if (nextAttributes == null) {
+      return prevAttributes..remove(AppFlowyRichTextKeys.code);
+    }
+
+    // if the nextAttributes doesn't include the code, exclude the code format.
+    if (!nextAttributes.keys.any(
+      (element) => element == AppFlowyRichTextKeys.code,
+    )) {
+      return prevAttributes..remove(AppFlowyRichTextKeys.code);
+    }
+
+    return prevAttributes;
+  }
+
+  bool isSupportSliced(Attributes attributes) {
+    return attributes.keys.every(
+      (element) => AppFlowyRichTextKeys.supportSliced.contains(element),
     );
   }
 }

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
@@ -140,6 +140,8 @@ Future<bool> _checkIfBacktickPressed(
     AppFlowyEditorLog.input.debug('format failed');
     // revert the transaction
     editorState.undoManager.undo();
+  } else {
+    editorState.sliceUpcomingAttributes = false;
   }
 
   return true;

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -190,7 +190,15 @@ class EditorState {
   ///
   /// If the value is true, the upcoming attributes will be sliced.
   /// If the value is false, the upcoming attributes will be skipped.
-  bool sliceUpcomingAttributes = true;
+  bool _sliceUpcomingAttributes = true;
+  bool get sliceUpcomingAttributes => _sliceUpcomingAttributes;
+  set sliceUpcomingAttributes(bool value) {
+    if (value == _sliceUpcomingAttributes) {
+      return;
+    }
+    AppFlowyEditorLog.input.debug('sliceUpcomingAttributes: $value');
+    _sliceUpcomingAttributes = value;
+  }
 
   final UndoManager undoManager = UndoManager();
 


### PR DESCRIPTION
Allow the developer to customize the delta slice function. 

One use case is skipping formatting for inline code of the subsequently input text with French IME.

