### PR TITLE
feat: select multiple lines with block selection style

### DIFF
--- a/example/lib/pages/desktop_editor.dart
+++ b/example/lib/pages/desktop_editor.dart
@@ -168,6 +168,9 @@ class _DesktopEditorState extends State<DesktopEditor> {
     map.forEach((key, value) {
       value.configuration = value.configuration.copyWith(
         padding: (_) => const EdgeInsets.symmetric(vertical: 8.0),
+        blockSelectionAreaMargin: (_) => const EdgeInsets.symmetric(
+          vertical: 1.0,
+        ),
       );
 
       if (key != PageBlockKeys.type) {

--- a/lib/src/core/document/path.dart
+++ b/lib/src/core/document/path.dart
@@ -133,10 +133,18 @@ extension PathExtensions on Path {
     return true;
   }
 
-  bool inSelection(Selection? selection) {
+  // if isSameDepth is true, the path must be the same depth as the selection
+  bool inSelection(
+    Selection? selection, {
+    bool isSameDepth = false,
+  }) {
     selection = selection?.normalized;
-    return selection != null &&
+    bool result = selection != null &&
         selection.start.path <= this &&
         this <= selection.end.path;
+    if (isSameDepth) {
+      return result && selection.start.path.length == length;
+    }
+    return result;
   }
 }

--- a/lib/src/core/document/path.dart
+++ b/lib/src/core/document/path.dart
@@ -134,6 +134,7 @@ extension PathExtensions on Path {
   }
 
   bool inSelection(Selection? selection) {
+    selection = selection?.normalized;
     return selection != null &&
         selection.start.path <= this &&
         this <= selection.end.path;

--- a/lib/src/editor/block_component/base_component/block_component_configuration.dart
+++ b/lib/src/editor/block_component/base_component/block_component_configuration.dart
@@ -9,6 +9,7 @@ class BlockComponentConfiguration {
     this.placeholderText = _placeholderText,
     this.textStyle = _textStyle,
     this.placeholderTextStyle = _placeholderTextStyle,
+    this.blockSelectionAreaMargin = _blockSelectionAreaPadding,
   });
 
   /// The padding of a block component.
@@ -35,17 +36,23 @@ class BlockComponentConfiguration {
   /// It inherits the style from [textStyle].
   final TextStyle Function(Node node) placeholderTextStyle;
 
+  /// The padding of a block selection area.
+  final EdgeInsets Function(Node node) blockSelectionAreaMargin;
+
   BlockComponentConfiguration copyWith({
     EdgeInsets Function(Node node)? padding,
     TextStyle Function(Node node)? textStyle,
     String Function(Node node)? placeholderText,
     TextStyle Function(Node node)? placeholderTextStyle,
+    EdgeInsets Function(Node node)? blockSelectionAreaMargin,
   }) {
     return BlockComponentConfiguration(
       padding: padding ?? this.padding,
       textStyle: textStyle ?? this.textStyle,
       placeholderText: placeholderText ?? this.placeholderText,
       placeholderTextStyle: placeholderTextStyle ?? this.placeholderTextStyle,
+      blockSelectionAreaMargin:
+          blockSelectionAreaMargin ?? this.blockSelectionAreaMargin,
     );
   }
 }
@@ -89,4 +96,8 @@ TextStyle _placeholderTextStyle(Node node) {
   return const TextStyle(
     color: Colors.grey,
   );
+}
+
+EdgeInsets _blockSelectionAreaPadding(Node node) {
+  return const EdgeInsets.symmetric(vertical: 0.0);
 }

--- a/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
@@ -105,7 +105,7 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
         final editorState = context.read<EditorState>();
         if (editorState.selectionType == SelectionType.block) {
           if (!widget.supportTypes.contains(BlockSelectionType.block) ||
-              !path.inSelection(selection) ||
+              !path.inSelection(selection, isSameDepth: true) ||
               prevBlockRect == null) {
             return sizedBox;
           }
@@ -177,7 +177,7 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
     if (selection != null && path.inSelection(selection)) {
       if (widget.supportTypes.contains(BlockSelectionType.block) &&
           context.read<EditorState>().selectionType == SelectionType.block) {
-        if (!path.inSelection(selection)) {
+        if (!path.inSelection(selection, isSameDepth: true)) {
           if (prevBlockRect != null) {
             setState(() {
               prevBlockRect = null;

--- a/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
@@ -104,7 +104,7 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
 
         if (context.read<EditorState>().selectionType == SelectionType.block) {
           if (!widget.supportTypes.contains(BlockSelectionType.block) ||
-              !path.equals(selection.start.path) ||
+              !path.inSelection(selection) ||
               prevBlockRect == null) {
             return sizedBox;
           }
@@ -170,7 +170,7 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
     if (selection != null && path.inSelection(selection)) {
       if (widget.supportTypes.contains(BlockSelectionType.block) &&
           context.read<EditorState>().selectionType == SelectionType.block) {
-        if (!path.equals(selection.start.path)) {
+        if (!path.inSelection(selection)) {
           if (prevBlockRect != null) {
             setState(() {
               prevBlockRect = null;

--- a/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_area.dart
@@ -102,15 +102,22 @@ class _BlockSelectionAreaState extends State<BlockSelectionArea> {
           return sizedBox;
         }
 
-        if (context.read<EditorState>().selectionType == SelectionType.block) {
+        final editorState = context.read<EditorState>();
+        if (editorState.selectionType == SelectionType.block) {
           if (!widget.supportTypes.contains(BlockSelectionType.block) ||
               !path.inSelection(selection) ||
               prevBlockRect == null) {
             return sizedBox;
           }
+          final builder = editorState.service.rendererService
+              .blockComponentBuilder(widget.node.type);
+          final padding = builder?.configuration.blockSelectionAreaMargin(
+            widget.node,
+          );
           return Positioned.fromRect(
             rect: prevBlockRect!,
             child: Container(
+              margin: padding,
               decoration: BoxDecoration(
                 color: widget.blockColor,
                 borderRadius: BorderRadius.circular(4),

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -230,14 +230,17 @@ class EditorState {
     Selection? selection, {
     SelectionUpdateReason reason = SelectionUpdateReason.transaction,
     Map? extraInfo,
+    SelectionType? customSelectionType,
   }) async {
     final completer = Completer<void>();
 
     if (reason == SelectionUpdateReason.uiEvent) {
-      selectionType = SelectionType.inline;
+      selectionType = customSelectionType ?? SelectionType.inline;
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) => completer.complete(),
       );
+    } else if (customSelectionType != null) {
+      selectionType = customSelectionType;
     }
 
     // broadcast to other users here


### PR DESCRIPTION
Use the API below to select multiple lines with block selection style.


```dart
      final selection = Selection.collapsed(
        Position(path: path),
      );
      editorState.updateSelectionWithReason(
        selection,
        customSelectionType: SelectionType.block,
      );
```

```dart
      value.configuration = value.configuration.copyWith(
        padding: (_) => const EdgeInsets.symmetric(vertical: 8.0),
        blockSelectionAreaMargin: (_) => const EdgeInsets.symmetric(
          vertical: 1.0,
        ),
      );
```

<img width="1111" alt="Screenshot 2024-10-16 at 15 07 51" src="https://github.com/user-attachments/assets/c59dcdb0-fd13-47b8-9026-a0462a99cb23">
