### PR TITLE
fix: links starting with 0 index lose href attribute after formating

### DIFF
--- a/lib/src/core/transform/transaction.dart
+++ b/lib/src/core/transform/transaction.dart
@@ -347,7 +347,7 @@ extension TextTransaction on Transaction {
       return;
     }
     var newAttributes = attributes;
-    if (index != 0 && attributes == null) {
+    if (attributes == null) {
       newAttributes = attributes ?? delta.sliceAttributes(index);
 
       if (newAttributes == null) {

--- a/test/core/transform/transaction_test.dart
+++ b/test/core/transform/transaction_test.dart
@@ -428,5 +428,36 @@ void main() async {
         replaceText3,
       );
     });
+
+    test('test replace texts, attributes', () async {
+      final document = Document(
+        root: pageNode(
+          children: [
+            paragraphNode(
+              delta: Delta()
+                ..insert('Hello', attributes: {'href': 'appflowy.io'}),
+            ),
+          ],
+        ),
+      );
+      final editorState = EditorState(document: document);
+      final selection = Selection(
+        start: Position(path: [0], offset: 0),
+        end: Position(path: [0], offset: 5),
+      );
+      editorState.selection = selection;
+      final transaction = editorState.transaction;
+      final node = editorState.getNodeAtPath([0])!;
+      transaction.replaceText(node, 0, 5, 'AppFlowy');
+      await editorState.apply(transaction);
+      expect(editorState.document.root.children.length, 1);
+      final delta = editorState.getNodeAtPath([0])?.delta;
+      expect(delta?.toJson(), [
+        {
+          'insert': 'AppFlowy',
+          'attributes': {'href': 'appflowy.io'},
+        }
+      ]);
+    });
   });
 }


### PR DESCRIPTION
Example:

Formatting the link [AppFlowy](appflowy.io) to [AppFlowy.IO](appflowy.io) loses the href attribute if AppFlowy is at the beginning of the text.


