### PR TITLE
fix: deleting the last table being the last node of the document, places an empty node to avoid the editor to crash

### DIFF
--- a/lib/src/editor/block_component/table_block_component/table_action.dart
+++ b/lib/src/editor/block_component/table_block_component/table_action.dart
@@ -214,6 +214,10 @@ void _deleteCol(Node tableNode, int col, EditorState editorState) {
       colsLen = tableNode.attributes[TableBlockKeys.colsLen];
 
   if (colsLen == 1) {
+    if (editorState.document.root.children.length == 1) {
+      final emptyParagraph = paragraphNode();
+      transaction.insertNode(tableNode.path, emptyParagraph);
+    }
     transaction.deleteNode(tableNode);
     tableNode.dispose();
   } else {
@@ -238,6 +242,10 @@ void _deleteRow(Node tableNode, int row, EditorState editorState) {
       colsLen = tableNode.attributes[TableBlockKeys.colsLen];
 
   if (rowsLen == 1) {
+    if (editorState.document.root.children.length == 1) {
+      final emptyParagraph = paragraphNode();
+      transaction.insertNode(tableNode.path, emptyParagraph);
+    }
     transaction.deleteNode(tableNode);
     tableNode.dispose();
   } else {


### PR DESCRIPTION
Dear all,

First ever pull request, probably not great, but it solves https://github.com/AppFlowy-IO/appflowy-editor/issues/948 , by preventing an empty state Document that bricks the editor after deleting a table, when such table was the last thing on the Document, leaving the editor in an broken state.

In my app, since users bricked their save games with this bug, I am detecting (after loading from file), whether there is any Document on empty state, and if so, I overwrite them with a blank Document. This is to recover into a healthy state, with this patch preventing it from happening again (from this, or any other cause that leads to the same state).

Any suggestions welcome, it just gets the work done for now.

Best regards
Saif