### PR TITLE
fix: highlight search match not scrolling document to reveal said match

### DIFF
--- a/lib/src/editor/editor_component/service/scroll/editor_scroll_controller.dart
+++ b/lib/src/editor/editor_component/service/scroll/editor_scroll_controller.dart
@@ -190,10 +190,14 @@ class EditorScrollController {
       );
     }
 
-    itemScrollController.jumpTo(
-      index: max(0, offset.toInt()),
-      alignment: 0.5,
-    );
+    final index = offset.toInt();
+    final (start, end) = visibleRangeNotifier.value;
+    if (index < start || index > end) {
+      itemScrollController.jumpTo(
+        index: max(0, index),
+        alignment: 0.5,
+      );
+    }
   }
 
   void jumpToTop() {

--- a/lib/src/editor/find_replace_menu/search_service_v3.dart
+++ b/lib/src/editor/find_replace_menu/search_service_v3.dart
@@ -71,7 +71,7 @@ class SearchServiceV3 {
 
   // Public entry method for _findAndHighlight, do necessary checks
   // and clear previous highlights before calling the private method
-  String findAndHighlight(String target, {bool unHighlight = false}) {
+  String findAndHighlight(String target) {
     Pattern pattern;
 
     try {
@@ -92,7 +92,7 @@ class SearchServiceV3 {
 
     if (target.isEmpty) return 'Empty';
 
-    _findAndHighlight(pattern, unHighlight: unHighlight);
+    _findAndHighlight(pattern);
 
     return '';
   }
@@ -109,13 +109,16 @@ class SearchServiceV3 {
       nodes: editorState.document.root.children,
     );
 
-    if (matchWrappers.value.isNotEmpty) {
+    if (matchWrappers.value.isEmpty || unHighlight) {
+      editorState.updateSelectionWithReason(
+        null,
+        reason: SelectionUpdateReason.searchHighlight,
+      );
+    } else {
       selectedIndex = selectedIndex;
       _highlightCurrentMatch(
         pattern,
       );
-    } else {
-      editorState.updateSelectionWithReason(null);
     }
   }
 
@@ -148,8 +151,11 @@ class SearchServiceV3 {
   ) {
     final selection = matchWrappers.value[selectedIndex].selection;
 
+    editorState.scrollService?.jumpTo(selection.end.path.first);
+
     editorState.updateSelectionWithReason(
       selection,
+      reason: SelectionUpdateReason.searchHighlight,
       extraInfo: {
         selectionExtraInfoDisableToolbar: true,
       },

--- a/lib/src/editor/find_replace_menu/search_service_v3.dart
+++ b/lib/src/editor/find_replace_menu/search_service_v3.dart
@@ -149,9 +149,9 @@ class SearchServiceV3 {
   void _highlightCurrentMatch(
     Pattern pattern,
   ) {
-    final selection = matchWrappers.value[selectedIndex].selection;
+    final MatchWrapper(:selection, :path) = matchWrappers.value[selectedIndex];
 
-    editorState.scrollService?.jumpTo(selection.end.path.first);
+    editorState.scrollService?.jumpTo(path.first);
 
     editorState.updateSelectionWithReason(
       selection,


### PR DESCRIPTION
I think some logic got lost during the transition from v2 to v3

no tests yet, need review

regression on appflowy main repo: entering text into the find text field causes title to get focus if it's empty