### PR TITLE
fix: cancel block selection when tapping the editor on mobile

### DIFF
--- a/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
@@ -321,6 +321,7 @@ class _MobileSelectionServiceWidgetState
     editorState.updateSelectionWithReason(
       selection,
       reason: SelectionUpdateReason.uiEvent,
+      customSelectionType: SelectionType.inline,
       extraInfo: {
         selectionDragModeKey: dragMode,
         selectionExtraInfoDoNotAttachTextService:
@@ -525,6 +526,7 @@ class _MobileSelectionServiceWidgetState
     editorState.updateSelectionWithReason(
       selection,
       reason: SelectionUpdateReason.uiEvent,
+      customSelectionType: SelectionType.inline,
       extraInfo: null,
     );
   }
@@ -598,6 +600,7 @@ class _MobileSelectionServiceWidgetState
     editorState.updateSelectionWithReason(
       editorState.selection,
       reason: SelectionUpdateReason.uiEvent,
+      customSelectionType: SelectionType.inline,
       extraInfo: {
         selectionExtraInfoDoNotAttachTextService: false,
       },
@@ -618,6 +621,7 @@ class _MobileSelectionServiceWidgetState
     editorState.updateSelectionWithReason(
       Selection.collapsed(position),
       reason: SelectionUpdateReason.uiEvent,
+      customSelectionType: SelectionType.inline,
       extraInfo: null,
     );
   }

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -129,7 +129,15 @@ class EditorState {
     selectionNotifier.value = value;
   }
 
-  SelectionType? selectionType;
+  SelectionType? _selectionType;
+  set selectionType(SelectionType? value) {
+    if (value == _selectionType) {
+      return;
+    }
+    _selectionType = value;
+  }
+
+  SelectionType? get selectionType => _selectionType;
 
   SelectionUpdateReason _selectionUpdateReason = SelectionUpdateReason.uiEvent;
   SelectionUpdateReason get selectionUpdateReason => _selectionUpdateReason;
@@ -243,12 +251,12 @@ class EditorState {
     final completer = Completer<void>();
 
     if (reason == SelectionUpdateReason.uiEvent) {
-      selectionType = customSelectionType ?? SelectionType.inline;
+      _selectionType = customSelectionType ?? SelectionType.inline;
       WidgetsBinding.instance.addPostFrameCallback(
         (timeStamp) => completer.complete(),
       );
     } else if (customSelectionType != null) {
-      selectionType = customSelectionType;
+      _selectionType = customSelectionType;
     }
 
     // broadcast to other users here


### PR DESCRIPTION
Tapping on mobile to select text should cancel the block selection.