### PR TITLE
fix: cut collapsed table cell won't crash the editor

### DIFF
--- a/lib/src/service/internal_key_event_handlers/copy_paste_handler.dart
+++ b/lib/src/service/internal_key_event_handlers/copy_paste_handler.dart
@@ -342,6 +342,17 @@ void _pasteRichClipboard(EditorState editorState, AppFlowyClipboardData data) {
   }
 }
 
+bool _isNodeInsideTable(Node node) {
+  Node? current = node;
+  while (current != null) {
+    if (current.type == 'table') {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
 /// 2. delete selected content
 void handleCut(EditorState editorState) {
   handleCopy(editorState);
@@ -357,7 +368,7 @@ Future<void> deleteSelectedContent(EditorState editorState) async {
   if (selection.isCollapsed) {
     // if the selection is collapsed, delete the current node
     final node = editorState.getNodeAtPath(selection.end.path);
-    if (node == null) {
+    if (node == null || _isNodeInsideTable(node)) {
       return;
     }
     transaction.deleteNode(node);


### PR DESCRIPTION
Currently, calling a cut action on a table cell will completely crash the table editor. it leaves the document in a state where a table has no cells, rather then deleting it completely.

Not sure if this approach is the best, but gets the job done. Any ideas welcome.

Warning: This won't retroactively fix editor states where the Document has already been broken prior to this patch.