### PR TITLE
fix: ignore backspace on empty table cells to avoid editor crash

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -9,7 +9,8 @@ Future<void> onDelete(
   AppFlowyEditorLog.input.debug('onDelete: $deletion');
 
   final selection = editorState.selection;
-  if (selection == null || (selection.end.offset == 0 && selection.end.path.length > 1)) {
+  if (selection == null ||
+      (selection.end.offset == 0 && selection.end.path.length > 1)) {
     return;
   }
 

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -9,7 +9,7 @@ Future<void> onDelete(
   AppFlowyEditorLog.input.debug('onDelete: $deletion');
 
   final selection = editorState.selection;
-  if (selection == null || (selection.end.offset == 0 && selection.end.path.length == 3)) {
+  if (selection == null || (selection.end.offset == 0 && selection.end.path.length > 1)) {
     return;
   }
 

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -9,7 +9,7 @@ Future<void> onDelete(
   AppFlowyEditorLog.input.debug('onDelete: $deletion');
 
   final selection = editorState.selection;
-  if (selection == null) {
+  if (selection == null || (selection.end.offset == 0 && selection.end.path.length == 3)) {
     return;
   }
 


### PR DESCRIPTION
Pressing "delete" (aka Backspace) on Android crashes the editor when called inside the empty cell of a table. It leaves the table in an invalid state, crashing the Editor.

This fix or workaround ignores backspaces called inside table cells at the first offset position of the cursor.

Any suggestions welcome!