### PR TITLE
fix: Searching command with / using in18

### DIFF
--- a/lib/src/editor/selection_menu/selection_menu_widget.dart
+++ b/lib/src/editor/selection_menu/selection_menu_widget.dart
@@ -50,6 +50,7 @@ class SelectionMenuItem {
   ///
   /// The keywords are used to quickly retrieve items.
   final List<String> keywords;
+  List<String> get allKeywords => keywords + [name.toLowerCase()];
   late final SelectionMenuItemHandler handler;
 
   VoidCallback? onSelected;
@@ -270,7 +271,7 @@ class _SelectionMenuWidgetState extends State<SelectionMenuWidget> {
     var maxKeywordLength = 0;
     final items = widget.items
         .where(
-          (item) => item.keywords.any((keyword) {
+          (item) => item.allKeywords.any((keyword) {
             final value = keyword.contains(newKeyword.toLowerCase());
             if (value) {
               maxKeywordLength = max(maxKeywordLength, keyword.length);


### PR DESCRIPTION
closes : https://github.com/AppFlowy-IO/AppFlowy/issues/6265

I have added the name in keywords list where the in18 keys are added so whenever any one searche in their native language and the key is availaible then it will consider the key while searching for a section.


https://github.com/user-attachments/assets/20a65eaf-5d69-4d04-999a-899ce39bcdef

