### PR TITLE
fix: app crash when deleting an emoji

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -56,7 +56,7 @@ dependency_overrides:
     git:
       url: https://github.com/AppFlowy-IO/AppFlowy-plugins.git
       path: "packages/appflowy_editor_plugins"
-      ref: "2d3d4fb"
+      ref: "3f82111"
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -16,25 +16,14 @@ Future<void> onDelete(
   // IME
   if (selection.isSingle) {
     final node = editorState.getNodeAtPath(selection.start.path);
-    if (node?.delta != null &&
+    final delta = node?.delta;
+    if (delta != null &&
         (deletion.composing.isValid || !deletion.deletedRange.isCollapsed)) {
       final node = editorState.getNodesInSelection(selection).first;
-      final start = deletion.deletedRange.start;
+      final start = delta.prevRunePosition(deletion.deletedRange.end);
       final length = deletion.deletedRange.end - start;
       final transaction = editorState.transaction;
-      final afterSelection = Selection(
-        start: Position(
-          path: node.path,
-          offset: deletion.selection.baseOffset,
-        ),
-        end: Position(
-          path: node.path,
-          offset: deletion.selection.extentOffset,
-        ),
-      );
-      transaction
-        ..deleteText(node, start, length)
-        ..afterSelection = afterSelection;
+      transaction..deleteText(node, start, length);
       await editorState.apply(transaction);
       return;
     }

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -17,13 +17,13 @@ Future<void> onDelete(
   if (selection.isSingle) {
     final node = editorState.getNodeAtPath(selection.start.path);
     final delta = node?.delta;
-    if (delta != null &&
+    if (node != null &&
+        delta != null &&
         (deletion.composing.isValid || !deletion.deletedRange.isCollapsed)) {
-      final node = editorState.getNodesInSelection(selection).first;
       final start = delta.prevRunePosition(deletion.deletedRange.end);
       final length = deletion.deletedRange.end - start;
       final transaction = editorState.transaction;
-      transaction..deleteText(node, start, length);
+      transaction.deleteText(node, start, length);
       await editorState.apply(transaction);
       return;
     }

--- a/test/editor/editor_component/ime/delta_input_on_delete_impl_test.dart
+++ b/test/editor/editor_component/ime/delta_input_on_delete_impl_test.dart
@@ -26,5 +26,30 @@ void main() {
 
       expect(document.first!.delta!.toPlainText(), 'Flowy!');
     });
+
+    test('delete an emoji', () async {
+      const text = '👍👍👍';
+      final document = Document.blank().addParagraph(initialText: text);
+
+      final editorState = EditorState(document: document);
+      editorState.selection = Selection.collapsed(
+        Position(
+          path: [0],
+          offset: text.length,
+        ),
+      );
+
+      await onDelete(
+        const TextEditingDeltaDeletion(
+          oldText: text,
+          deletedRange: TextRange(start: 5, end: 6),
+          selection: TextSelection(baseOffset: 5, extentOffset: 5),
+          composing: TextRange.empty,
+        ),
+        editorState,
+      );
+
+      expect(document.first!.delta!.toPlainText(), '👍👍');
+    });
   });
 }


### PR DESCRIPTION
While opening the emoji menu, the IME will be triggered. Deleting an emoji may cause a crash because the text input returns an incorrect length for the deleted emoji.