### PR TITLE
fix: hide the floating toolbar if no content is visible

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -56,7 +56,7 @@ dependency_overrides:
     git:
       url: https://github.com/AppFlowy-IO/AppFlowy-plugins.git
       path: "packages/appflowy_editor_plugins"
-      ref: "2d3d4fb"
+      ref: "3f82111"
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_delete_impl.dart
@@ -9,8 +9,7 @@ Future<void> onDelete(
   AppFlowyEditorLog.input.debug('onDelete: $deletion');
 
   final selection = editorState.selection;
-  if (selection == null ||
-      (selection.end.offset == 0 && selection.end.path.length > 1)) {
+  if (selection == null) {
     return;
   }
 

--- a/lib/src/editor/toolbar/desktop/floating_toolbar.dart
+++ b/lib/src/editor/toolbar/desktop/floating_toolbar.dart
@@ -153,13 +153,26 @@ class _FloatingToolbarState extends State<FloatingToolbar>
   }
 
   void _showToolbar() {
-    if (editorState.selection?.isCollapsed ?? true) {
+    final selection = editorState.selection;
+    if (selection == null || selection.isCollapsed) {
       return;
     }
+
     if (editorState.selectionExtraInfo?[selectionExtraInfoDisableToolbar] ==
         true) {
       return;
     }
+
+    // check the content is visible
+    final nodes = editorState.getSelectedNodes();
+    if (nodes.isEmpty ||
+        nodes.every((node) {
+          final delta = node.delta;
+          return delta == null || delta.isEmpty;
+        })) {
+      return;
+    }
+
     final rects = editorState.selectionRects();
     if (rects.isEmpty) {
       return;

--- a/test/new/toolbar/desktop/floating_toolbar_test.dart
+++ b/test/new/toolbar/desktop/floating_toolbar_test.dart
@@ -102,5 +102,21 @@ void main() async {
 
       await editor.dispose();
     });
+
+    testWidgets('select invisible content should not show the toolbar',
+        (tester) async {
+      final editor = tester.editor..addParagraphs(3, initialText: '');
+      await editor.startTesting(withFloatingToolbar: true);
+
+      final selection = Selection(
+        start: Position(path: [0], offset: 0),
+        end: Position(path: [2], offset: 0),
+      );
+      await editor.updateSelection(selection);
+
+      expect(find.byType(FloatingToolbarWidget), findsNothing);
+
+      await editor.dispose();
+    });
   });
 }


### PR DESCRIPTION
Hide the floating toolbar if no content is visible.