### PR TITLE
fix: out of text range while composing error

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -283,7 +283,14 @@ extension on TextEditingValue {
   TextEditingValue format() {
     final text = _whitespace + this.text;
     final selection = this.selection >> _len;
-    final composing = this.composing >> _len;
+
+    TextRange composing = this.composing >> _len;
+    final textLength = text.length;
+
+    // check invalid composing
+    if (composing.start > textLength || composing.end > textLength) {
+      composing = TextRange.empty;
+    }
 
     return TextEditingValue(
       text: text,


### PR DESCRIPTION
Problem:

https://github.com/user-attachments/assets/73f25a31-b82a-495b-9578-d8f638bd3ae7

Re-positioning the cursor in the middle of sentence while composing occurs following error. 

<img width="1009" alt="스크린샷 2024-12-02 오후 11 00 51" src="https://github.com/user-attachments/assets/f1205e13-466d-4528-a636-8702d100b25f">

so I add logic for checking validity of cursor position.