### PR TITLE
feat: support customize supported node types for slash menu

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/character/slash_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/character/slash_command.dart
@@ -5,6 +5,15 @@ import 'package:appflowy_editor/src/editor/util/platform_extension.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+const Set<String> _defaultSupportSlashMenuNodeTypes = {
+  ParagraphBlockKeys.type,
+  HeadingBlockKeys.type,
+  TodoListBlockKeys.type,
+  BulletedListBlockKeys.type,
+  NumberedListBlockKeys.type,
+  QuoteBlockKeys.type,
+};
+
 /// Show the slash menu
 ///
 /// - support
@@ -26,6 +35,7 @@ CharacterShortcutEvent customSlashCommand(
   bool deleteKeywordsByDefault = false,
   bool singleColumn = true,
   SelectionMenuStyle style = SelectionMenuStyle.light,
+  Set<String> supportSlashMenuNodeTypes = _defaultSupportSlashMenuNodeTypes,
 }) {
   return CharacterShortcutEvent(
     key: 'show the slash menu',
@@ -37,18 +47,10 @@ CharacterShortcutEvent customSlashCommand(
       deleteKeywordsByDefault: deleteKeywordsByDefault,
       singleColumn: singleColumn,
       style: style,
+      supportSlashMenuNodeTypes: supportSlashMenuNodeTypes,
     ),
   );
 }
-
-final Set<String> supportSlashMenuNodeWhiteList = {
-  ParagraphBlockKeys.type,
-  HeadingBlockKeys.type,
-  TodoListBlockKeys.type,
-  BulletedListBlockKeys.type,
-  NumberedListBlockKeys.type,
-  QuoteBlockKeys.type,
-};
 
 SelectionMenuService? _selectionMenuService;
 Future<bool> _showSlashMenu(
@@ -58,6 +60,7 @@ Future<bool> _showSlashMenu(
   bool singleColumn = true,
   bool deleteKeywordsByDefault = false,
   SelectionMenuStyle style = SelectionMenuStyle.light,
+  Set<String> supportSlashMenuNodeTypes = _defaultSupportSlashMenuNodeTypes,
 }) async {
   if (PlatformExtension.isMobile) {
     return false;
@@ -82,7 +85,8 @@ Future<bool> _showSlashMenu(
   final node = editorState.getNodeAtPath(selection.start.path);
 
   // only enable in white-list nodes
-  if (node == null || !_isSupportSlashMenuNode(node)) {
+  if (node == null ||
+      !_isSupportSlashMenuNode(node, supportSlashMenuNodeTypes)) {
     return false;
   }
 
@@ -121,10 +125,22 @@ Future<bool> _showSlashMenu(
   return true;
 }
 
-bool _isSupportSlashMenuNode(Node node) {
-  var result = supportSlashMenuNodeWhiteList.contains(node.type);
-  if (node.level > 1 && node.parent != null) {
-    return result && _isSupportSlashMenuNode(node.parent!);
+bool _isSupportSlashMenuNode(
+  Node node,
+  Set<String> supportSlashMenuNodeWhiteList,
+) {
+  // Check if current node type is supported
+  if (!supportSlashMenuNodeWhiteList.contains(node.type)) {
+    return false;
   }
-  return result;
+
+  // If node has a parent and level > 1, recursively check parent nodes
+  if (node.level > 1 && node.parent != null) {
+    return _isSupportSlashMenuNode(
+      node.parent!,
+      supportSlashMenuNodeWhiteList,
+    );
+  }
+
+  return true;
 }


### PR DESCRIPTION
Use `supportSlashMenuNodeTypes` to customize which nodes support the slash menu.

```
CharacterShortcutEvent customSlashCommand(
  List<SelectionMenuItem> items, {
  // ...
  Set<String> supportSlashMenuNodeTypes = _defaultSupportSlashMenuNodeTypes,
})
```



