### PR TITLE
fix: closing a ')' braket to create a link will erase a text following it to the end of a paragraph

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/character/markdown_link_shortcut_event.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/character/markdown_link_shortcut_event.dart
@@ -30,7 +30,8 @@ bool handleFormatMarkdownLinkToLink({
     return false;
   }
 
-  final plainText = '${delta.toPlainText()})';
+  final slicedDelta = delta.slice(0, selection.end.offset);
+  final plainText = '${slicedDelta.toPlainText()})';
 
   // Determine if regex matches the plainText.
   if (!_linkRegex.hasMatch(plainText)) {

--- a/test/new/service/shortcuts/character_shortcut_events/markdown_shortcut_events/format_markdown_link_test.dart
+++ b/test/new/service/shortcuts/character_shortcut_events/markdown_shortcut_events/format_markdown_link_test.dart
@@ -92,5 +92,37 @@ void main() async {
       final after = editorState.getNodeAtPath([0])!;
       expect(after.delta!.toPlainText(), text);
     });
+
+    // Before
+    // Hello [AppFlowy](appflowy.com World
+    // After
+    // Hello [AppFlowy](appflowy.com) World
+    test('format the text in markdown link syntax to appflowy href', () async {
+      const text1 = 'Hello [AppFlowy](appflowy.com';
+      const text2 = ' World';
+      final document = Document.blank().addParagraphs(
+        1,
+        builder: (index) => Delta()..insert(text1 + text2),
+      );
+      final editorState = EditorState(document: document);
+      final selection = Selection.collapsed(
+        Position(path: [0], offset: text1.length),
+      );
+      editorState.selection = selection;
+      final result = await formatMarkdownLinkToLink.execute(editorState);
+      expect(result, true);
+      final after = editorState.getNodeAtPath([0])!;
+      expect(
+        after.delta!.toJson(),
+        [
+          {'insert': 'Hello '},
+          {
+            'insert': 'AppFlowy',
+            'attributes': {'href': 'appflowy.com'},
+          },
+          {'insert': ' World'},
+        ],
+      );
+    });
   });
 }


### PR DESCRIPTION
closes https://github.com/LucasXu0/appflowy-editor/pull/new/fix_6903

Slice the delta from beginning to the selection end.

