### PR TITLE
feat: add `partialSliced` to support partial sliced attributes

### DIFF
--- a/lib/src/core/document/text_delta.dart
+++ b/lib/src/core/document/text_delta.dart
@@ -11,9 +11,14 @@ typedef AppFlowyEditorSliceAttributes = Attributes? Function(
   int index,
 );
 
+/// Default slice attributes function.
+///
+/// For the BIUS attributes, the slice attributes function will slice the attributes from the previous position,
+///   if the index is 0, it will slice the attributes from the next position.
+/// For the link and code attributes, the slice attributes function will only work if the index is in the range of the link or code.
 AppFlowyEditorSliceAttributes? defaultAppFlowyEditorSliceAttributes = (
   delta,
-  index,
+  int index,
 ) {
   if (index < 0) {
     return null;
@@ -41,10 +46,10 @@ AppFlowyEditorSliceAttributes? defaultAppFlowyEditorSliceAttributes = (
   if (prevAttributes == null) {
     return null;
   }
-  // if the prevAttributes doesn't include the code, return it.
-  // Otherwise, check if the nextAttributes includes the code.
+  // if the prevAttributes doesn't include the code/href, return it.
+  // Otherwise, check if the nextAttributes includes the code/href.
   if (!prevAttributes.keys.any(
-    (element) => element == AppFlowyRichTextKeys.code,
+    (element) => AppFlowyRichTextKeys.partialSliced.contains(element),
   )) {
     return prevAttributes;
   }
@@ -52,14 +57,20 @@ AppFlowyEditorSliceAttributes? defaultAppFlowyEditorSliceAttributes = (
   // check if the nextAttributes includes the code.
   final nextAttributes = delta.slice(index, index + 1).firstOrNull?.attributes;
   if (nextAttributes == null) {
-    return prevAttributes..remove(AppFlowyRichTextKeys.code);
+    return prevAttributes
+      ..removeWhere(
+        (key, _) => AppFlowyRichTextKeys.partialSliced.contains(key),
+      );
   }
 
-  // if the nextAttributes doesn't include the code, exclude the code format.
+  // if the nextAttributes doesn't include the code/href, exclude the code/href format.
   if (!nextAttributes.keys.any(
-    (element) => element == AppFlowyRichTextKeys.code,
+    (element) => AppFlowyRichTextKeys.partialSliced.contains(element),
   )) {
-    return prevAttributes..remove(AppFlowyRichTextKeys.code);
+    return prevAttributes
+      ..removeWhere(
+        (key, _) => AppFlowyRichTextKeys.partialSliced.contains(key),
+      );
   }
 
   return prevAttributes;

--- a/lib/src/editor/block_component/rich_text/appflowy_rich_text_keys.dart
+++ b/lib/src/editor/block_component/rich_text/appflowy_rich_text_keys.dart
@@ -13,6 +13,7 @@ class AppFlowyRichTextKeys {
   static String autoComplete = 'auto_complete';
   static String transparent = 'transparent';
 
+  /// The attributes supported sliced.
   static List<String> supportSliced = [
     bold,
     italic,
@@ -21,6 +22,14 @@ class AppFlowyRichTextKeys {
     textColor,
     backgroundColor,
     code,
+  ];
+
+  /// The attributes is partially supported sliced.
+  ///
+  /// For the code and href attributes, the slice attributes function will only work if the index is in the range of the code or href.
+  static List<String> partialSliced = [
+    code,
+    href,
   ];
 
   // The values supported toggled even if the selection is collapsed.


### PR DESCRIPTION
Add the `partialSliced` value to indicate whether the key should be sliced if the index is out of the attribute's range.

For example, if you only need to slice the attributes when the index is within the attribute's range, add the key to partialSliced.

`**Hello World**` <- If you input here, it should not follow the previous format if the `partialSliced` value contains the `AppFlowyRichTextKeys.bold`