### PR TITLE
fix: shift+enter should wrap the line in list

### DIFF
--- a/lib/src/editor/block_component/base_component/insert_newline_in_type_command.dart
+++ b/lib/src/editor/block_component/base_component/insert_newline_in_type_command.dart
@@ -1,11 +1,18 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 Future<bool> insertNewLineInType(
   EditorState editorState,
   String type, {
   Attributes attributes = const {},
 }) async {
+  // check if the shift key is pressed, if so, we should return false to let the system handle it.
+  final isShiftPressed = HardwareKeyboard.instance.isShiftPressed;
+  if (isShiftPressed) {
+    return false;
+  }
+
   final selection = editorState.selection;
   if (selection == null || !selection.isCollapsed) {
     return false;

--- a/lib/src/editor/editor_component/service/ime/character_shortcut_event_helper.dart
+++ b/lib/src/editor/editor_component/service/ime/character_shortcut_event_helper.dart
@@ -12,6 +12,9 @@ Future<bool> executeCharacterShortcutEvent(
   for (final shortcutEvent in characterShortcutEvents) {
     if (shortcutEvent.character == character &&
         await shortcutEvent.handler(editorState)) {
+      AppFlowyEditorLog.input.debug(
+        'keyboard service - handled by character shortcut event: $shortcutEvent',
+      );
       return true;
     }
   }

--- a/lib/src/editor/editor_component/service/shortcuts/command/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/backspace_command.dart
@@ -24,10 +24,14 @@ CommandShortcutEventHandler _backspaceCommandHandler = (editorState) {
     return KeyEventResult.ignored;
   }
 
+  final reason = editorState.selectionUpdateReason;
+
   if (selectionType == SelectionType.block) {
     return _backspaceInBlockSelection(editorState);
   } else if (selection.isCollapsed) {
     return _backspaceInCollapsedSelection(editorState);
+  } else if (reason == SelectionUpdateReason.selectAll) {
+    return _backspaceInSelectAll(editorState);
   } else {
     return _backspaceInNotCollapsedSelection(editorState);
   }
@@ -160,6 +164,20 @@ CommandShortcutEventHandler _backspaceInBlockSelection = (editorState) {
   editorState
       .apply(transaction)
       .then((value) => editorState.selectionType = null);
+
+  return KeyEventResult.handled;
+};
+
+CommandShortcutEventHandler _backspaceInSelectAll = (editorState) {
+  final selection = editorState.selection;
+  if (selection == null) {
+    return KeyEventResult.ignored;
+  }
+
+  final transaction = editorState.transaction;
+  final nodes = editorState.getNodesInSelection(selection);
+  transaction.deleteNodes(nodes);
+  editorState.apply(transaction);
 
   return KeyEventResult.handled;
 };

--- a/lib/src/editor/editor_component/service/shortcuts/command/select_all_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/select_all_command.dart
@@ -20,12 +20,11 @@ CommandShortcutEventHandler _selectAllCommandHandler = (editorState) {
       editorState.selection == null) {
     return KeyEventResult.ignored;
   }
-  final firstSelectable = editorState.getFirstSelectable();
   final lastSelectable = editorState.getLastSelectable();
-  if (firstSelectable == null || lastSelectable == null) {
+  if (lastSelectable == null) {
     return KeyEventResult.handled;
   }
-  final start = firstSelectable.$2.start(firstSelectable.$1);
+  final start = Position(path: [0]);
   final end = lastSelectable.$2.end(lastSelectable.$1);
   editorState.updateSelectionWithReason(
     Selection(start: start, end: end),

--- a/test/editor/block_component/base_component/insert_newline_in_type_command_test.dart
+++ b/test/editor/block_component/base_component/insert_newline_in_type_command_test.dart
@@ -3,6 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('InsertNewlineInTypeCommand tests', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
     test('bulleted list', () async {
       final bulletedNode = bulletedListNode(
         text: 'bulleted list 1',


### PR DESCRIPTION
Ignore the shift+enter in insertNewLine shortcut and let the system handle it.