### PR TITLE
fix: assertion error in auto_expand_editor example

### DIFF
--- a/example/lib/pages/auto_expand_editor.dart
+++ b/example/lib/pages/auto_expand_editor.dart
@@ -32,20 +32,18 @@ class AutoExpandEditor extends StatelessWidget {
                 maxHeight: 360,
                 maxWidth: 400,
               ),
-              child: SingleChildScrollView(
-                child: IntrinsicHeight(
-                  child: AppFlowyEditor(
+              child: IntrinsicHeight(
+                child: AppFlowyEditor(
+                  editorState: editorState,
+                  shrinkWrap: true,
+                  autoScrollEdgeOffset: 24,
+                  editorStyle: const EditorStyle.desktop(
+                    padding: EdgeInsets.symmetric(horizontal: 8),
+                  ),
+                  blockComponentBuilders: _buildBlockComponentBuilders(),
+                  editorScrollController: EditorScrollController(
                     editorState: editorState,
-                    disableAutoScroll: true,
                     shrinkWrap: true,
-                    editorStyle: const EditorStyle.desktop(
-                      padding: EdgeInsets.symmetric(horizontal: 8),
-                    ),
-                    blockComponentBuilders: _buildBlockComponentBuilders(),
-                    editorScrollController: EditorScrollController(
-                      editorState: editorState,
-                      shrinkWrap: true,
-                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
fixes #974 and makes auto scrolling work when reaching the maxHeight of the container