### PR TITLE
fix: enter after emoji will create a softbreak on mobile

### DIFF
--- a/lib/src/editor/editor_component/service/ime/character_shortcut_event_helper.dart
+++ b/lib/src/editor/editor_component/service/ime/character_shortcut_event_helper.dart
@@ -5,6 +5,11 @@ Future<bool> executeCharacterShortcutEvent(
   String? character,
   List<CharacterShortcutEvent> characterShortcutEvents,
 ) async {
+  // if the character is a space + enter, we should execute the enter event
+  if (character == ' \n') {
+    character = '\n';
+  }
+
   if (character?.length != 1) {
     return false;
   }

--- a/test/editor/editor_component/ime/character_shortcut_on_insert_impl_test.dart
+++ b/test/editor/editor_component/ime/character_shortcut_on_insert_impl_test.dart
@@ -1,0 +1,31 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/editor_component/service/ime/delta_input_impl.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('character shortcut on insert', () {
+    WidgetsFlutterBinding.ensureInitialized();
+
+    test('call', () async {
+      final editorState = EditorState.blank();
+      editorState.selection = Selection.collapsed(
+        Position(path: [0]),
+      );
+      await onInsert(
+        const TextEditingDeltaInsertion(
+          textInserted: ' \n',
+          composing: TextRange.empty,
+          oldText: '',
+          selection: TextSelection.collapsed(offset: 0),
+          insertionOffset: 0,
+        ),
+        editorState,
+        [insertNewLine],
+      );
+      final nodes = editorState.document.root.children;
+      expect(nodes.length, 2);
+    });
+  });
+}


### PR DESCRIPTION
The keyboard inserts ' \n' instead of '\n' when pressing Enter after an emoji. We should ignore the space in this case.