### PR TITLE
fix: unable to parse image if the image is inside the paragraph

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -56,7 +56,7 @@ dependency_overrides:
     git:
       url: https://github.com/AppFlowy-IO/AppFlowy-plugins.git
       path: "packages/appflowy_editor_plugins"
-      ref: "3f82111"
+      ref: "ca82890"
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
@@ -59,7 +59,7 @@ Future<void> onNonTextUpdate(
     // for the another keyboards (e.g. system keyboard), they will trigger the
     // `onFloatingCursor` event instead.
     AppFlowyEditorLog.input.debug('[Android] onNonTextUpdate: $nonTextUpdate');
-    if (selection != null && selection != editorState.selection) {
+    if (selection != null) {
       editorState.updateSelectionWithReason(
         Selection.collapsed(
           Position(

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -17,7 +17,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
   @override
   Document convert(String input) {
     final List<md.Node> mdNodes = md.Document(
-      extensionSet: md.ExtensionSet.gitHubWeb,
+      extensionSet: md.ExtensionSet.gitHubFlavored,
       inlineSyntaxes: [
         ...inlineSyntaxes,
         UnderlineInlineSyntax(),

--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -16,6 +16,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
 
   @override
   Document convert(String input) {
+    final formattedMarkdown = _formatMarkdown(input);
     final List<md.Node> mdNodes = md.Document(
       extensionSet: md.ExtensionSet.gitHubFlavored,
       inlineSyntaxes: [
@@ -23,7 +24,7 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
         UnderlineInlineSyntax(),
       ],
       encodeHtml: false,
-    ).parse(input);
+    ).parse(formattedMarkdown);
 
     final document = Document.blank();
     final nodes = mdNodes
@@ -60,5 +61,28 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
     }
 
     return nodes;
+  }
+
+  String _formatMarkdown(String markdown) {
+    // Rule 1: single '\n' between text and image, add double '\n'
+    String result = markdown.replaceAllMapped(
+      RegExp(r'([^\n])\n!\[([^\]]*)\]\(([^)]+)\)', multiLine: true),
+      (match) {
+        final text = match[1] ?? '';
+        final altText = match[2] ?? '';
+        final url = match[3] ?? '';
+        return '$text\n\n![$altText]($url)';
+      },
+    );
+
+    // Rule 2: without '\n' between text and image, add double '\n'
+    result = result.replaceAllMapped(
+      RegExp(r'([^\n])!\[([^\]]*)\]\(([^)]+)\)'),
+      (match) => '${match[1]}\n\n![${match[2]}](${match[3]})',
+    );
+
+    // Add another rules here.
+
+    return result;
   }
 }

--- a/lib/src/plugins/markdown/decoder/parser/markdown_image_parser.dart
+++ b/lib/src/plugins/markdown/decoder/parser/markdown_image_parser.dart
@@ -15,6 +15,12 @@ class MarkdownImageParserV2 extends CustomMarkdownParser {
       return [];
     }
 
+    if (element.attributes['src'] != null) {
+      return [
+        imageNode(url: element.attributes['src']!),
+      ];
+    }
+
     if (element.children?.length != 1 ||
         element.children?.first is! md.Element) {
       return [];

--- a/lib/src/plugins/markdown/decoder/parser/markdown_paragraph_parser.dart
+++ b/lib/src/plugins/markdown/decoder/parser/markdown_paragraph_parser.dart
@@ -39,25 +39,13 @@ class MarkdownParagraphParserV2 extends CustomMarkdownParser {
     final splitContent = _splitByBrTag(ec);
 
     // Transform each split content into a paragraph node
-    final result = <Node>[];
-    for (final content in splitContent) {
-      for (final node in content) {
-        if (node is md.Element && node.tag == 'img') {
-          final image = const MarkdownImageParserV2()
-              .transform(node, parsers)
-              .firstOrNull;
-          if (image != null) {
-            result.add(image);
-            continue;
-          }
-        }
-        final deltaDecoder = DeltaMarkdownDecoder();
-        final delta = deltaDecoder.convertNodes([node]);
-        result.add(paragraphNode(delta: delta));
-      }
-    }
+    return splitContent.map((content) {
+      final deltaDecoder = DeltaMarkdownDecoder();
+      final delta = deltaDecoder.convertNodes(content);
+      return paragraphNode(delta: delta);
+    }).toList();
 
-    return result;
+    // return result;
   }
 }
 

--- a/lib/src/plugins/markdown/decoder/parser/markdown_paragraph_parser.dart
+++ b/lib/src/plugins/markdown/decoder/parser/markdown_paragraph_parser.dart
@@ -39,11 +39,25 @@ class MarkdownParagraphParserV2 extends CustomMarkdownParser {
     final splitContent = _splitByBrTag(ec);
 
     // Transform each split content into a paragraph node
-    return splitContent.map((content) {
-      final deltaDecoder = DeltaMarkdownDecoder();
-      final delta = deltaDecoder.convertNodes(content);
-      return paragraphNode(delta: delta);
-    }).toList();
+    final result = <Node>[];
+    for (final content in splitContent) {
+      for (final node in content) {
+        if (node is md.Element && node.tag == 'img') {
+          final image = const MarkdownImageParserV2()
+              .transform(node, parsers)
+              .firstOrNull;
+          if (image != null) {
+            result.add(image);
+            continue;
+          }
+        }
+        final deltaDecoder = DeltaMarkdownDecoder();
+        final delta = deltaDecoder.convertNodes([node]);
+        result.add(paragraphNode(delta: delta));
+      }
+    }
+
+    return result;
   }
 }
 

--- a/test/plugins/markdown/document_markdown_test.dart
+++ b/test/plugins/markdown/document_markdown_test.dart
@@ -27,13 +27,34 @@ void main() {
       expect(markdown, markdownDocumentEncoded);
     });
 
-    test('paragraph + image', () {
+    test('paragraph + image with single \n', () {
       const markdown = '''This is the first line
 ![image](https://example.com/image.png)''';
       final document = markdownToDocument(markdown);
       final nodes = document.root.children;
       expect(nodes.length, 2);
-      expect(nodes[0].delta?.toPlainText(), 'This is the first line\n');
+      expect(nodes[0].delta?.toPlainText(), 'This is the first line');
+      expect(nodes[1].attributes['url'], 'https://example.com/image.png');
+    });
+
+    test('paragraph + image with double \n', () {
+      const markdown = '''This is the first line
+
+![image](https://example.com/image.png)''';
+      final document = markdownToDocument(markdown);
+      final nodes = document.root.children;
+      expect(nodes.length, 2);
+      expect(nodes[0].delta?.toPlainText(), 'This is the first line');
+      expect(nodes[1].attributes['url'], 'https://example.com/image.png');
+    });
+
+    test('paragraph + image without \n', () {
+      const markdown =
+          '''This is the first line![image](https://example.com/image.png)''';
+      final document = markdownToDocument(markdown);
+      final nodes = document.root.children;
+      expect(nodes.length, 2);
+      expect(nodes[0].delta?.toPlainText(), 'This is the first line');
       expect(nodes[1].attributes['url'], 'https://example.com/image.png');
     });
   });

--- a/test/plugins/markdown/document_markdown_test.dart
+++ b/test/plugins/markdown/document_markdown_test.dart
@@ -26,6 +26,16 @@ void main() {
 
       expect(markdown, markdownDocumentEncoded);
     });
+
+    test('paragraph + image', () {
+      const markdown = '''This is the first line
+![image](https://example.com/image.png)''';
+      final document = markdownToDocument(markdown);
+      final nodes = document.root.children;
+      expect(nodes.length, 2);
+      expect(nodes[0].delta?.toPlainText(), 'This is the first line\n');
+      expect(nodes[1].attributes['url'], 'https://example.com/image.png');
+    });
   });
 }
 


### PR DESCRIPTION
Parse the image without a line break or single link break after the text.