### PR TITLE
fix: using space bar to move the cursor not working on Android

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_on_non_text_update_impl.dart
@@ -59,7 +59,7 @@ Future<void> onNonTextUpdate(
     // for the another keyboards (e.g. system keyboard), they will trigger the
     // `onFloatingCursor` event instead.
     AppFlowyEditorLog.input.debug('[Android] onNonTextUpdate: $nonTextUpdate');
-    if (selection != null && selection != editorState.selection) {
+    if (selection != null) {
       editorState.updateSelectionWithReason(
         Selection.collapsed(
           Position(


### PR DESCRIPTION
the `selection != editorState.selection` will always be `false`

remove it then the space bar is able to work correctly