### PR TITLE
fix: RTL languages display incorrectly with soft line break(#7153)

### DIFF
--- a/lib/src/editor/block_component/base_component/block_component_configuration.dart
+++ b/lib/src/editor/block_component/base_component/block_component_configuration.dart
@@ -122,5 +122,5 @@ EdgeInsets _blockSelectionAreaPadding(Node node) {
 }
 
 TextAlign _textAlign(Node node) {
-  return TextAlign.left;
+  return TextAlign.start;
 }


### PR DESCRIPTION
To fix [#7153](https://github.com/AppFlowy-IO/AppFlowy/issues/7153)

Before the fix:

https://github.com/user-attachments/assets/987ab270-1758-44d9-813f-41c6b67bd9c8


After the fix:

https://github.com/user-attachments/assets/33b74dc4-db61-4320-b9cc-5fab508376e6

