### PR TITLE
fix: missing paste after permission dialog in iOS

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command/copy_paste_extension.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/copy_paste_extension.dart
@@ -8,9 +8,19 @@ final _listTypes = [
 
 extension EditorCopyPaste on EditorState {
   Future<void> pasteSingleLineNode(Node insertedNode) async {
-    final selection = await deleteSelectionIfNeeded();
-    if (selection == null) {
-      return;
+    AppFlowyEditorLog.editor
+        .debug('EditorCopyPaste: initiate paste single line node');
+    var selection = await deleteSelectionIfNeeded();
+    var attempts = 0;
+    while (selection == null) {
+      await Future.delayed(Duration(milliseconds: 50));
+      selection = await deleteSelectionIfNeeded();
+      attempts++;
+      if (attempts > 10) {
+        AppFlowyEditorLog.editor
+            .debug('EditorCopyPaste: selection is empty, attempted $attempts times');
+        return;
+      }
     }
     final node = getNodeAtPath(selection.start.path);
     final delta = node?.delta;


### PR DESCRIPTION
Fixes issue specified in https://github.com/AppFlowy-IO/AppFlowy/issues/7214#issuecomment-2600791861 :
> When I do copy and paste http url, a system asks whether to "Allow a Paste from Safari". If I click Allow, nothing happens. However, subsequent pastes work.

This is a naive fix intended to demonstrate the issue for discussion, and it requires cleanup/refactor before landing.