### PR TITLE
fix: scrollController disposed twice

### DIFF
--- a/lib/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart
@@ -382,7 +382,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     _animationController?.dispose();
     primary.itemPositionsNotifier.itemPositions.dispose();
     secondary.itemPositionsNotifier.itemPositions.dispose();
-    secondary.scrollController.dispose();
+    if (secondary.scrollController.hasClients) {
+      secondary.scrollController.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
fix the error:

```
 A ScrollController was used after being disposed.
  Once you have called dispose() on a ScrollController, it can no longer be used.

 When the exception was thrown, this was the stack:
  #0      ChangeNotifier.debugAssertNotDisposed.<anonymous closure> (package:flutter/src/foundation/change_notifier.dart:183:9)
  #1      ChangeNotifier.debugAssertNotDisposed (package:flutter/src/foundation/change_notifier.dart:190:6)
  #2      ChangeNotifier.dispose (package:flutter/src/foundation/change_notifier.dart:379:27)
  #3      ScrollController.dispose (package:flutter/src/widgets/scroll_controller.dart:267:11)
  #4      _ScrollablePositionedListState.dispose (package:appflowy_editor/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart:385:32)
...
```