### PR TITLE
feat: add trailing builder in block menu

### DIFF
--- a/lib/src/editor/block_component/base_component/block_component_action_wrapper.dart
+++ b/lib/src/editor/block_component/base_component/block_component_action_wrapper.dart
@@ -7,17 +7,24 @@ typedef BlockComponentActionBuilder = Widget Function(
   BlockComponentActionState state,
 );
 
+typedef BlockComponentActionTrailingBuilder = Widget Function(
+  BuildContext context,
+  BlockComponentActionState state,
+);
+
 class BlockComponentActionWrapper extends StatefulWidget {
   const BlockComponentActionWrapper({
     super.key,
     required this.node,
     required this.child,
     required this.actionBuilder,
+    this.actionTrailingBuilder,
   });
 
   final Node node;
   final Widget child;
   final BlockComponentActionBuilder actionBuilder;
+  final BlockComponentActionTrailingBuilder? actionTrailingBuilder;
 
   @override
   State<BlockComponentActionWrapper> createState() =>
@@ -82,6 +89,11 @@ class _BlockComponentActionWrapperState
               actionBuilder: (context) => widget.actionBuilder(context, this),
             ),
           ),
+          if (widget.actionTrailingBuilder != null)
+            widget.actionTrailingBuilder!(
+              context,
+              this,
+            ),
           Expanded(child: widget.child),
         ],
       ),

--- a/lib/src/editor/block_component/base_component/selection/block_selection_container.dart
+++ b/lib/src/editor/block_component/base_component/selection/block_selection_container.dart
@@ -16,6 +16,7 @@ class BlockSelectionContainer extends StatelessWidget {
       BlockSelectionType.cursor,
       BlockSelectionType.selection,
     ],
+    this.selectionAboveBlock = false,
     required this.child,
   });
 
@@ -42,10 +43,26 @@ class BlockSelectionContainer extends StatelessWidget {
 
   final List<BlockSelectionType> supportTypes;
 
+  // the selection area should above the block component
+  final bool selectionAboveBlock;
+
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    final blockSelectionArea = BlockSelectionArea(
+      node: node,
+      delegate: delegate,
+      listenable: listenable,
+      cursorColor: cursorColor,
+      selectionColor: selectionColor,
+      blockColor: blockColor,
+      supportTypes: supportTypes
+          .where(
+            (element) => element != BlockSelectionType.cursor,
+          )
+          .toList(),
+    );
     return Stack(
       clipBehavior: Clip.none,
       // In RTL mode, if the alignment is topStart,
@@ -66,20 +83,10 @@ class BlockSelectionContainer extends StatelessWidget {
                 .toList(),
           ),
         // block selection or selection area
-        BlockSelectionArea(
-          node: node,
-          delegate: delegate,
-          listenable: listenable,
-          cursorColor: cursorColor,
-          selectionColor: selectionColor,
-          blockColor: blockColor,
-          supportTypes: supportTypes
-              .where(
-                (element) => element != BlockSelectionType.cursor,
-              )
-              .toList(),
-        ),
+        if (!selectionAboveBlock) blockSelectionArea,
         child,
+        // block selection or selection area
+        if (selectionAboveBlock) blockSelectionArea,
         // cursor
         // remote cursor
         if (supportTypes.contains(BlockSelectionType.cursor) &&

--- a/lib/src/editor/block_component/base_component/widget/nested_list_widget.dart
+++ b/lib/src/editor/block_component/base_component/widget/nested_list_widget.dart
@@ -36,7 +36,12 @@ class NestedListWidget extends StatelessWidget {
       NestedListMode.stack => Stack(
           children: [
             child,
-            ...children,
+            Column(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: children,
+            ),
           ],
         ),
       NestedListMode.column => Column(

--- a/lib/src/editor/block_component/base_component/widget/nested_list_widget.dart
+++ b/lib/src/editor/block_component/base_component/widget/nested_list_widget.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
 
+enum NestedListMode {
+  stack,
+  column,
+}
+
 class NestedListWidget extends StatelessWidget {
   const NestedListWidget({
     super.key,
     this.indentPadding = const EdgeInsets.only(left: 28),
+    this.mode = NestedListMode.column,
     required this.child,
     required this.children,
   });
@@ -18,27 +24,38 @@ class NestedListWidget extends StatelessWidget {
   /// the indent padding is applied to the second line.
   final EdgeInsets indentPadding;
 
+  /// The mode of the nested list.
+  final NestedListMode mode;
+
   final Widget child;
   final List<Widget> children;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.max,
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        child,
-        Padding(
-          padding: indentPadding,
-          child: Column(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
-          ),
+    return switch (mode) {
+      NestedListMode.stack => Stack(
+          children: [
+            child,
+            ...children,
+          ],
         ),
-      ],
-    );
+      NestedListMode.column => Column(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            child,
+            Padding(
+              padding: indentPadding,
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: children,
+              ),
+            ),
+          ],
+        ),
+    };
   }
 }

--- a/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
+++ b/lib/src/editor/block_component/bulleted_list_block_component/bulleted_list_block_component.dart
@@ -56,6 +56,10 @@ class BulletedListBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -69,6 +73,7 @@ class BulletedListBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.iconBuilder,
   });
@@ -181,6 +186,7 @@ class _BulletedListBlockComponentWidgetState
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/divider_block_component/divider_block_component.dart
+++ b/lib/src/editor/block_component/divider_block_component/divider_block_component.dart
@@ -48,6 +48,10 @@ class DividerBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -61,6 +65,7 @@ class DividerBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.lineColor = Colors.grey,
     this.height = 10,
@@ -127,6 +132,7 @@ class _DividerBlockComponentWidgetState
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_block_component.dart
@@ -61,6 +61,10 @@ class HeadingBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 }
@@ -71,6 +75,7 @@ class HeadingBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.textStyleBuilder,
   });
@@ -192,6 +197,7 @@ class _HeadingBlockComponentWidgetState
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/image_block_component/image_block_component.dart
+++ b/lib/src/editor/block_component/image_block_component/image_block_component.dart
@@ -77,6 +77,10 @@ class ImageBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
       showMenu: showMenu,
       menuBuilder: menuBuilder,
     );
@@ -93,6 +97,7 @@ class ImageBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.showMenu = false,
     this.menuBuilder,
@@ -175,6 +180,7 @@ class ImageBlockComponentWidgetState extends State<ImageBlockComponentWidget>
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
+++ b/lib/src/editor/block_component/numbered_list_block_component/numbered_list_block_component.dart
@@ -66,6 +66,10 @@ class NumberedListBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -79,6 +83,7 @@ class NumberedListBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.iconBuilder,
   });
@@ -196,6 +201,7 @@ class _NumberedListBlockComponentWidgetState
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/paragraph_block_component/paragraph_block_component.dart
+++ b/lib/src/editor/block_component/paragraph_block_component/paragraph_block_component.dart
@@ -56,6 +56,10 @@ class ParagraphBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -69,6 +73,7 @@ class ParagraphBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.showPlaceholder,
   });
@@ -206,6 +211,7 @@ class _ParagraphBlockComponentWidgetState
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
+++ b/lib/src/editor/block_component/quote_block_component/quote_block_component.dart
@@ -53,6 +53,10 @@ class QuoteBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -66,6 +70,7 @@ class QuoteBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.iconBuilder,
   });
@@ -175,6 +180,7 @@ class _QuoteBlockComponentWidgetState extends State<QuoteBlockComponentWidget>
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/table_block_component/table_block_component.dart
+++ b/lib/src/editor/block_component/table_block_component/table_block_component.dart
@@ -106,6 +106,10 @@ class TableBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -183,6 +187,7 @@ class TableBlockComponentWidget extends BlockComponentStatefulWidget {
     this.menuBuilder,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
   });
 
@@ -246,6 +251,7 @@ class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget>
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/block_component/table_block_component/table_cell_block_component.dart
+++ b/lib/src/editor/block_component/table_block_component/table_cell_block_component.dart
@@ -64,6 +64,10 @@ class TableCellBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 
@@ -82,6 +86,7 @@ class TableCelBlockWidget extends BlockComponentStatefulWidget {
     this.colorBuilder,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
   });
 

--- a/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
+++ b/lib/src/editor/block_component/todo_list_block_component/todo_list_block_component.dart
@@ -76,6 +76,10 @@ class TodoListBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
       toggleChildrenTriggers: toggleChildrenTriggers,
     );
   }
@@ -90,6 +94,7 @@ class TodoListBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.textStyleBuilder,
     this.iconBuilder,
@@ -216,6 +221,7 @@ class _TodoListBlockComponentWidgetState
       child = BlockComponentActionWrapper(
         node: node,
         actionBuilder: widget.actionBuilder!,
+        actionTrailingBuilder: widget.actionTrailingBuilder,
         child: child,
       );
     }

--- a/lib/src/editor/editor_component/entry/page_block_component.dart
+++ b/lib/src/editor/editor_component/entry/page_block_component.dart
@@ -37,6 +37,7 @@ class PageBlockComponent extends BlockComponentStatelessWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
     this.header,
     this.footer,

--- a/lib/src/editor/editor_component/service/renderer/block_component_service.dart
+++ b/lib/src/editor/editor_component/service/renderer/block_component_service.dart
@@ -12,6 +12,11 @@ typedef BlockActionBuilder = Widget Function(
   BlockComponentActionState state,
 );
 
+typedef BlockActionTrailingBuilder = Widget Function(
+  BlockComponentContext blockComponentContext,
+  BlockComponentActionState state,
+);
+
 typedef BlockComponentValidate = bool Function(Node node);
 
 abstract class BlockComponentActionState {
@@ -36,6 +41,9 @@ abstract class BlockComponentBuilder with BlockComponentSelectable {
   bool Function(Node node) showActions = (_) => false;
 
   BlockActionBuilder actionBuilder = (_, __) => const SizedBox.shrink();
+
+  BlockActionTrailingBuilder actionTrailingBuilder =
+      (_, __) => const SizedBox.shrink();
 
   BlockComponentConfiguration configuration =
       const BlockComponentConfiguration();

--- a/lib/src/editor/editor_component/service/renderer/block_component_widget.dart
+++ b/lib/src/editor/editor_component/service/renderer/block_component_widget.dart
@@ -6,6 +6,7 @@ mixin BlockComponentWidget on Widget {
   Node get node;
   BlockComponentConfiguration get configuration;
   BlockComponentActionBuilder? get actionBuilder;
+  BlockComponentActionTrailingBuilder? get actionTrailingBuilder;
   bool get showActions;
 }
 
@@ -17,6 +18,7 @@ class BlockComponentStatelessWidget extends StatelessWidget
     required this.configuration,
     this.showActions = false,
     this.actionBuilder,
+    this.actionTrailingBuilder,
   });
 
   @override
@@ -32,6 +34,9 @@ class BlockComponentStatelessWidget extends StatelessWidget
   final BlockComponentConfiguration configuration;
 
   @override
+  final BlockComponentActionTrailingBuilder? actionTrailingBuilder;
+
+  @override
   Widget build(BuildContext context) {
     throw UnimplementedError();
   }
@@ -45,6 +50,7 @@ class BlockComponentStatefulWidget extends StatefulWidget
     required this.configuration,
     this.showActions = false,
     this.actionBuilder,
+    this.actionTrailingBuilder,
   });
 
   @override
@@ -52,6 +58,9 @@ class BlockComponentStatefulWidget extends StatefulWidget
 
   @override
   final BlockComponentActionBuilder? actionBuilder;
+
+  @override
+  final BlockComponentActionTrailingBuilder? actionTrailingBuilder;
 
   @override
   final bool showActions;

--- a/lib/src/plugins/blocks/columns/column_block_component.dart
+++ b/lib/src/plugins/blocks/columns/column_block_component.dart
@@ -49,6 +49,7 @@ class ColumnBlockComponent extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
   });
 

--- a/lib/src/plugins/blocks/columns/columns_block_component.dart
+++ b/lib/src/plugins/blocks/columns/columns_block_component.dart
@@ -57,6 +57,7 @@ class ColumnsBlockComponent extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
   });
 

--- a/test/customer/custom_error_block_test.dart
+++ b/test/customer/custom_error_block_test.dart
@@ -87,6 +87,10 @@ class ErrorBlockComponentBuilder extends BlockComponentBuilder {
         blockComponentContext,
         state,
       ),
+      actionTrailingBuilder: (context, state) => actionTrailingBuilder(
+        blockComponentContext,
+        state,
+      ),
     );
   }
 }
@@ -97,6 +101,7 @@ class ErrorBlockComponentWidget extends BlockComponentStatefulWidget {
     required super.node,
     super.showActions,
     super.actionBuilder,
+    super.actionTrailingBuilder,
     super.configuration = const BlockComponentConfiguration(),
   });
 


### PR DESCRIPTION
- Customize the selection area position. We can use the position to control the selection area either above or below the block.
- Add a trailing builder in the block menu. We can use it to add more padding between the block and the block menu.

---

The red box in the screenshot is added by the trailing builder to ensure that the block menu doesn't overlap with the blue quote icon.

<img width="576" alt="Screenshot 2025-03-10 at 09 02 48" src="https://github.com/user-attachments/assets/55e8e7aa-3a66-414f-85dd-6f14ab663f71" />
