### PR TITLE
fix: interceptor not working with continuous deleting

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_service.dart
@@ -28,22 +28,23 @@ class DeltaTextInputService extends TextInputService with DeltaTextInputClient {
   TextInputConnection? _textInputConnection;
 
   @override
-  Future<void> apply(List<TextEditingDelta> deltas) async {
+  Future<bool> apply(List<TextEditingDelta> deltas) async {
     final formattedDeltas = deltas.map((e) => e.format()).toList();
+    bool willApply = true;
     for (final delta in formattedDeltas) {
       _updateComposing(delta);
-
       switch (delta) {
         case TextEditingDeltaInsertion _:
-          await onInsert(delta);
+          if (!(await onInsert(delta))) willApply = false;
         case TextEditingDeltaDeletion _:
-          await onDelete(delta);
+          if (!(await onDelete(delta))) willApply = false;
         case TextEditingDeltaReplacement _:
-          await onReplace(delta);
+          if (!(await onReplace(delta))) willApply = false;
         case TextEditingDeltaNonTextUpdate _:
-          await onNonTextUpdate(delta);
+          if (!(await onNonTextUpdate(delta))) willApply = false;
       }
     }
+    return willApply;
   }
 
   @override
@@ -154,7 +155,8 @@ class DeltaTextInputService extends TextInputService with DeltaTextInputClient {
           deletedRange: deleteRange,
           selection: const TextSelection.collapsed(
             offset: -1,
-          ), // just pass a invalid value, because we don't use this selection inside.
+          ),
+          // just pass a invalid value, because we don't use this selection inside.
           composing: TextRange.empty,
         ),
       );
@@ -253,7 +255,9 @@ extension on TextEditingDeltaNonTextUpdate {
 
 extension on TextSelection {
   TextSelection operator <<(int shiftAmount) => shift(-shiftAmount);
+
   TextSelection operator >>(int shiftAmount) => shift(shiftAmount);
+
   TextSelection shift(int shiftAmount) => TextSelection(
         baseOffset: max(0, baseOffset + shiftAmount),
         extentOffset: max(0, extentOffset + shiftAmount),
@@ -262,7 +266,9 @@ extension on TextSelection {
 
 extension on TextRange {
   TextRange operator <<(int shiftAmount) => shift(-shiftAmount);
+
   TextRange operator >>(int shiftAmount) => shift(shiftAmount);
+
   TextRange shift(int shiftAmount) => !isValid
       ? this
       : TextRange(
@@ -273,6 +279,7 @@ extension on TextRange {
 
 extension on String {
   String operator <<(int shiftAmount) => shift(shiftAmount);
+
   String shift(int shiftAmount) {
     if (shiftAmount > length) {
       return '';

--- a/lib/src/editor/editor_component/service/ime/text_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/text_input_service.dart
@@ -12,10 +12,10 @@ abstract class TextInputService {
     this.contentInsertionConfiguration,
   });
 
-  Future<void> Function(TextEditingDeltaInsertion insertion) onInsert;
-  Future<void> Function(TextEditingDeltaDeletion deletion) onDelete;
-  Future<void> Function(TextEditingDeltaReplacement replacement) onReplace;
-  Future<void> Function(TextEditingDeltaNonTextUpdate nonTextUpdate)
+  Future<bool> Function(TextEditingDeltaInsertion insertion) onInsert;
+  Future<bool> Function(TextEditingDeltaDeletion deletion) onDelete;
+  Future<bool> Function(TextEditingDeltaReplacement replacement) onReplace;
+  Future<bool> Function(TextEditingDeltaNonTextUpdate nonTextUpdate)
       onNonTextUpdate;
   Future<void> Function(TextInputAction action) onPerformAction;
   Future<void> Function(RawFloatingCursorPoint point)? onFloatingCursor;
@@ -42,9 +42,10 @@ abstract class TextInputService {
 
   /// Applies insertion, deletion and replacement
   ///   to the text currently being edited.
+  ///   return false means will not apply
   ///
   /// For more information, please check [TextEditingDelta].
-  Future<void> apply(List<TextEditingDelta> deltas);
+  Future<bool> apply(List<TextEditingDelta> deltas);
 
   /// Closes the editing state of the text currently being edited.
   void close();

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -375,7 +375,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
             AppFlowyEditorLog.input.info(
               'keyboard service onInsert - intercepted by interceptor: $interceptor',
             );
-            return;
+            return false;
           }
         }
 
@@ -384,6 +384,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
           editorState,
           widget.characterShortcutEvents,
         );
+        return true;
       },
       onDelete: (deletion) async {
         for (final interceptor in interceptors) {
@@ -395,7 +396,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
             AppFlowyEditorLog.input.info(
               'keyboard service onDelete - intercepted by interceptor: $interceptor',
             );
-            return;
+            return false;
           }
         }
 
@@ -403,6 +404,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
           deletion,
           editorState,
         );
+        return true;
       },
       onReplace: (replacement) async {
         for (final interceptor in interceptors) {
@@ -415,7 +417,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
             AppFlowyEditorLog.input.info(
               'keyboard service onReplace - intercepted by interceptor: $interceptor',
             );
-            return;
+            return false;
           }
         }
 
@@ -424,6 +426,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
           editorState,
           widget.characterShortcutEvents,
         );
+        return true;
       },
       onNonTextUpdate: (nonTextUpdate) async {
         for (final interceptor in interceptors) {
@@ -436,7 +439,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
             AppFlowyEditorLog.input.info(
               'keyboard service onNonTextUpdate - intercepted by interceptor: $interceptor',
             );
-            return;
+            return false;
           }
         }
 
@@ -445,6 +448,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
           editorState,
           widget.characterShortcutEvents,
         );
+        return true;
       },
       onPerformAction: (action) async {
         for (final interceptor in interceptors) {

--- a/test/editor/editor_component/ime/non_delta_input_service_test.dart
+++ b/test/editor/editor_component/ime/non_delta_input_service_test.dart
@@ -88,10 +88,10 @@ void main() {
         onContentInserted: (value) => completer.complete(true),
       );
       final inputService = NonDeltaTextInputService(
-        onInsert: (_) async {},
-        onDelete: (_) async {},
-        onReplace: (_) async {},
-        onNonTextUpdate: (_) async {},
+        onInsert: (_) async => true,
+        onDelete: (_) async => true,
+        onReplace: (_) async => true,
+        onNonTextUpdate: (_) async => true,
         onPerformAction: (_) async {},
         contentInsertionConfiguration: config,
       );
@@ -154,10 +154,22 @@ void main() {
         const TextEditingValue(selection: TextSelection.collapsed(offset: 0));
     const space = ' ';
     final inputService = NonDeltaTextInputService(
-      onInsert: (v) async => value = v.apply(value),
-      onDelete: (v) async => value = v.apply(value),
-      onReplace: (v) async => value = v.apply(value),
-      onNonTextUpdate: (v) async => value = v.apply(value),
+      onInsert: (v) async {
+        value = v.apply(value);
+        return true;
+      },
+      onDelete: (v) async {
+        value = v.apply(value);
+        return true;
+      },
+      onReplace: (v) async {
+        value = v.apply(value);
+        return true;
+      },
+      onNonTextUpdate: (v) async {
+        value = v.apply(value);
+        return true;
+      },
       onPerformAction: (_) async {},
     );
     inputService.attach(value, const TextInputConfiguration());


### PR DESCRIPTION
Related to a mobile slash menu issue:

**ｗhen I type ‘/’ and enter the second-level menu by selecting any item, I can return to the first-level menu using backspace. 
but after selecting items for three times, backspace no longer works to return to the first level.**

<img width="340" alt="image" src="https://github.com/user-attachments/assets/8c0f99d1-2356-4fe9-94f2-74a89cee6431" />
