### PR TITLE
Fixed bug, fixed bug: type 'int' is not a subtype of type 'double?' 

### DIFF
--- a/lib/src/editor/block_component/table_block_component/table_block_component.dart
+++ b/lib/src/editor/block_component/table_block_component/table_block_component.dart
@@ -35,10 +35,10 @@ class TableStyle {
   final Color borderHoverColor;
 
   const TableStyle({
-    this.colWidth = 160,
-    this.rowHeight = 40,
-    this.colMinimumWidth = 40,
-    this.borderWidth = 2,
+    this.colWidth = 160.0,
+    this.rowHeight = 40.0,
+    this.colMinimumWidth = 40.0,
+    this.borderWidth = 2.0,
     this.addIcon = TableDefaults.addIcon,
     this.handlerIcon = TableDefaults.handlerIcon,
     this.borderColor = TableDefaults.borderColor,
@@ -117,14 +117,12 @@ class TableBlockComponentBuilder extends BlockComponentBuilder {
   BlockComponentValidate get validate => (node) {
         // check the node is valid
         if (node.attributes.isEmpty) {
-          AppFlowyEditorLog.editor
-              .debug('TableBlockComponentBuilder: node is empty');
+          AppFlowyEditorLog.editor.debug('TableBlockComponentBuilder: node is empty');
           return false;
         }
 
         // check the node has rowPosition and colPosition
-        if (!node.attributes.containsKey(TableBlockKeys.colsLen) ||
-            !node.attributes.containsKey(TableBlockKeys.rowsLen)) {
+        if (!node.attributes.containsKey(TableBlockKeys.colsLen) || !node.attributes.containsKey(TableBlockKeys.rowsLen)) {
           AppFlowyEditorLog.editor.debug(
             'TableBlockComponentBuilder: node has no colsLen or rowsLen',
           );
@@ -137,8 +135,7 @@ class TableBlockComponentBuilder extends BlockComponentBuilder {
         // check its children
         final children = node.children;
         if (children.isEmpty) {
-          AppFlowyEditorLog.editor
-              .debug('TableBlockComponentBuilder: children is empty');
+          AppFlowyEditorLog.editor.debug('TableBlockComponentBuilder: children is empty');
           return false;
         }
 
@@ -153,9 +150,7 @@ class TableBlockComponentBuilder extends BlockComponentBuilder {
         for (var i = 0; i < colsLen; i++) {
           for (var j = 0; j < rowsLen; j++) {
             final child = children.where(
-              (n) =>
-                  n.attributes[TableCellBlockKeys.colPosition] == i &&
-                  n.attributes[TableCellBlockKeys.rowPosition] == j,
+              (n) => n.attributes[TableCellBlockKeys.colPosition] == i && n.attributes[TableCellBlockKeys.rowPosition] == j,
             );
             if (child.isEmpty) {
               AppFlowyEditorLog.editor.debug(
@@ -197,12 +192,10 @@ class TableBlockComponentWidget extends BlockComponentStatefulWidget {
   final TableStyle tableStyle;
 
   @override
-  State<TableBlockComponentWidget> createState() =>
-      _TableBlockComponentWidgetState();
+  State<TableBlockComponentWidget> createState() => _TableBlockComponentWidgetState();
 }
 
-class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget>
-    with SelectableMixin, BlockComponentConfigurable {
+class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget> with SelectableMixin, BlockComponentConfigurable {
   @override
   BlockComponentConfiguration get configuration => widget.configuration;
 
@@ -281,10 +274,7 @@ class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget>
     final tableBox = tableKey.currentContext?.findRenderObject();
     if (parentBox is RenderBox && tableBox is RenderBox) {
       return [
-        (shiftWithBaseOffset
-                ? tableBox.localToGlobal(Offset.zero, ancestor: parentBox)
-                : Offset.zero) &
-            tableBox.size,
+        (shiftWithBaseOffset ? tableBox.localToGlobal(Offset.zero, ancestor: parentBox) : Offset.zero) & tableBox.size,
       ];
     }
     return [Offset.zero & _renderBox.size];

--- a/lib/src/editor/block_component/table_block_component/table_col.dart
+++ b/lib/src/editor/block_component/table_block_component/table_col.dart
@@ -51,8 +51,7 @@ class _TableColState extends State<TableCol> {
     children.addAll([
       SizedBox(
         width: context.select(
-          (Node n) => getCellNode(n, widget.colIdx, 0)
-              ?.attributes[TableCellBlockKeys.width],
+          (Node n) => (getCellNode(n, widget.colIdx, 0)?.attributes[TableCellBlockKeys.width] as num).toDouble(),
         ),
         child: Stack(
           children: [
@@ -125,8 +124,7 @@ class _TableColState extends State<TableCol> {
     node.addListener(listeners[node.id]!);
   }
 
-  void updateRowHeightCallback(int row) =>
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+  void updateRowHeightCallback(int row) => WidgetsBinding.instance.addPostFrameCallback((_) {
         if (row >= widget.tableNode.rowsLen) {
           return;
         }

--- a/lib/src/editor/block_component/table_block_component/table_col_border.dart
+++ b/lib/src/editor/block_component/table_block_component/table_col_border.dart
@@ -34,9 +34,7 @@ class _TableColBorderState extends State<TableColBorder> {
 
   @override
   Widget build(BuildContext context) {
-    return widget.resizable
-        ? buildResizableBorder(context)
-        : buildFixedBorder(context);
+    return widget.resizable ? buildResizableBorder(context) : buildFixedBorder(context);
   }
 
   MouseRegion buildResizableBorder(BuildContext context) {
@@ -71,12 +69,11 @@ class _TableColBorderState extends State<TableColBorder> {
         child: Container(
           key: _borderKey,
           width: widget.tableNode.config.borderWidth,
-          height: context.select(
+          height: (context.select(
             (Node n) => n.attributes[TableBlockKeys.colsHeight],
-          ),
-          color: _borderHovering || _borderDragging
-              ? widget.borderHoverColor
-              : widget.borderColor,
+          ) as num)
+              .toDouble(),
+          color: _borderHovering || _borderDragging ? widget.borderHoverColor : widget.borderColor,
         ),
       ),
     );
@@ -85,9 +82,10 @@ class _TableColBorderState extends State<TableColBorder> {
   Container buildFixedBorder(BuildContext context) {
     return Container(
       width: widget.tableNode.config.borderWidth,
-      height: context.select(
+      height: (context.select(
         (Node n) => n.attributes[TableBlockKeys.colsHeight],
-      ),
+      ) as num)
+          .toDouble(),
       color: Colors.grey,
     );
   }

--- a/lib/src/editor/block_component/table_block_component/table_config.dart
+++ b/lib/src/editor/block_component/table_block_component/table_config.dart
@@ -14,17 +14,13 @@ class TableConfig {
   }
 
   static TableConfig fromJson(Map<String, dynamic> json) {
-    double func(String key, double defaultVal) => json.containsKey(key)
-        ? double.tryParse(json[key].toString())!
-        : defaultVal;
+    double func(String key, double defaultVal) =>
+        json.containsKey(key) ? num.tryParse(json[key].toString())!.toDouble() : defaultVal;
 
     return TableConfig(
-      colDefaultWidth:
-          func(TableBlockKeys.colDefaultWidth, TableDefaults.colWidth),
-      rowDefaultHeight:
-          func(TableBlockKeys.rowDefaultHeight, TableDefaults.rowHeight),
-      colMinimumWidth:
-          func(TableBlockKeys.colMinimumWidth, TableDefaults.colMinimumWidth),
+      colDefaultWidth: func(TableBlockKeys.colDefaultWidth, TableDefaults.colWidth),
+      rowDefaultHeight: func(TableBlockKeys.rowDefaultHeight, TableDefaults.rowHeight),
+      colMinimumWidth: func(TableBlockKeys.colMinimumWidth, TableDefaults.colMinimumWidth),
       borderWidth: func(TableBlockKeys.borderWidth, TableDefaults.borderWidth),
     );
   }
@@ -37,8 +33,5 @@ class TableConfig {
     };
   }
 
-  late final double colDefaultWidth,
-      rowDefaultHeight,
-      colMinimumWidth,
-      borderWidth;
+  late final double colDefaultWidth, rowDefaultHeight, colMinimumWidth, borderWidth;
 }

--- a/lib/src/editor/block_component/table_block_component/table_node.dart
+++ b/lib/src/editor/block_component/table_block_component/table_node.dart
@@ -21,10 +21,7 @@ class TableNode {
     final colsLen = attributes[TableBlockKeys.colsLen];
     final rowsLen = attributes[TableBlockKeys.rowsLen];
 
-    if (colsLen == null ||
-        rowsLen == null ||
-        colsLen is! int ||
-        rowsLen is! int) {
+    if (colsLen == null || rowsLen == null || colsLen is! int || rowsLen is! int) {
       AppFlowyEditorLog.editor.debug(
         'TableNode: colsLen or rowsLen is not an integer or null',
       );
@@ -42,8 +39,7 @@ class TableNode {
     for (final child in node.children) {
       if (!child.attributes.containsKey(TableCellBlockKeys.rowPosition) ||
           !child.attributes.containsKey(TableCellBlockKeys.colPosition)) {
-        AppFlowyEditorLog.editor
-            .debug('TableNode: cell has no rowPosition or colPosition');
+        AppFlowyEditorLog.editor.debug('TableNode: cell has no rowPosition or colPosition');
         return;
       }
     }
@@ -53,9 +49,7 @@ class TableNode {
       for (var j = 0; j < rowsLen; j++) {
         final cell = node.children
             .where(
-              (n) =>
-                  n.attributes[TableCellBlockKeys.colPosition] == i &&
-                  n.attributes[TableCellBlockKeys.rowPosition] == j,
+              (n) => n.attributes[TableCellBlockKeys.colPosition] == i && n.attributes[TableCellBlockKeys.rowPosition] == j,
             )
             .firstOrNull;
 
@@ -188,12 +182,9 @@ class TableNode {
     Transaction? transaction,
   }) {
     // The extra 8 is because of paragraph padding
-    double maxHeight = _cells
-        .map<double>((c) => c[row].children.first.rect.height + 8)
-        .reduce(max);
+    double maxHeight = _cells.map<double>((c) => c[row].children.first.rect.height + 8).reduce(max);
 
-    if (_cells[0][row].attributes[TableCellBlockKeys.height] != maxHeight &&
-        !maxHeight.isNaN) {
+    if (_cells[0][row].attributes[TableCellBlockKeys.height] != maxHeight && !maxHeight.isNaN) {
       for (int i = 0; i < colsLen; i++) {
         final currHeight = _cells[i][row].attributes[TableCellBlockKeys.height];
         if (currHeight == maxHeight) {
@@ -213,15 +204,14 @@ class TableNode {
       }
     }
 
-    if (node.attributes[TableBlockKeys.colsHeight] != colsHeight &&
-        !colsHeight.isNaN) {
+    if (node.attributes[TableBlockKeys.colsHeight] != colsHeight && !colsHeight.isNaN) {
       if (transaction != null) {
-        transaction.updateNode(node, {TableBlockKeys.colsHeight: colsHeight});
+        transaction.updateNode(node, {TableBlockKeys.colsHeight: colsHeight.toDouble()});
         if (editorState != null && editorState.editable != true) {
-          node.updateAttributes({TableBlockKeys.colsHeight: colsHeight});
+          node.updateAttributes({TableBlockKeys.colsHeight: colsHeight.toDouble()});
         }
       } else {
-        node.updateAttributes({TableBlockKeys.colsHeight: colsHeight});
+        node.updateAttributes({TableBlockKeys.colsHeight: colsHeight.toDouble()});
       }
     }
   }


### PR DESCRIPTION
To reproduce simply convert Document to JSON and Tables will get int types of size instead of double, causing error when reading on Desktop platforms. Somehow Web works fine [Magic]. 