### PR TITLE
fix: parse table width/height error if the value is int

### DIFF
--- a/example/assets/example.json
+++ b/example/assets/example.json
@@ -160,8 +160,8 @@
             "data": {
               "colPosition": 0,
               "rowPosition": 0,
-              "height": 47.0,
-              "width": 553.09375
+              "height": 47,
+              "width": 553
             }
           },
           {

--- a/lib/src/editor/block_component/table_block_component/table_cell_block_component.dart
+++ b/lib/src/editor/block_component/table_block_component/table_cell_block_component.dart
@@ -110,8 +110,7 @@ class _TableCeBlockWidgetState extends State<TableCelBlockWidget> {
           onExit: (_) => setState(() => _rowActionVisibility = false),
           child: Container(
             constraints: BoxConstraints(
-              minHeight: context
-                  .select((Node n) => n.attributes[TableCellBlockKeys.height]),
+              minHeight: context.select((Node n) => n.cellHeight),
             ),
             color: context.select(
               (Node n) =>
@@ -146,8 +145,8 @@ class _TableCeBlockWidgetState extends State<TableCelBlockWidget> {
             final int col = n.attributes[TableCellBlockKeys.colPosition];
             double left = -12;
             for (var i = 0; i < col; i++) {
-              left -= getCellNode(n.parent!, i, 0)
-                  ?.attributes[TableCellBlockKeys.width] as double;
+              left -= getCellNode(n.parent!, i, 0)?.cellWidth ??
+                  TableDefaults.colWidth;
               left -= n.parent!.attributes['borderWidth'] ??
                   TableDefaults.borderWidth;
             }
@@ -155,8 +154,7 @@ class _TableCeBlockWidgetState extends State<TableCelBlockWidget> {
             return Matrix4.translationValues(left, 0.0, 0.0);
           }),
           alignment: Alignment.centerLeft,
-          height: context
-              .select((Node n) => n.attributes[TableCellBlockKeys.height]),
+          height: context.select((Node n) => n.cellHeight),
           menuBuilder: widget.menuBuilder,
           dir: TableDirection.row,
         ),

--- a/lib/src/editor/block_component/table_block_component/table_col.dart
+++ b/lib/src/editor/block_component/table_block_component/table_col.dart
@@ -51,8 +51,7 @@ class _TableColState extends State<TableCol> {
     children.addAll([
       SizedBox(
         width: context.select(
-          (Node n) => getCellNode(n, widget.colIdx, 0)
-              ?.attributes[TableCellBlockKeys.width],
+          (Node n) => getCellNode(n, widget.colIdx, 0)?.cellWidth,
         ),
         child: Stack(
           children: [

--- a/lib/src/editor/block_component/table_block_component/util.dart
+++ b/lib/src/editor/block_component/table_block_component/util.dart
@@ -8,3 +8,35 @@ Node? getCellNode(Node tableNode, int col, int row) {
         n.attributes[TableCellBlockKeys.rowPosition] == row,
   );
 }
+
+extension TableCellNodeDynamicExtension on dynamic {
+  double toDouble({double defaultValue = 0.0}) {
+    if (this is int) {
+      return this.toDouble();
+    } else if (this is double) {
+      return this;
+    } else {
+      return double.tryParse(toString()) ?? defaultValue;
+    }
+  }
+}
+
+extension TableCellNodeAttributesExtension on Node {
+  double get cellWidth {
+    assert(type == TableCellBlockKeys.type);
+    return attributes[TableCellBlockKeys.width]?.toDouble() ??
+        TableDefaults.colWidth;
+  }
+
+  double get cellHeight {
+    assert(type == TableCellBlockKeys.type);
+    return attributes[TableCellBlockKeys.height]?.toDouble() ??
+        TableDefaults.rowHeight;
+  }
+
+  double get colHeight {
+    assert(type == TableBlockKeys.type);
+    return attributes[TableBlockKeys.colsHeight]?.toDouble() ??
+        TableDefaults.rowHeight;
+  }
+}


### PR DESCRIPTION
Add dynamic value to double conversion to ensure the width and height values from the table node are doubles.