### PR TITLE
fix: rename the descroption of turning into heading shortcuts

### DIFF
--- a/lib/src/editor/block_component/heading_block_component/heading_command_shortcut.dart
+++ b/lib/src/editor/block_component/heading_block_component/heading_command_shortcut.dart
@@ -19,7 +19,7 @@ final List<CommandShortcutEvent> toggleHeadingCommands = [
 ///   - web
 ///
 final CommandShortcutEvent toggleH1 = CommandShortcutEvent(
-  key: 'toggle H1',
+  key: 'toggle into Heading 1',
   getDescription: () => AppFlowyEditorL10n.current.cmdToggleH1,
   command: 'ctrl+shift+t',
   macOSCommand: 'cmd+shift+t',
@@ -30,7 +30,7 @@ final CommandShortcutEvent toggleH1 = CommandShortcutEvent(
 );
 
 final CommandShortcutEvent toggleH2 = CommandShortcutEvent(
-  key: 'toggle H2',
+  key: 'toggle into Heading 2',
   getDescription: () => AppFlowyEditorL10n.current.cmdToggleH2,
   command: 'ctrl+shift+g',
   macOSCommand: 'cmd+shift+g',
@@ -41,7 +41,7 @@ final CommandShortcutEvent toggleH2 = CommandShortcutEvent(
 );
 
 final CommandShortcutEvent toggleH3 = CommandShortcutEvent(
-  key: 'toggle H3',
+  key: 'toggle into Heading 3',
   getDescription: () => AppFlowyEditorL10n.current.cmdToggleH3,
   command: 'ctrl+shift+j',
   macOSCommand: 'cmd+shift+j',

--- a/lib/src/l10n/l10n.dart
+++ b/lib/src/l10n/l10n.dart
@@ -1844,7 +1844,7 @@ class AppFlowyEditorLocalizations {
   /// `toggle H1`
   String get cmdToggleH1 {
     return Intl.message(
-      'toggle H1',
+      'toggle into Heading 1',
       name: 'cmdToggleH1',
       desc: '',
       args: [],
@@ -1854,7 +1854,7 @@ class AppFlowyEditorLocalizations {
   /// `toggle H2`
   String get cmdToggleH2 {
     return Intl.message(
-      'toggle H2',
+      'toggle into Heading 2',
       name: 'cmdToggleH2',
       desc: '',
       args: [],
@@ -1864,7 +1864,7 @@ class AppFlowyEditorLocalizations {
   /// `toggle H3`
   String get cmdToggleH3 {
     return Intl.message(
-      'toggle H3',
+      'toggle into Heading 3',
       name: 'cmdToggleH3',
       desc: '',
       args: [],


### PR DESCRIPTION
To fix https://github.com/AppFlowy-IO/AppFlowy/issues/7586
Rename the shortcuts description to avoid misunderstanding