### PR TITLE
fix: prevent lock after backspacing on select all

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/backspace_command.dart
@@ -177,6 +177,11 @@ CommandShortcutEventHandler _backspaceInSelectAll = (editorState) {
   final transaction = editorState.transaction;
   final nodes = editorState.getNodesInSelection(selection);
   transaction.deleteNodes(nodes);
+  // insert a new paragraph node to avoid locking the editor
+  transaction.insertNode(
+    editorState.document.root.children.first.path,
+    paragraphNode(),
+  );
   editorState.apply(transaction);
 
   return KeyEventResult.handled;


### PR DESCRIPTION
Dear all,

I have noticed that in Desktop versions, if you select all (CTRL+A) and press backspace, the editor enters in a locked state. It makes it further unclickable since the document loses all node children.

This PR fixes this.

Best regards,
Saif