### PR TITLE
fix: backspace select all

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command/backspace_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/backspace_command.dart
@@ -177,11 +177,14 @@ CommandShortcutEventHandler _backspaceInSelectAll = (editorState) {
   final transaction = editorState.transaction;
   final nodes = editorState.getNodesInSelection(selection);
   transaction.deleteNodes(nodes);
-  // insert a new paragraph node to avoid locking the editor
+
+  // Insert a new paragraph node to avoid locking the editor
   transaction.insertNode(
     editorState.document.root.children.first.path,
     paragraphNode(),
   );
+  transaction.afterSelection = Selection.collapsed(Position(path: [0]));
+
   editorState.apply(transaction);
 
   return KeyEventResult.handled;

--- a/lib/src/flutter/overlay.dart
+++ b/lib/src/flutter/overlay.dart
@@ -5,6 +5,8 @@
 //  We Need to commit(https://github.com/flutter/flutter/pull/113770) to fix the
 //  overflow issue.
 
+// coverage:ignore-file
+
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/lib/src/flutter/scrollable_helpers.dart
+++ b/lib/src/flutter/scrollable_helpers.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'dart:async';
 import 'dart:math' as math;
 

--- a/lib/src/flutter/scrollable_positioned_list/src/element_registry.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/element_registry.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'package:flutter/widgets.dart';
 
 /// A registry to track some [Element]s in the tree.

--- a/lib/src/flutter/scrollable_positioned_list/src/item_positions_listener.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/item_positions_listener.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'package:flutter/foundation.dart';
 
 import 'item_positions_notifier.dart';

--- a/lib/src/flutter/scrollable_positioned_list/src/item_positions_notifier.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/item_positions_notifier.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'package:flutter/foundation.dart';
 
 import 'item_positions_listener.dart';

--- a/lib/src/flutter/scrollable_positioned_list/src/positioned_list.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/positioned_list.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';

--- a/lib/src/flutter/scrollable_positioned_list/src/post_mount_callback.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/post_mount_callback.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'package:flutter/widgets.dart';
 
 /// Widget whose [Element] calls a callback when the element is mounted.

--- a/lib/src/flutter/scrollable_positioned_list/src/scroll_offset_listener.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/scroll_offset_listener.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'dart:async';
 
 import 'scroll_offset_notifier.dart';

--- a/lib/src/flutter/scrollable_positioned_list/src/scroll_offset_notifier.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/scroll_offset_notifier.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'dart:async';
 
 import 'scroll_offset_listener.dart';

--- a/lib/src/flutter/scrollable_positioned_list/src/scroll_view.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/scroll_view.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 

--- a/lib/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'dart:async';
 import 'dart:math';
 

--- a/lib/src/flutter/scrollable_positioned_list/src/viewport.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/viewport.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// coverage:ignore-file
+
 import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';

--- a/lib/src/flutter/scrollable_positioned_list/src/wrapping.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/wrapping.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';

--- a/test/new/service/shortcuts/command_shortcut_events/backspace_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/backspace_command_test.dart
@@ -173,6 +173,32 @@ void main() async {
           blockComponentTextDirectionRTL,
         );
       });
+
+      test("backspace when all is selected", () async {
+        final document = Document.blank().addParagraphs(
+          5,
+          initialText: text,
+        );
+        final editorState = EditorState(document: document);
+
+        final selection = Selection(
+          start: Position(path: [0], offset: 0),
+          end: Position(path: [4], offset: text.length),
+        );
+        editorState.updateSelectionWithReason(
+          selection,
+          reason: SelectionUpdateReason.selectAll,
+        );
+
+        final result = backspaceCommand.execute(editorState);
+        expect(result, KeyEventResult.handled);
+
+        expect(editorState.selection, Selection.collapsed(Position(path: [0])));
+        expect(editorState.document.root.children.length, 1);
+
+        final node = editorState.getNodeAtPath([0])!;
+        expect(node.delta!.toPlainText(), ''); // empty
+      });
     });
 
     group('backspaceCommand - not collapsed selection', () {


### PR DESCRIPTION
- After inserting the new node when deleting all nodes, we should update selection to retain cursor and focus.
- Added test to ensure it keeps working
- Ignore imported files from Flutter in coverage, seems irrelevant