### PR TITLE
feat: allow tables to be aligned (Draft - has issues)

### DIFF
--- a/lib/src/editor/block_component/table_block_component/table_block_component.dart
+++ b/lib/src/editor/block_component/table_block_component/table_block_component.dart
@@ -202,7 +202,7 @@ class TableBlockComponentWidget extends BlockComponentStatefulWidget {
 }
 
 class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget>
-    with SelectableMixin, BlockComponentConfigurable {
+    with SelectableMixin, BlockComponentConfigurable, BlockComponentAlignMixin {
   @override
   BlockComponentConfiguration get configuration => widget.configuration;
 
@@ -256,7 +256,10 @@ class _TableBlockComponentWidgetState extends State<TableBlockComponentWidget>
       );
     }
 
-    return child;
+    return Align(
+      alignment: alignment ?? Alignment.center,
+      child: child
+    );
   }
 
   final tableKey = GlobalKey();

--- a/lib/src/editor/command/text_commands.dart
+++ b/lib/src/editor/command/text_commands.dart
@@ -255,6 +255,12 @@ extension TextTransforms on EditorState {
     final transaction = this.transaction;
 
     for (final node in nodes) {
+
+      // if node is table, skip
+      if (node.type == TableCellBlockKeys.type) {
+        continue;
+      }
+      
       transaction
         ..insertNode(
           node.path,


### PR DESCRIPTION
Dear Appflowy team,

The goal of this PR (Draft) is to support tables alignment, to avoid a situation like this:
![image](https://github.com/user-attachments/assets/1d1b8f47-c76c-44a5-b1a1-06830666bd03)

The approach is to add a BlockComponentAlignMixin and let the Table widget to align accordingly.

**Current problem:** The JSON state of the editor exponentially grows in a bad way, see the attached json example
[New game 8 - state 2.json](https://github.com/user-attachments/files/19447985/New.game.8.-.state.2.json)
