### PR TITLE
fix: support flutter 3.32 and dependency compatibility

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   google_fonts: ^6.1.0
   flutter_localizations:
     sdk: flutter
-  file_picker: ^8.0.2
+  file_picker: ^10.1.9
   universal_html: ^2.0.8
   highlight: ^0.7.0
   http: ^1.1.0
@@ -71,7 +71,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.1
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -239,6 +239,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       textInputService.attach(
         textEditingValue,
         TextInputConfiguration(
+          viewId: View.of(context).viewId,
           enableDeltaModel: false,
           inputType: TextInputType.multiline,
           textCapitalization: TextCapitalization.sentences,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,13 +15,13 @@ dependencies:
   collection: "^1.18.0"
   device_info_plus: "^11.0.0"
   diff_match_patch: "^0.4.1"
-  file_picker: "^8.0.2"
+  file_picker: ^10.1.9
   flutter:
     sdk: flutter
   flutter_svg: "^2.0.6"
   html: ^0.15.5
   http: "^1.2.0"
-  intl: "^0.19.0"
+  intl: ^0.20.2
   keyboard_height_plugin: "^0.1.5"
   logging: "^1.2.0"
   markdown: "^7.2.1"


### PR DESCRIPTION
Hello,

This branch adds a necessary viewId parameter for Flutter 3.32.0 to identify current Window (it is related to Flutters' new multi-Windows support, read here: https://github.com/flutter/flutter/issues/169204 )

Small risk: Flutter 3.32.1+ might update this API or include defaults in future releases, although the current change sets up a sane default value in `TextInputConfiguration` which needs it.

Also updates a dependency no longer building otherwise.

Best regards