### PR TITLE
fix: add newline rules to separate multiple images in markdown

### DIFF
--- a/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
+++ b/lib/src/plugins/markdown/decoder/document_markdown_decoder.dart
@@ -81,6 +81,21 @@ class DocumentMarkdownDecoder extends Converter<String, Document> {
       (match) => '${match[1]}\n\n![${match[2]}](${match[3]})',
     );
 
+    // Rule 3: single '\n' between two images, add double '\n'
+    result = result.replaceAllMapped(
+      RegExp(
+        r'(!\[[^\]]*\]\([^)]+\))\n(?=!?\[[^\]]*\]\([^)]+\))',
+        multiLine: true,
+      ),
+      (match) => '${match[1]}\n\n',
+    );
+
+    // Rule 4:without '\n' between two images, add double '\n'
+    result = result.replaceAllMapped(
+      RegExp(r'(!\[[^\]]*\]\([^)]+\))(?=!?\[[^\]]*\]\([^)]+\))'),
+      (match) => '${match[1]}\n\n',
+    );
+
     // Add another rules here.
 
     return result;

--- a/test/plugins/markdown/document_markdown_test.dart
+++ b/test/plugins/markdown/document_markdown_test.dart
@@ -57,6 +57,30 @@ void main() {
       expect(nodes[0].delta?.toPlainText(), 'This is the first line');
       expect(nodes[1].attributes['url'], 'https://example.com/image.png');
     });
+    test('multiple images on separate lines without blank lines', () {
+      const markdown = '''![image1](https://example.com/image.png)
+![image2](https://example.com/image.png)
+![image3](https://example.com/image.png)
+''';
+      final document = markdownToDocument(markdown);
+      final nodes = document.root.children;
+      expect(nodes.length, 3);
+      expect(nodes[0].attributes['url'], 'https://example.com/image.png');
+      expect(nodes[1].attributes['url'], 'https://example.com/image.png');
+      expect(nodes[2].attributes['url'], 'https://example.com/image.png');
+    });
+
+    test('multiple images on same line (inline)', () {
+      const markdown = '''
+![inline1](https://example.com/image.png) ![inline2](https://example.com/image.png) ![inline3](https://example.com/image.png)
+''';
+      final document = markdownToDocument(markdown);
+      final nodes = document.root.children;
+      expect(nodes.length, 3);
+      expect(nodes[0].attributes['url'], 'https://example.com/image.png');
+      expect(nodes[1].attributes['url'], 'https://example.com/image.png');
+      expect(nodes[2].attributes['url'], 'https://example.com/image.png');
+    });
   });
 }
 


### PR DESCRIPTION
* Added two new rules in `DocumentMarkdownDecoder` to handle formatting for multiple images:
  1. Ensures a double newline (`\n\n`) is added when a single newline separates two images.
  2. Ensures a double newline (`\n\n`) is added when no newline separates two images.
* Added a test case to verify that multiple images on separate lines without blank lines are properly decoded into distinct nodes.
* Added a test case to verify that multiple images on the same line (inline) are properly decoded into distinct nodes.

This pull request fixes #1113.