### PR TITLE
fix: unable to input text on windows desktop

### DIFF
--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -239,6 +239,7 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       textInputService.attach(
         textEditingValue,
         TextInputConfiguration(
+          viewId: View.of(context).viewId,
           enableDeltaModel: false,
           inputType: TextInputType.multiline,
           textCapitalization: TextCapitalization.sentences,


### PR DESCRIPTION
Fixes #1125

Fixed by providing the relevant `viewId` to `TextInputConfiguration` in `KeyboardServiceWidget`.