### PR TITLE
fix: restore tab visibility and prevent “TabAlignment.start is only v…

### DIFF
--- a/lib/src/editor/toolbar/mobile/toolbar_items/color/text_and_background_color_tool_bar_item.dart
+++ b/lib/src/editor/toolbar/mobile/toolbar_items/color/text_and_background_color_tool_bar_item.dart
@@ -64,6 +64,8 @@ class _TextAndBackgroundColorMenuState
             child: TabBar(
               indicatorSize: TabBarIndicatorSize.tab,
               tabs: myTabs,
+              isScrollable: false,
+              tabAlignment: TabAlignment.fill,
               labelColor: style.tabBarSelectedBackgroundColor,
               indicator: BoxDecoration(
                 borderRadius: BorderRadius.circular(style.borderRadius),


### PR DESCRIPTION
Before:
<img width="435" height="902" alt="스크린샷 2025-07-12 오후 3 50 27" src="https://github.com/user-attachments/assets/efff8d72-defc-44da-a7a2-41c46e0bd627" />

After(Same as existing UI):
<img width="435" height="902" alt="스크린샷 2025-07-12 오후 3 51 36" src="https://github.com/user-attachments/assets/93e19e10-bb10-4766-9f12-98d9300b13d3" />
