### PR TITLE
fix: TextStyleExtensions combine logic issue with fontfamily

### DIFF
--- a/lib/src/extensions/text_style_extension.dart
+++ b/lib/src/extensions/text_style_extension.dart
@@ -69,7 +69,8 @@ extension TextStyleExtensions on TextStyle {
       decorationStyle: other.decorationStyle,
       decorationThickness: other.decorationThickness,
       debugLabel: other.debugLabel,
-      fontFamily: other.fontFamily,
+      fontFamily:
+          (other.fontFamily?.isEmpty ?? true) ? fontFamily : other.fontFamily,
       fontFamilyFallback: other.fontFamilyFallback,
       overflow: other.overflow,
     );


### PR DESCRIPTION
<img width="431" height="294" alt="image" src="https://github.com/user-attachments/assets/045cfda1-e758-43c5-afee-d5c2471a3a42" />
