### PR TITLE
fix: selection move direction logic should visit children

### DIFF
--- a/lib/src/editor/command/selection_commands.dart
+++ b/lib/src/editor/command/selection_commands.dart
@@ -260,7 +260,10 @@ extension SelectionTransform on EditorState {
       else if (direction == SelectionMoveDirection.backward &&
           end != null &&
           end.offset <= offset) {
-        final nextStart = node.next?.selectable?.start();
+        final nextStart = node
+            .nextNodeWhere((element) => element.selectable != null)
+            ?.selectable
+            ?.start();
         if (nextStart != null) {
           updateSelectionWithReason(
             Selection.collapsed(nextStart),

--- a/lib/src/extensions/node_extensions.dart
+++ b/lib/src/extensions/node_extensions.dart
@@ -38,6 +38,40 @@ extension NodeExtensions on Node {
     return Rect.zero;
   }
 
+  Node? nextNodeWhere(bool Function(Node element) test) {
+    for (final child in children) {
+      final matchingNode = child._thisOrDescendantMatching(test);
+      if (matchingNode != null) {
+        return matchingNode;
+      }
+    }
+
+    var next = this.next;
+    while (next != null) {
+      final nextDescendentMatch = next._thisOrDescendantMatching(test);
+      if (nextDescendentMatch != null) {
+        return nextDescendentMatch;
+      }
+      next = next.next;
+    }
+
+    return parent?.next?._thisOrDescendantMatching(test);
+  }
+
+  Node? _thisOrDescendantMatching(bool Function(Node element) test) {
+    if (test(this)) {
+      return this;
+    }
+    for (final child in children) {
+      final matchingNode = child._thisOrDescendantMatching(test);
+      if (matchingNode != null) {
+        return matchingNode;
+      }
+    }
+
+    return null;
+  }
+
   /// Returns the first previous node in the subtree that satisfies the given predicate
   Node? previousNodeWhere(bool Function(Node element) test) {
     var previous = this.previous;


### PR DESCRIPTION
Before:

1. Find a matching sibling

After:

1. Find a matching descendant
2. Find a matching sibling or one of its descendants
3. Find the next sibling of its parent

This solves two bugs:

1. arrow right in a nested list doesn't go to a sub item
2. arrow right in a nested list doesn't exit out


https://github.com/user-attachments/assets/f2a2bfe2-9491-43ab-b7dd-7bcc864025b3


https://github.com/user-attachments/assets/c6127c93-9909-4817-9da4-3b3c52ba469b


