### PR TITLE
fix: redo works only once

### DIFF
--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -37,6 +37,7 @@ class ApplyOptions {
     this.recordUndo = true,
     this.recordRedo = false,
     this.inMemoryUpdate = false,
+    this.isRedo = false,
   });
 
   /// This flag indicates that
@@ -47,6 +48,9 @@ class ApplyOptions {
 
   /// This flag used to determine whether the transaction is in-memory update.
   final bool inMemoryUpdate;
+
+  /// This flag used to determine whether the transaction is recorded for redo.
+  final bool isRedo;
 }
 
 @Deprecated('use SelectionUpdateReason instead')
@@ -672,7 +676,9 @@ class EditorState {
     bool skipDebounce,
   ) {
     if (options.recordUndo) {
-      final undoItem = undoManager.getUndoHistoryItem();
+      final undoItem = undoManager.getUndoHistoryItem(
+        clearRedoStack: !options.recordRedo && !options.isRedo,
+      );
       undoItem.addAll(transaction.operations);
       if (undoItem.beforeSelection == null &&
           transaction.beforeSelection != null) {

--- a/lib/src/history/undo_manager.dart
+++ b/lib/src/history/undo_manager.dart
@@ -95,8 +95,11 @@ class UndoManager {
       : undoStack = FixedSizeStack(stackSize),
         redoStack = FixedSizeStack(stackSize);
 
-  HistoryItem getUndoHistoryItem() {
+  HistoryItem getUndoHistoryItem({bool clearRedoStack = true}) {
     if (undoStack.isEmpty) {
+      if (clearRedoStack) {
+        redoStack.clear();
+      }
       final item = HistoryItem();
       undoStack.push(item);
 
@@ -104,7 +107,9 @@ class UndoManager {
     }
     final last = undoStack.last;
     if (last.sealed) {
-      redoStack.clear();
+      if (clearRedoStack) {
+        redoStack.clear();
+      }
       final item = HistoryItem();
       undoStack.push(item);
 
@@ -150,7 +155,9 @@ class UndoManager {
       options: const ApplyOptions(
         recordUndo: true,
         recordRedo: false,
+        isRedo: true,
       ),
+      skipHistoryDebounce: true,
     );
   }
 

--- a/test/new/service/shortcuts/command_shortcut_events/undo_redo_command_test.dart
+++ b/test/new/service/shortcuts/command_shortcut_events/undo_redo_command_test.dart
@@ -187,8 +187,8 @@ void main() async {
       // second redo
       await _pressRedoCommand(editor);
       expect(editor.nodeAtPath([0])!.delta!.toPlainText(), text0);
-      expect(editor.nodeAtPath([1])!.delta!.toPlainText(), isEmpty);
-      expect(editor.nodeAtPath([1, 0])!.delta!.toPlainText(), text01);
+      expect(editor.nodeAtPath([0, 0])!.delta!.toPlainText(), isEmpty);
+      expect(editor.nodeAtPath([0, 0, 0])!.delta!.toPlainText(), text01);
 
       await editor.dispose();
     });


### PR DESCRIPTION
- Undo works for multiple operations, but redo works only for one operation and then stops working.
- Fixed by differentiating redo operation from general editor operation, in turn preventing redo stack from getting cleared.

This PR fixes #634 