### PR TITLE
fix: stop mobile selection handles from collapsing selection on tap

### DIFF
--- a/lib/src/render/selection/mobile_basic_handle.dart
+++ b/lib/src/render/selection/mobile_basic_handle.dart
@@ -93,59 +93,194 @@ class DragHandle extends _IDragHandle {
 
   @override
   Widget build(BuildContext context) {
-    Widget child;
+    if (handleType == HandleType.none ||
+        handleType == HandleType.collapsed) {
+      // Collapsed handle still uses the inner per-platform widgets, which
+      // build their own gesture detectors sized to the (already enlarged)
+      // outer rect.
+      Widget child;
+      if (PlatformExtension.isIOS) {
+        child = _IOSDragHandle(
+          handleHeight: handleHeight,
+          handleColor: handleColor,
+          handleWidth: handleWidth,
+          handleBallWidth: handleBallWidth,
+          handleType: handleType,
+          debugPaintSizeEnabled: debugPaintSizeEnabled,
+          onDragging: onDragging,
+        );
+      } else if (PlatformExtension.isAndroid) {
+        child = _AndroidDragHandle(
+          handleHeight: handleHeight,
+          handleColor: handleColor,
+          handleWidth: handleWidth,
+          handleBallWidth: handleBallWidth,
+          handleType: handleType,
+          debugPaintSizeEnabled: debugPaintSizeEnabled,
+          onDragging: onDragging,
+        );
+      } else {
+        throw UnsupportedError('Unsupported platform');
+      }
+      if (debugPaintSizeEnabled) {
+        child = ColoredBox(
+          color: Colors.red.withValues(alpha: 0.5),
+          child: child,
+        );
+      }
+      return child;
+    }
 
+    return _SelectionDragHandle(
+      handleHeight: handleHeight,
+      handleColor: handleColor,
+      handleWidth: handleWidth,
+      handleBallWidth: handleBallWidth,
+      handleType: handleType,
+      debugPaintSizeEnabled: debugPaintSizeEnabled,
+      onDragging: onDragging,
+    );
+  }
+}
+
+/// Selection (left/right) drag handle. Owns its own gesture detector that
+/// fills the entire outer touch zone (provided by [Positioned.fromRect] in
+/// [MobileSelectionHandle]) and consumes both pans and taps so the editor's
+/// tap recognizer below it cannot collapse the selection while the user is
+/// trying to grab the handle.
+class _SelectionDragHandle extends StatefulWidget {
+  const _SelectionDragHandle({
+    required this.handleHeight,
+    required this.handleColor,
+    required this.handleWidth,
+    required this.handleBallWidth,
+    required this.handleType,
+    required this.debugPaintSizeEnabled,
+    required this.onDragging,
+  });
+
+  final double handleHeight;
+  final Color handleColor;
+  final double handleWidth;
+  final double handleBallWidth;
+  final HandleType handleType;
+  final bool debugPaintSizeEnabled;
+  final ValueChanged<bool>? onDragging;
+
+  @override
+  State<_SelectionDragHandle> createState() => _SelectionDragHandleState();
+}
+
+class _SelectionDragHandleState extends State<_SelectionDragHandle> {
+  Selection? _selection;
+
+  @override
+  Widget build(BuildContext context) {
+    final editorState = context.read<EditorState>();
+
+    Widget visual;
     if (PlatformExtension.isIOS) {
-      child = _IOSDragHandle(
-        handleHeight: handleHeight,
-        handleColor: handleColor,
-        handleWidth: handleWidth,
-        handleBallWidth: handleBallWidth,
-        handleType: handleType,
-        debugPaintSizeEnabled: debugPaintSizeEnabled,
-        onDragging: onDragging,
+      visual = _IOSDragHandleVisual(
+        handleHeight: widget.handleHeight,
+        handleColor: widget.handleColor,
+        handleWidth: widget.handleWidth,
+        handleBallWidth: widget.handleBallWidth,
+        handleType: widget.handleType,
       );
     } else if (PlatformExtension.isAndroid) {
-      child = _AndroidDragHandle(
-        handleHeight: handleHeight,
-        handleColor: handleColor,
-        handleWidth: handleWidth,
-        handleBallWidth: handleBallWidth,
-        handleType: handleType,
-        debugPaintSizeEnabled: debugPaintSizeEnabled,
-        onDragging: onDragging,
+      visual = _AndroidDragHandleVisual(
+        handleColor: widget.handleColor,
+        handleWidth: widget.handleWidth,
+        handleHeight: widget.handleHeight,
+        handleBallWidth: widget.handleBallWidth,
+        handleType: widget.handleType,
       );
     } else {
       throw UnsupportedError('Unsupported platform');
     }
 
-    if (debugPaintSizeEnabled) {
-      child = ColoredBox(
+    if (widget.debugPaintSizeEnabled) {
+      visual = ColoredBox(
         color: Colors.red.withValues(alpha: 0.5),
-        child: child,
+        child: visual,
       );
     }
 
-    if (handleType != HandleType.none && handleType != HandleType.collapsed) {
-      final offset = PlatformExtension.isIOS ? -handleWidth : 0.0;
-      child = Stack(
+    final visualEdgeOffset =
+        PlatformExtension.isIOS ? -widget.handleWidth : 0.0;
+    final ballWidth = widget.handleBallWidth;
+    double dyOffset = 0.0;
+    if (PlatformExtension.isIOS) {
+      if (widget.handleType == HandleType.left) {
+        dyOffset = ballWidth;
+      } else if (widget.handleType == HandleType.right) {
+        dyOffset = -ballWidth;
+      }
+    } else if (PlatformExtension.isAndroid) {
+      dyOffset = -ballWidth * 2;
+    }
+
+    return RawGestureDetector(
+      behavior: HitTestBehavior.opaque,
+      gestures: {
+        PanGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+          () => PanGestureRecognizer(),
+          (recognizer) {
+            recognizer
+              ..dragStartBehavior = DragStartBehavior.down
+              ..onStart = (details) {
+                _selection = editorState.service.selectionService.onPanStart(
+                  details.translate(0, dyOffset),
+                  widget.handleType.dragMode,
+                );
+                widget.onDragging?.call(true);
+              }
+              ..onUpdate = (details) {
+                final newSelection =
+                    editorState.service.selectionService.onPanUpdate(
+                  details.translate(0, dyOffset),
+                  widget.handleType.dragMode,
+                );
+                if (PlatformExtension.isAndroid &&
+                    _selection != newSelection) {
+                  HapticFeedback.selectionClick();
+                }
+                _selection = newSelection;
+                widget.onDragging?.call(true);
+              }
+              ..onEnd = (details) {
+                editorState.service.selectionService.onPanEnd(
+                  details,
+                  widget.handleType.dragMode,
+                );
+                widget.onDragging?.call(false);
+              };
+          },
+        ),
+        // Swallow taps inside the touch zone. The editor's tap recognizer
+        // sits above us in the gesture arena; without this it wins on lift
+        // and collapses the selection back to a caret. We register a no-op
+        // recognizer so the inner (deeper) tap wins instead.
+        TapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+          () => TapGestureRecognizer(),
+          (recognizer) {
+            recognizer.onTap = () {};
+          },
+        ),
+      },
+      child: Stack(
         clipBehavior: Clip.none,
+        fit: StackFit.expand,
         children: [
-          if (handleType == HandleType.left)
-            Positioned(
-              left: offset,
-              child: child,
-            ),
-          if (handleType == HandleType.right)
-            Positioned(
-              right: offset,
-              child: child,
-            ),
+          if (widget.handleType == HandleType.left)
+            Positioned(left: visualEdgeOffset, top: 0, child: visual),
+          if (widget.handleType == HandleType.right)
+            Positioned(right: visualEdgeOffset, top: 0, child: visual),
         ],
-      );
-    }
-
-    return child;
+      ),
+    );
   }
 }
 
@@ -360,6 +495,121 @@ class _AndroidDragHandle extends _IDragHandle {
     );
 
     return child;
+  }
+}
+
+/// Pure visual half of [_IOSDragHandle] used by [_SelectionDragHandle] for
+/// the left/right handles. Mirrors the iOS column layout (ball + bar) without
+/// owning any gesture detection.
+class _IOSDragHandleVisual extends StatelessWidget {
+  const _IOSDragHandleVisual({
+    required this.handleHeight,
+    required this.handleColor,
+    required this.handleWidth,
+    required this.handleBallWidth,
+    required this.handleType,
+  });
+
+  final double handleHeight;
+  final Color handleColor;
+  final double handleWidth;
+  final double handleBallWidth;
+  final HandleType handleType;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (handleType == HandleType.left)
+          Container(
+            width: handleBallWidth,
+            height: handleBallWidth,
+            decoration: BoxDecoration(
+              color: handleColor,
+              shape: BoxShape.circle,
+            ),
+          ),
+        if (handleType == HandleType.right)
+          SizedBox(width: handleBallWidth, height: handleBallWidth),
+        Container(
+          width: handleWidth,
+          color: handleColor,
+          height: handleHeight - 2.0 * handleBallWidth,
+        ),
+        if (handleType == HandleType.right)
+          Container(
+            width: handleBallWidth,
+            height: handleBallWidth,
+            decoration: BoxDecoration(
+              color: handleColor,
+              shape: BoxShape.circle,
+            ),
+          ),
+        if (handleType == HandleType.left)
+          SizedBox(width: handleBallWidth, height: handleBallWidth),
+      ],
+    );
+  }
+}
+
+/// Pure visual half of [_AndroidDragHandle] used by [_SelectionDragHandle] for
+/// the left/right handles. Mirrors the Android column layout (bar + rounded
+/// teardrop ball) without owning any gesture detection.
+class _AndroidDragHandleVisual extends StatelessWidget {
+  const _AndroidDragHandleVisual({
+    required this.handleColor,
+    required this.handleWidth,
+    required this.handleHeight,
+    required this.handleBallWidth,
+    required this.handleType,
+  });
+
+  final Color handleColor;
+  final double handleWidth;
+  final double handleHeight;
+  final double handleBallWidth;
+  final HandleType handleType;
+
+  @override
+  Widget build(BuildContext context) {
+    final ballWidth = handleBallWidth * 2.0;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: handleType.crossAxisAlignment,
+      children: [
+        SizedBox(
+          width: handleWidth,
+          height: handleHeight - 2.0 * handleBallWidth,
+        ),
+        if (handleType == HandleType.left)
+          Container(
+            width: ballWidth,
+            height: ballWidth,
+            decoration: BoxDecoration(
+              color: handleColor,
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(handleBallWidth),
+                bottomLeft: Radius.circular(handleBallWidth),
+                bottomRight: Radius.circular(handleBallWidth),
+              ),
+            ),
+          ),
+        if (handleType == HandleType.right)
+          Container(
+            width: ballWidth,
+            height: ballWidth,
+            decoration: BoxDecoration(
+              color: handleColor,
+              borderRadius: BorderRadius.only(
+                topRight: Radius.circular(handleBallWidth),
+                bottomLeft: Radius.circular(handleBallWidth),
+                bottomRight: Radius.circular(handleBallWidth),
+              ),
+            ),
+          ),
+      ],
+    );
   }
 }
 

--- a/lib/src/render/selection/mobile_selection_handle.dart
+++ b/lib/src/render/selection/mobile_selection_handle.dart
@@ -1,6 +1,14 @@
+import 'dart:math' as math;
+
 import 'package:appflowy_editor/src/editor/util/platform_extension.dart';
 import 'package:appflowy_editor/src/render/selection/mobile_basic_handle.dart';
 import 'package:flutter/material.dart';
+
+// Apple HIG / Material minimum recommended touch target. Used to grow the
+// handle's hit area without changing the visible ball position, so users can
+// grab the drag handle without accidentally tapping the editor below.
+const double _kMinIOSTouchTarget = 44.0;
+const double _kMinAndroidTouchTarget = 48.0;
 
 class MobileSelectionHandle extends StatelessWidget {
   const MobileSelectionHandle({
@@ -38,6 +46,10 @@ class MobileSelectionHandle extends StatelessWidget {
           rect.width + 4 * (handleWidth + threshold),
           rect.height + 2 * handleBallWidth,
         );
+        adjustedRect = _expandToMinTouchTarget(
+          adjustedRect,
+          minSize: _kMinIOSTouchTarget,
+        );
       } else if (PlatformExtension.isAndroid) {
         // on Android, normally the cursor will be hidden if the selection is not collapsed.
         // Extend the click area to make it easier to click.
@@ -48,6 +60,10 @@ class MobileSelectionHandle extends StatelessWidget {
           // Enable clicking in the handle area outside the stack.
           // https://github.com/flutter/flutter/issues/75747
           rect.height + 2 * handleBallWidth,
+        );
+        adjustedRect = _expandToMinTouchTarget(
+          adjustedRect,
+          minSize: _kMinAndroidTouchTarget,
         );
       }
     }
@@ -67,5 +83,31 @@ class MobileSelectionHandle extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  /// Pads [r] outward so that both axes are at least [minSize], anchoring the
+  /// expansion away from the visible handle ball so the ball stays put on
+  /// screen. For the left handle the ball sits at the left of [r], so we grow
+  /// to the right; for the right handle we grow to the left. We always grow
+  /// downward, since the ball lives below the text baseline.
+  Rect _expandToMinTouchTarget(Rect r, {required double minSize}) {
+    final extraW = math.max(0.0, minSize - r.width);
+    final extraH = math.max(0.0, minSize - r.height);
+    if (extraW == 0 && extraH == 0) return r;
+
+    double left = r.left;
+    double width = r.width;
+    if (extraW > 0) {
+      if (handleType == HandleType.left) {
+        // Ball is at r.left, grow rightward.
+        width += extraW;
+      } else {
+        // Ball is at r.right, grow leftward.
+        left -= extraW;
+        width += extraW;
+      }
+    }
+
+    return Rect.fromLTWH(left, r.top, width, r.height + extraH);
   }
 }

--- a/lib/src/render/selection/mobile_selection_handle.dart
+++ b/lib/src/render/selection/mobile_selection_handle.dart
@@ -34,26 +34,22 @@ class MobileSelectionHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(handleType != HandleType.collapsed);
 
-    var adjustedRect = rect;
+    var visualRect = rect;
     if (handleType != HandleType.none) {
       if (PlatformExtension.isIOS) {
         // on iOS, the cursor will still be visible if the selection is not collapsed.
         // So, adding a threshold padding to avoid row overflow.
         const threshold = 0.25;
-        adjustedRect = Rect.fromLTWH(
+        visualRect = Rect.fromLTWH(
           rect.left - 2 * (handleWidth + threshold),
           rect.top - handleBallWidth,
           rect.width + 4 * (handleWidth + threshold),
           rect.height + 2 * handleBallWidth,
         );
-        adjustedRect = _expandToMinTouchTarget(
-          adjustedRect,
-          minSize: _kMinIOSTouchTarget,
-        );
       } else if (PlatformExtension.isAndroid) {
         // on Android, normally the cursor will be hidden if the selection is not collapsed.
         // Extend the click area to make it easier to click.
-        adjustedRect = Rect.fromLTWH(
+        visualRect = Rect.fromLTWH(
           rect.left - 2 * handleBallWidth,
           rect.top,
           rect.width + 4 * handleBallWidth,
@@ -61,23 +57,30 @@ class MobileSelectionHandle extends StatelessWidget {
           // https://github.com/flutter/flutter/issues/75747
           rect.height + 2 * handleBallWidth,
         );
-        adjustedRect = _expandToMinTouchTarget(
-          adjustedRect,
-          minSize: _kMinAndroidTouchTarget,
-        );
       }
     }
 
+    // Touch zone is grown to meet HIG/Material minimum touch targets, but the
+    // visible handle column keeps its original height so the ball stays glued
+    // to the text baseline.
+    Rect touchRect = visualRect;
+    if (handleType != HandleType.none) {
+      final minSize = PlatformExtension.isIOS
+          ? _kMinIOSTouchTarget
+          : _kMinAndroidTouchTarget;
+      touchRect = _expandToMinTouchTarget(visualRect, minSize: minSize);
+    }
+
     return Positioned.fromRect(
-      rect: adjustedRect,
+      rect: touchRect,
       child: CompositedTransformFollower(
         link: layerLink,
-        offset: adjustedRect.topLeft,
+        offset: touchRect.topLeft,
         showWhenUnlinked: false,
         child: DragHandle(
           handleType: handleType,
           handleColor: handleColor,
-          handleHeight: adjustedRect.height,
+          handleHeight: visualRect.height,
           handleWidth: handleWidth,
           handleBallWidth: handleBallWidth,
         ),


### PR DESCRIPTION
Wrap the left/right drag handle in a dedicated _SelectionDragHandle that fills the outer touch rect with its own RawGestureDetector, owns the pan recognizer, and registers a no-op tap recognizer so it wins the gesture arena over the editor's tap recognizer below. This stops a finger lift on the handle from collapsing the selection back to a caret.

Also expand the handle's hit area to the platform minimum touch target (44pt iOS / 48dp Android), anchoring growth away from the visible ball so the ball position is unchanged.