### PR TITLE
fix: preserve node identity during type updates

### DIFF
--- a/lib/src/core/document/diff.dart
+++ b/lib/src/core/document/diff.dart
@@ -10,7 +10,18 @@ List<Operation> diffDocuments(Document oldDocument, Document newDocument) {
 List<Operation> diffNodes(Node oldNode, Node newNode) {
   List<Operation> operations = [];
 
-  if (!_equality.equals(oldNode.attributes, newNode.attributes)) {
+  if (oldNode.type != newNode.type && oldNode.path.isNotEmpty) {
+    operations.add(
+      UpdateNodeTypeOperation(
+        oldNode.path,
+        oldNode.id,
+        newNode.type,
+        oldNode.type,
+        newNode.attributes,
+        oldNode.attributes,
+      ),
+    );
+  } else if (!_equality.equals(oldNode.attributes, newNode.attributes)) {
     operations.add(
       UpdateOperation(oldNode.path, newNode.attributes, oldNode.attributes),
     );

--- a/lib/src/core/document/document.dart
+++ b/lib/src/core/document/document.dart
@@ -178,6 +178,7 @@ class Document {
 
     target.unlink();
     parent.insert(replacement, index: index);
+
     return true;
   }
 

--- a/lib/src/core/document/document.dart
+++ b/lib/src/core/document/document.dart
@@ -153,6 +153,34 @@ class Document {
     return true;
   }
 
+  /// Updates the [Node] type at the given [Path] while preserving its id,
+  /// children, external values, and temporary metadata.
+  bool updateNodeType(Path path, String type, Attributes attributes) {
+    if (path.isEmpty) {
+      return false;
+    }
+
+    final target = nodeAtPath(path);
+    final parent = target?.parent;
+    if (target == null || parent == null) {
+      return false;
+    }
+
+    final index = path.last;
+    final replacement = Node(
+      type: type,
+      id: target.id,
+      attributes: {...attributes},
+      children: target.children.toList(growable: false),
+    )
+      ..externalValues = target.externalValues
+      ..extraInfos = target.extraInfos;
+
+    target.unlink();
+    parent.insert(replacement, index: index);
+    return true;
+  }
+
   /// Updates the [Node] with [Delta] at the given [Path]
   bool updateText(Path path, Delta delta) {
     if (path.isEmpty) {

--- a/lib/src/core/document/node.dart
+++ b/lib/src/core/document/node.dart
@@ -271,19 +271,24 @@ final class Node extends ChangeNotifier with LinkedListEntry<Node> {
   /// Be careful of the children, they will be deep copied if not provided.
   Node copyWith({
     String? type,
+    String? id,
+    bool preserveChildIds = false,
     Iterable<Node>? children,
     Attributes? attributes,
   }) {
     final node = Node(
       type: type ?? this.type,
-      id: nanoid(6),
+      id: id ?? nanoid(6),
       attributes: attributes ?? {...this.attributes},
       children: children ?? [],
     );
     if (children == null && _children.isNotEmpty) {
       for (final child in _children) {
         node._children.add(
-          child.copyWith()..parent = node,
+          child.copyWith(
+            id: preserveChildIds ? child.id : null,
+            preserveChildIds: preserveChildIds,
+          )..parent = node,
         );
       }
     }
@@ -385,16 +390,23 @@ final class TextNode extends Node {
     Attributes? attributes,
     Delta? delta,
     String? id,
+    bool preserveChildIds = false,
   }) {
     final textNode = TextNode(
       children: children ?? [],
       attributes: attributes ?? this.attributes,
       delta: delta ?? this.delta,
     );
+    if (id != null) {
+      textNode.id = id;
+    }
     if (children == null && this.children.isNotEmpty) {
       for (final child in this.children) {
         textNode._children.add(
-          child.copyWith()..parent = textNode,
+          child.copyWith(
+            id: preserveChildIds ? child.id : null,
+            preserveChildIds: preserveChildIds,
+          )..parent = textNode,
         );
       }
     }

--- a/lib/src/core/transform/operation.dart
+++ b/lib/src/core/transform/operation.dart
@@ -201,6 +201,7 @@ class UpdateNodeTypeOperation extends Operation {
     final oldType = json['oldType'] as String;
     final attributes = json['attributes'] as Attributes;
     final oldAttributes = json['oldAttributes'] as Attributes;
+
     return UpdateNodeTypeOperation(
       path,
       nodeId,

--- a/lib/src/core/transform/operation.dart
+++ b/lib/src/core/transform/operation.dart
@@ -182,6 +182,99 @@ class UpdateOperation extends Operation {
       path.hashCode ^ attributes.hashCode ^ oldAttributes.hashCode;
 }
 
+/// [UpdateNodeTypeOperation] changes a node's block type without replacing
+/// the node in the document tree.
+class UpdateNodeTypeOperation extends Operation {
+  const UpdateNodeTypeOperation(
+    super.path,
+    this.nodeId,
+    this.type,
+    this.oldType,
+    this.attributes,
+    this.oldAttributes,
+  );
+
+  factory UpdateNodeTypeOperation.fromJson(Map<String, dynamic> json) {
+    final path = json['path'] as Path;
+    final nodeId = json['nodeId'] as String? ?? '';
+    final type = json['type'] as String;
+    final oldType = json['oldType'] as String;
+    final attributes = json['attributes'] as Attributes;
+    final oldAttributes = json['oldAttributes'] as Attributes;
+    return UpdateNodeTypeOperation(
+      path,
+      nodeId,
+      type,
+      oldType,
+      attributes,
+      oldAttributes,
+    );
+  }
+
+  final String nodeId;
+  final String type;
+  final String oldType;
+  final Attributes attributes;
+  final Attributes oldAttributes;
+
+  @override
+  Operation invert() => UpdateNodeTypeOperation(
+        path,
+        nodeId,
+        oldType,
+        type,
+        oldAttributes,
+        attributes,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'op': 'update_node_type',
+      'path': path,
+      'nodeId': nodeId,
+      'type': type,
+      'oldType': oldType,
+      'attributes': {...attributes},
+      'oldAttributes': {...oldAttributes},
+    };
+  }
+
+  @override
+  Operation copyWith({Path? path}) {
+    return UpdateNodeTypeOperation(
+      path ?? this.path,
+      nodeId,
+      type,
+      oldType,
+      {...attributes},
+      {...oldAttributes},
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is UpdateNodeTypeOperation &&
+        other.path.equals(path) &&
+        other.nodeId == nodeId &&
+        other.type == type &&
+        other.oldType == oldType &&
+        mapEquals(other.attributes, attributes) &&
+        mapEquals(other.oldAttributes, oldAttributes);
+  }
+
+  @override
+  int get hashCode =>
+      path.hashCode ^
+      nodeId.hashCode ^
+      type.hashCode ^
+      oldType.hashCode ^
+      attributes.hashCode ^
+      oldAttributes.hashCode;
+}
+
 /// [UpdateTextOperation] represents a text update operation.
 class UpdateTextOperation extends Operation {
   const UpdateTextOperation(

--- a/lib/src/core/transform/transaction.dart
+++ b/lib/src/core/transform/transaction.dart
@@ -92,6 +92,28 @@ class Transaction {
     );
   }
 
+  /// Updates a node's type while keeping the same node id and children.
+  ///
+  /// Unlike [updateNode], this replaces the node attributes. Block types have
+  /// different data contracts, so carrying old type-specific attributes into
+  /// the new block type would leak stale state.
+  void updateNodeType(
+    Node node,
+    String type,
+    Attributes attributes,
+  ) {
+    add(
+      UpdateNodeTypeOperation(
+        node.path,
+        node.id,
+        type,
+        node.type,
+        {...attributes},
+        {...node.attributes},
+      ),
+    );
+  }
+
   /// Deletes the [Node] in the document.
   void deleteNode(Node node) {
     deleteNodesAtPath(node.path);

--- a/lib/src/editor/block_component/base_component/markdown_format_helper.dart
+++ b/lib/src/editor/block_component/base_component/markdown_format_helper.dart
@@ -111,5 +111,6 @@ bool _hasSameDescendantContent(Node before, Node after) {
       return false;
     }
   }
+
   return true;
 }

--- a/lib/src/editor/block_component/base_component/markdown_format_helper.dart
+++ b/lib/src/editor/block_component/base_component/markdown_format_helper.dart
@@ -1,4 +1,7 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:collection/collection.dart';
+
+const _nodeEquality = DeepCollectionEquality();
 
 /// Formats the current node to specified markdown style.
 ///
@@ -61,17 +64,52 @@ Future<bool> formatMarkdownSymbol(
 
   final formattedNodes = nodesBuilder(text, node, delta);
 
-  // Create a transaction that replaces the current node with the
-  // formatted node.
-  final transaction = editorState.transaction
-    ..insertNodes(
-      node.path,
-      formattedNodes,
-    )
-    ..deleteNode(node)
-    ..afterSelection = afterSelection;
+  final transaction = editorState.transaction;
+  if (_canUpdateNodeTypeInPlace(node, formattedNodes)) {
+    final formattedNode = formattedNodes.single;
+    transaction.updateNodeType(
+      node,
+      formattedNode.type,
+      formattedNode.attributes,
+    );
+  } else {
+    // Create a transaction that replaces the current node with the
+    // formatted node.
+    transaction
+      ..insertNodes(
+        node.path,
+        formattedNodes,
+      )
+      ..deleteNode(node);
+  }
+  transaction.afterSelection = afterSelection;
 
   await editorState.apply(transaction);
 
+  return true;
+}
+
+bool _canUpdateNodeTypeInPlace(Node node, List<Node> formattedNodes) {
+  if (formattedNodes.length != 1) {
+    return false;
+  }
+
+  return _hasSameDescendantContent(node, formattedNodes.single);
+}
+
+bool _hasSameDescendantContent(Node before, Node after) {
+  if (before.children.length != after.children.length) {
+    return false;
+  }
+
+  for (var i = 0; i < before.children.length; i++) {
+    final beforeChild = before.children.elementAt(i);
+    final afterChild = after.children.elementAt(i);
+    if (beforeChild.type != afterChild.type ||
+        !_nodeEquality.equals(beforeChild.attributes, afterChild.attributes) ||
+        !_hasSameDescendantContent(beforeChild, afterChild)) {
+      return false;
+    }
+  }
   return true;
 }

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -735,6 +735,8 @@ class EditorState {
         if (!mapEquals(op.attributes, op.oldAttributes)) {
           document.update(op.path, op.attributes);
         }
+      } else if (op is UpdateNodeTypeOperation) {
+        document.updateNodeType(op.path, op.type, op.attributes);
       } else if (op is DeleteOperation) {
         document.delete(op.path, op.nodes.length);
       } else if (op is UpdateTextOperation) {
@@ -763,6 +765,8 @@ class EditorState {
             );
           }
         }
+      } else if (op is UpdateNodeTypeOperation) {
+        document.updateNodeType(op.path, op.type, op.attributes);
       } else if (op is UpdateOperation) {
         document.update(op.path, op.attributes);
       } else if (op is DeleteOperation) {

--- a/test/core/document/diff_test.dart
+++ b/test/core/document/diff_test.dart
@@ -47,6 +47,39 @@ void main() async {
       );
     });
 
+    test('same id type changes', () async {
+      final id = nanoid(6);
+      final documentA = Document.blank()
+        ..insert([0], [buildNodeWithId(id, 'Hello World')]);
+      final documentB = Document.blank()
+        ..insert([
+          0,
+        ], [
+          Node(
+            type: HeadingBlockKeys.type,
+            id: id,
+            attributes: {
+              HeadingBlockKeys.level: 1,
+              HeadingBlockKeys.delta: (Delta()..insert('Hello World')).toJson(),
+            },
+          ),
+        ]);
+
+      final ops = diffDocuments(documentA, documentB);
+      expect(ops.length, 1);
+      final op = ops.first;
+      expect(op, isA<UpdateNodeTypeOperation>());
+      expect((op as UpdateNodeTypeOperation).nodeId, id);
+      expect(op.path, [0]);
+      expect(op.type, HeadingBlockKeys.type);
+
+      final expectation = jsonEncode(documentB.toJson());
+      expect(
+        jsonEncode((await apply(documentA, ops)).toJson()),
+        expectation,
+      );
+    });
+
     test('insert', () async {
       final id1 = nanoid(6);
       final id2 = nanoid(6);

--- a/test/core/document/node_test.dart
+++ b/test/core/document/node_test.dart
@@ -120,6 +120,27 @@ void main() async {
       expect(identical(node.children.first, base.children.first), false);
     });
 
+    test('copyWith can preserve ids', () {
+      final child = Node(
+        type: 'child',
+        id: 'child-id',
+      );
+      final base = Node(
+        type: 'base',
+        id: 'base-id',
+        children: [child],
+      );
+
+      final node = base.copyWith(
+        id: base.id,
+        preserveChildIds: true,
+      );
+
+      expect(node.id, 'base-id');
+      expect(node.children.first.id, 'child-id');
+      expect(identical(node.children.first, child), false);
+    });
+
     test('test insert', () {
       final base = Node(
         type: 'base',

--- a/test/core/transform/operation_test.dart
+++ b/test/core/transform/operation_test.dart
@@ -72,6 +72,30 @@ void main() async {
       expect(op.copyWith(), op);
     });
 
+    test('test update node type operation', () {
+      const op = UpdateNodeTypeOperation(
+        [0],
+        'node-id',
+        'heading',
+        'paragraph',
+        {'level': 1},
+        {'delta': []},
+      );
+      final json = op.toJson();
+      expect(json, {
+        'op': 'update_node_type',
+        'path': [0],
+        'nodeId': 'node-id',
+        'type': 'heading',
+        'oldType': 'paragraph',
+        'attributes': {'level': 1},
+        'oldAttributes': {'delta': []},
+      });
+      expect(UpdateNodeTypeOperation.fromJson(json), op);
+      expect(op.invert().invert(), op);
+      expect(op.copyWith(), op);
+    });
+
     test('test delete operation', () {
       final node = Node(type: 'example');
       final op = DeleteOperation([0], [node]);


### PR DESCRIPTION
## Summary

Small editor-only change to preserve node identity during safe block type conversions.

Scope is intentionally limited to `appflowy-editor`:
- Add `UpdateNodeTypeOperation` for same-node type/data updates.
- Add `Transaction.updateNodeType` and `Document.updateNodeType`.
- Allow `Node.copyWith` to preserve ids only when explicitly requested.
- Use in-place type updates for markdown shortcut conversions when descendant shape/content is unchanged.
- Emit and apply same-id type diffs from `diffDocuments` / `EditorState`.

## Related GitHub Issues

- AppFlowy-IO/AppFlowy#8704 - document fails to open after toggle lists and images; reports `Failed to apply update: block parent ... Type: 8`.
- AppFlowy-IO/AppFlowy#8649 - same `Type: 8` document-open failure on Linux.
- AppFlowy-IO/AppFlowy#8427 - same failure around the 0.11.0 migration boundary.
- AppFlowy-IO/AppFlowy#8124 - earlier multi-platform document corruption report repaired manually, without a code fix.
- AppFlowy-IO/AppFlowy#8414 - adjacent grid/database update error included in the investigation notes.

## Why

The old markdown conversion path replaced a block with insert+delete even when only the block type changed. That regenerated node ids and made downstream clients treat a type conversion as a structural replacement. Desktop/web integration can use this operation to preserve block identity instead.

## Diff Size

- 10 files changed
- 299 insertions
- 13 deletions
- No desktop, Rust, web, vendored dependency, generated, or lockfile changes

## Verification

- `dart format --output=none --set-exit-if-changed ...`
- `git diff --check origin/main...HEAD`

Could not run targeted Flutter tests locally because this machine uses Flutter 3.27.4 while current `main` requires Flutter >=3.32.0 / `.fvmrc` specifies 3.38.5:

```text
Because appflowy_editor requires Flutter SDK version >=3.32.0, version solving failed.
```