### PR TITLE
fix: preserve node identity during type updates

### DIFF
--- a/lib/src/core/document/diff.dart
+++ b/lib/src/core/document/diff.dart
@@ -10,7 +10,18 @@ List<Operation> diffDocuments(Document oldDocument, Document newDocument) {
 List<Operation> diffNodes(Node oldNode, Node newNode) {
   final List<Operation> operations = [];
 
-  if (!_equality.equals(oldNode.attributes, newNode.attributes)) {
+  if (oldNode.type != newNode.type && oldNode.path.isNotEmpty) {
+    operations.add(
+      UpdateNodeTypeOperation(
+        oldNode.path,
+        oldNode.id,
+        newNode.type,
+        oldNode.type,
+        newNode.attributes,
+        oldNode.attributes,
+      ),
+    );
+  } else if (!_equality.equals(oldNode.attributes, newNode.attributes)) {
     operations.add(
       UpdateOperation(oldNode.path, newNode.attributes, oldNode.attributes),
     );

--- a/lib/src/core/document/document.dart
+++ b/lib/src/core/document/document.dart
@@ -157,6 +157,34 @@ class Document {
     return true;
   }
 
+  /// Updates the [Node] type at the given [Path] while preserving its id,
+  /// children, external values, and temporary metadata.
+  bool updateNodeType(Path path, String type, Attributes attributes) {
+    if (path.isEmpty) {
+      return false;
+    }
+
+    final target = nodeAtPath(path);
+    final parent = target?.parent;
+    if (target == null || parent == null) {
+      return false;
+    }
+
+    final index = path.last;
+    final replacement = Node(
+      type: type,
+      id: target.id,
+      attributes: {...attributes},
+      children: target.children.toList(growable: false),
+    )
+      ..externalValues = target.externalValues
+      ..extraInfos = target.extraInfos;
+
+    target.unlink();
+    parent.insert(replacement, index: index);
+    return true;
+  }
+
   /// Updates the [Node] with [Delta] at the given [Path]
   bool updateText(Path path, Delta delta) {
     if (path.isEmpty) {

--- a/lib/src/core/document/document.dart
+++ b/lib/src/core/document/document.dart
@@ -182,6 +182,7 @@ class Document {
 
     target.unlink();
     parent.insert(replacement, index: index);
+
     return true;
   }
 

--- a/lib/src/core/document/node.dart
+++ b/lib/src/core/document/node.dart
@@ -263,19 +263,24 @@ final class Node extends ChangeNotifier with LinkedListEntry<Node> {
   /// Be careful of the children, they will be deep copied if not provided.
   Node copyWith({
     String? type,
+    String? id,
+    bool preserveChildIds = false,
     Iterable<Node>? children,
     Attributes? attributes,
   }) {
     final node = Node(
       type: type ?? this.type,
-      id: nanoid(6),
+      id: id ?? nanoid(6),
       attributes: attributes ?? {...this.attributes},
       children: children ?? [],
     );
     if (children == null && _children.isNotEmpty) {
       for (final child in _children) {
         node._children.add(
-          child.copyWith()..parent = node,
+          child.copyWith(
+            id: preserveChildIds ? child.id : null,
+            preserveChildIds: preserveChildIds,
+          )..parent = node,
         );
       }
     }
@@ -372,16 +377,23 @@ final class TextNode extends Node {
     Attributes? attributes,
     Delta? delta,
     String? id,
+    bool preserveChildIds = false,
   }) {
     final textNode = TextNode(
       children: children ?? [],
       attributes: attributes ?? this.attributes,
       delta: delta ?? this.delta,
     );
+    if (id != null) {
+      textNode.id = id;
+    }
     if (children == null && this.children.isNotEmpty) {
       for (final child in this.children) {
         textNode._children.add(
-          child.copyWith()..parent = textNode,
+          child.copyWith(
+            id: preserveChildIds ? child.id : null,
+            preserveChildIds: preserveChildIds,
+          )..parent = textNode,
         );
       }
     }

--- a/lib/src/core/transform/operation.dart
+++ b/lib/src/core/transform/operation.dart
@@ -264,13 +264,14 @@ class UpdateNodeTypeOperation extends Operation {
   }
 
   @override
-  int get hashCode =>
-      path.hashCode ^
-      nodeId.hashCode ^
-      type.hashCode ^
-      oldType.hashCode ^
-      attributes.hashCode ^
-      oldAttributes.hashCode;
+  int get hashCode => Object.hash(
+        Object.hashAll(path),
+        nodeId,
+        type,
+        oldType,
+        hashAttributes(attributes),
+        hashAttributes(oldAttributes),
+      );
 }
 
 /// [UpdateTextOperation] represents a text update operation.

--- a/lib/src/core/transform/operation.dart
+++ b/lib/src/core/transform/operation.dart
@@ -198,6 +198,7 @@ class UpdateNodeTypeOperation extends Operation {
     final oldType = json['oldType'] as String;
     final attributes = json['attributes'] as Attributes;
     final oldAttributes = json['oldAttributes'] as Attributes;
+
     return UpdateNodeTypeOperation(
       path,
       nodeId,

--- a/lib/src/core/transform/operation.dart
+++ b/lib/src/core/transform/operation.dart
@@ -179,6 +179,99 @@ class UpdateOperation extends Operation {
       path.hashCode ^ attributes.hashCode ^ oldAttributes.hashCode;
 }
 
+/// [UpdateNodeTypeOperation] changes a node's block type without replacing
+/// the node in the document tree.
+class UpdateNodeTypeOperation extends Operation {
+  const UpdateNodeTypeOperation(
+    super.path,
+    this.nodeId,
+    this.type,
+    this.oldType,
+    this.attributes,
+    this.oldAttributes,
+  );
+
+  factory UpdateNodeTypeOperation.fromJson(Map<String, dynamic> json) {
+    final path = json['path'] as Path;
+    final nodeId = json['nodeId'] as String? ?? '';
+    final type = json['type'] as String;
+    final oldType = json['oldType'] as String;
+    final attributes = json['attributes'] as Attributes;
+    final oldAttributes = json['oldAttributes'] as Attributes;
+    return UpdateNodeTypeOperation(
+      path,
+      nodeId,
+      type,
+      oldType,
+      attributes,
+      oldAttributes,
+    );
+  }
+
+  final String nodeId;
+  final String type;
+  final String oldType;
+  final Attributes attributes;
+  final Attributes oldAttributes;
+
+  @override
+  Operation invert() => UpdateNodeTypeOperation(
+        path,
+        nodeId,
+        oldType,
+        type,
+        oldAttributes,
+        attributes,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'op': 'update_node_type',
+      'path': path,
+      'nodeId': nodeId,
+      'type': type,
+      'oldType': oldType,
+      'attributes': {...attributes},
+      'oldAttributes': {...oldAttributes},
+    };
+  }
+
+  @override
+  Operation copyWith({Path? path}) {
+    return UpdateNodeTypeOperation(
+      path ?? this.path,
+      nodeId,
+      type,
+      oldType,
+      {...attributes},
+      {...oldAttributes},
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is UpdateNodeTypeOperation &&
+        other.path.equals(path) &&
+        other.nodeId == nodeId &&
+        other.type == type &&
+        other.oldType == oldType &&
+        mapEquals(other.attributes, attributes) &&
+        mapEquals(other.oldAttributes, oldAttributes);
+  }
+
+  @override
+  int get hashCode =>
+      path.hashCode ^
+      nodeId.hashCode ^
+      type.hashCode ^
+      oldType.hashCode ^
+      attributes.hashCode ^
+      oldAttributes.hashCode;
+}
+
 /// [UpdateTextOperation] represents a text update operation.
 class UpdateTextOperation extends Operation {
   const UpdateTextOperation(

--- a/lib/src/core/transform/transaction.dart
+++ b/lib/src/core/transform/transaction.dart
@@ -91,6 +91,28 @@ class Transaction {
     );
   }
 
+  /// Updates a node's type while keeping the same node id and children.
+  ///
+  /// Unlike [updateNode], this replaces the node attributes. Block types have
+  /// different data contracts, so carrying old type-specific attributes into
+  /// the new block type would leak stale state.
+  void updateNodeType(
+    Node node,
+    String type,
+    Attributes attributes,
+  ) {
+    add(
+      UpdateNodeTypeOperation(
+        node.path,
+        node.id,
+        type,
+        node.type,
+        {...attributes},
+        {...node.attributes},
+      ),
+    );
+  }
+
   /// Deletes the [Node] in the document.
   void deleteNode(Node node) {
     deleteNodesAtPath(node.path);

--- a/lib/src/editor/block_component/base_component/markdown_format_helper.dart
+++ b/lib/src/editor/block_component/base_component/markdown_format_helper.dart
@@ -1,4 +1,7 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:collection/collection.dart';
+
+const _nodeEquality = DeepCollectionEquality();
 
 /// Formats the current node to specified markdown style.
 ///
@@ -60,16 +63,51 @@ Future<bool> formatMarkdownSymbol(
 
   final formattedNodes = nodesBuilder(text, node, delta);
 
-  // Create a transaction that replaces the current node with the
-  // formatted node.
-  final transaction = editorState.transaction
-    ..insertNodes(
-      node.path,
-      formattedNodes,
-    )
-    ..deleteNode(node)
-    ..afterSelection = afterSelection;
+  final transaction = editorState.transaction;
+  if (_canUpdateNodeTypeInPlace(node, formattedNodes)) {
+    final formattedNode = formattedNodes.single;
+    transaction.updateNodeType(
+      node,
+      formattedNode.type,
+      formattedNode.attributes,
+    );
+  } else {
+    // Create a transaction that replaces the current node with the
+    // formatted node.
+    transaction
+      ..insertNodes(
+        node.path,
+        formattedNodes,
+      )
+      ..deleteNode(node);
+  }
+  transaction.afterSelection = afterSelection;
 
   await editorState.apply(transaction);
+  return true;
+}
+
+bool _canUpdateNodeTypeInPlace(Node node, List<Node> formattedNodes) {
+  if (formattedNodes.length != 1) {
+    return false;
+  }
+
+  return _hasSameDescendantContent(node, formattedNodes.single);
+}
+
+bool _hasSameDescendantContent(Node before, Node after) {
+  if (before.children.length != after.children.length) {
+    return false;
+  }
+
+  for (var i = 0; i < before.children.length; i++) {
+    final beforeChild = before.children.elementAt(i);
+    final afterChild = after.children.elementAt(i);
+    if (beforeChild.type != afterChild.type ||
+        !_nodeEquality.equals(beforeChild.attributes, afterChild.attributes) ||
+        !_hasSameDescendantContent(beforeChild, afterChild)) {
+      return false;
+    }
+  }
   return true;
 }

--- a/lib/src/editor/block_component/base_component/markdown_format_helper.dart
+++ b/lib/src/editor/block_component/base_component/markdown_format_helper.dart
@@ -109,5 +109,6 @@ bool _hasSameDescendantContent(Node before, Node after) {
       return false;
     }
   }
+
   return true;
 }

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -741,7 +741,7 @@ class EditorState {
           document.update(op.path, op.attributes);
         }
       } else if (op is UpdateNodeTypeOperation) {
-        document.updateNodeType(op.path, op.type, op.attributes);
+        _applyUpdateNodeTypeOperation(op);
       } else if (op is DeleteOperation) {
         document.delete(op.path, op.nodes.length);
       } else if (op is UpdateTextOperation) {
@@ -771,7 +771,7 @@ class EditorState {
           }
         }
       } else if (op is UpdateNodeTypeOperation) {
-        document.updateNodeType(op.path, op.type, op.attributes);
+        _applyUpdateNodeTypeOperation(op);
       } else if (op is UpdateOperation) {
         document.update(op.path, op.attributes);
       } else if (op is DeleteOperation) {
@@ -794,5 +794,33 @@ class EditorState {
     }
 
     return selection;
+  }
+
+  bool _applyUpdateNodeTypeOperation(UpdateNodeTypeOperation op) {
+    final node = _resolveUpdateNodeTypeTarget(op);
+    if (node == null) {
+      return false;
+    }
+
+    return document.updateNodeType(node.path, op.type, op.attributes);
+  }
+
+  Node? _resolveUpdateNodeTypeTarget(UpdateNodeTypeOperation op) {
+    final pathNode = document.nodeAtPath(op.path);
+    if (op.nodeId.isEmpty || pathNode?.id == op.nodeId) {
+      return pathNode;
+    }
+
+    final iterator = NodeIterator(
+      document: document,
+      startNode: document.root,
+    );
+    while (iterator.moveNext()) {
+      if (iterator.current.id == op.nodeId) {
+        return iterator.current;
+      }
+    }
+
+    return null;
   }
 }

--- a/lib/src/editor_state.dart
+++ b/lib/src/editor_state.dart
@@ -740,6 +740,8 @@ class EditorState {
         if (!mapEquals(op.attributes, op.oldAttributes)) {
           document.update(op.path, op.attributes);
         }
+      } else if (op is UpdateNodeTypeOperation) {
+        document.updateNodeType(op.path, op.type, op.attributes);
       } else if (op is DeleteOperation) {
         document.delete(op.path, op.nodes.length);
       } else if (op is UpdateTextOperation) {
@@ -768,6 +770,8 @@ class EditorState {
             );
           }
         }
+      } else if (op is UpdateNodeTypeOperation) {
+        document.updateNodeType(op.path, op.type, op.attributes);
       } else if (op is UpdateOperation) {
         document.update(op.path, op.attributes);
       } else if (op is DeleteOperation) {

--- a/test/core/document/diff_test.dart
+++ b/test/core/document/diff_test.dart
@@ -46,6 +46,39 @@ void main() async {
       );
     });
 
+    test('same id type changes', () async {
+      final id = nanoid(6);
+      final documentA = Document.blank()
+        ..insert([0], [buildNodeWithId(id, 'Hello World')]);
+      final documentB = Document.blank()
+        ..insert([
+          0,
+        ], [
+          Node(
+            type: HeadingBlockKeys.type,
+            id: id,
+            attributes: {
+              HeadingBlockKeys.level: 1,
+              HeadingBlockKeys.delta: (Delta()..insert('Hello World')).toJson(),
+            },
+          ),
+        ]);
+
+      final ops = diffDocuments(documentA, documentB);
+      expect(ops.length, 1);
+      final op = ops.first;
+      expect(op, isA<UpdateNodeTypeOperation>());
+      expect((op as UpdateNodeTypeOperation).nodeId, id);
+      expect(op.path, [0]);
+      expect(op.type, HeadingBlockKeys.type);
+
+      final expectation = jsonEncode(documentB.toJson());
+      expect(
+        jsonEncode((await apply(documentA, ops)).toJson()),
+        expectation,
+      );
+    });
+
     test('insert', () async {
       final id1 = nanoid(6);
       final id2 = nanoid(6);

--- a/test/core/document/node_test.dart
+++ b/test/core/document/node_test.dart
@@ -120,6 +120,27 @@ void main() async {
       expect(identical(node.children.first, base.children.first), false);
     });
 
+    test('copyWith can preserve ids', () {
+      final child = Node(
+        type: 'child',
+        id: 'child-id',
+      );
+      final base = Node(
+        type: 'base',
+        id: 'base-id',
+        children: [child],
+      );
+
+      final node = base.copyWith(
+        id: base.id,
+        preserveChildIds: true,
+      );
+
+      expect(node.id, 'base-id');
+      expect(node.children.first.id, 'child-id');
+      expect(identical(node.children.first, child), false);
+    });
+
     test('test insert', () {
       final base = Node(
         type: 'base',

--- a/test/core/transform/operation_test.dart
+++ b/test/core/transform/operation_test.dart
@@ -96,6 +96,29 @@ void main() async {
       expect(op.copyWith(), op);
     });
 
+    test('UpdateNodeTypeOperation hashCode matches equality', () {
+      final op1 = UpdateNodeTypeOperation(
+        [0],
+        'node-id',
+        'heading',
+        'paragraph',
+        {'level': 1},
+        {'delta': 'text'},
+      );
+      final op2 = UpdateNodeTypeOperation(
+        [0],
+        'node-id',
+        'heading',
+        'paragraph',
+        {'level': 1},
+        {'delta': 'text'},
+      );
+
+      expect(op1, op2);
+      expect(op1.hashCode, op2.hashCode);
+      expect({op1}.contains(op2), true);
+    });
+
     test('test delete operation', () {
       final node = Node(type: 'example');
       final op = DeleteOperation([0], [node]);

--- a/test/core/transform/operation_test.dart
+++ b/test/core/transform/operation_test.dart
@@ -72,6 +72,30 @@ void main() async {
       expect(op.copyWith(), op);
     });
 
+    test('test update node type operation', () {
+      const op = UpdateNodeTypeOperation(
+        [0],
+        'node-id',
+        'heading',
+        'paragraph',
+        {'level': 1},
+        {'delta': []},
+      );
+      final json = op.toJson();
+      expect(json, {
+        'op': 'update_node_type',
+        'path': [0],
+        'nodeId': 'node-id',
+        'type': 'heading',
+        'oldType': 'paragraph',
+        'attributes': {'level': 1},
+        'oldAttributes': {'delta': []},
+      });
+      expect(UpdateNodeTypeOperation.fromJson(json), op);
+      expect(op.invert().invert(), op);
+      expect(op.copyWith(), op);
+    });
+
     test('test delete operation', () {
       final node = Node(type: 'example');
       final op = DeleteOperation([0], [node]);

--- a/test/core/transform/transaction_test.dart
+++ b/test/core/transform/transaction_test.dart
@@ -65,6 +65,9 @@ void main() async {
     });
 
     test('remote updateNodeType resolves stale path by node id', () async {
+      // Remote type updates may be queued with an old path. In that case the
+      // node id is the stable identity and must win over the stale path, or the
+      // update can convert a newly inserted sibling by mistake.
       final inserted = paragraphNode(text: 'inserted')..id = 'inserted-id';
       final target = paragraphNode(text: 'target')..id = 'target-id';
       final document = Document.blank()..insert([0], [inserted, target]);
@@ -94,6 +97,8 @@ void main() async {
 
     test('remote updateNodeType skips stale path when node id is missing',
         () async {
+      // If the stable node id cannot be found, the operation should be ignored.
+      // Applying it to the stale path would mutate the wrong block.
       final inserted = paragraphNode(text: 'inserted')..id = 'inserted-id';
       final document = Document.blank()..insert([0], [inserted]);
       final editorState = EditorState(document: document);
@@ -120,6 +125,8 @@ void main() async {
 
     test('updateNodeType undo and redo preserve identity and children',
         () async {
+      // Same-shape type updates keep the block in place. Undo/redo must only
+      // switch type/data and must not regenerate the parent or child ids.
       final child = paragraphNode(text: 'child')..id = 'child-id';
       final node = paragraphNode(
         text: 'parent',

--- a/test/core/transform/transaction_test.dart
+++ b/test/core/transform/transaction_test.dart
@@ -64,6 +64,97 @@ void main() async {
       expect(editorState.document.last!.type, 'paragraph-2');
     });
 
+    test('remote updateNodeType resolves stale path by node id', () async {
+      final inserted = paragraphNode(text: 'inserted')..id = 'inserted-id';
+      final target = paragraphNode(text: 'target')..id = 'target-id';
+      final document = Document.blank()..insert([0], [inserted, target]);
+      final editorState = EditorState(document: document);
+      final transaction = editorState.transaction
+        ..add(
+          UpdateNodeTypeOperation(
+            [0],
+            target.id,
+            HeadingBlockKeys.type,
+            ParagraphBlockKeys.type,
+            {
+              HeadingBlockKeys.level: 1,
+              HeadingBlockKeys.delta: target.delta!.toJson(),
+            },
+            target.attributes,
+          ),
+        );
+
+      await editorState.apply(transaction, isRemote: true);
+
+      expect(editorState.getNodeAtPath([0])!.id, inserted.id);
+      expect(editorState.getNodeAtPath([0])!.type, ParagraphBlockKeys.type);
+      expect(editorState.getNodeAtPath([1])!.id, target.id);
+      expect(editorState.getNodeAtPath([1])!.type, HeadingBlockKeys.type);
+    });
+
+    test('remote updateNodeType skips stale path when node id is missing',
+        () async {
+      final inserted = paragraphNode(text: 'inserted')..id = 'inserted-id';
+      final document = Document.blank()..insert([0], [inserted]);
+      final editorState = EditorState(document: document);
+      final transaction = editorState.transaction
+        ..add(
+          UpdateNodeTypeOperation(
+            [0],
+            'missing-id',
+            HeadingBlockKeys.type,
+            ParagraphBlockKeys.type,
+            {
+              HeadingBlockKeys.level: 1,
+              HeadingBlockKeys.delta: inserted.delta!.toJson(),
+            },
+            inserted.attributes,
+          ),
+        );
+
+      await editorState.apply(transaction, isRemote: true);
+
+      expect(editorState.getNodeAtPath([0])!.id, inserted.id);
+      expect(editorState.getNodeAtPath([0])!.type, ParagraphBlockKeys.type);
+    });
+
+    test('updateNodeType undo and redo preserve identity and children',
+        () async {
+      final child = paragraphNode(text: 'child')..id = 'child-id';
+      final node = paragraphNode(
+        text: 'parent',
+        children: [child],
+      )..id = 'parent-id';
+      final document = Document.blank()..insert([0], [node]);
+      final editorState = EditorState(document: document);
+      final transaction = editorState.transaction
+        ..updateNodeType(
+          node,
+          BulletedListBlockKeys.type,
+          {
+            BulletedListBlockKeys.delta: node.delta!.toJson(),
+          },
+        );
+
+      await editorState.apply(transaction, skipHistoryDebounce: true);
+
+      expect(editorState.getNodeAtPath([0])!.id, 'parent-id');
+      expect(editorState.getNodeAtPath([0])!.type, BulletedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children.first.id, 'child-id');
+
+      editorState.undoManager.undo();
+
+      expect(editorState.getNodeAtPath([0])!.id, 'parent-id');
+      expect(editorState.getNodeAtPath([0])!.type, ParagraphBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children.first.id, 'child-id');
+
+      editorState.undoManager.redo();
+
+      expect(editorState.getNodeAtPath([0])!.id, 'parent-id');
+      expect(editorState.getNodeAtPath([0])!.type, BulletedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children.first.id, 'child-id');
+    });
+
     test('toJson', () {
       final beforeSelection = Selection.collapsed(Position(path: [0]));
       final afterSelection =

--- a/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
+++ b/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
@@ -148,5 +148,117 @@ void main() async {
         ),
       );
     });
+
+    test('paragraph to heading preserves id through undo and redo', () async {
+      const syntax = '#';
+      const text = 'Welcome to AppFlowy Editor 🔥!';
+      final node = paragraphNode(text: '$syntax$text')..id = 'paragraph-id';
+      final document = Document.blank()..insert([0], [node]);
+      final editorState = EditorState(document: document);
+      editorState.selection = Selection.collapsed(
+        Position(path: [0], offset: syntax.length),
+      );
+
+      final result = await formatSignToHeading.execute(editorState);
+
+      expect(result, true);
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'paragraph-id');
+      expect(editorState.getNodeAtPath([0])!.type, HeadingBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.delta!.toPlainText(), text);
+
+      editorState.undoManager.undo();
+
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'paragraph-id');
+      expect(editorState.getNodeAtPath([0])!.type, ParagraphBlockKeys.type);
+      expect(
+        editorState.getNodeAtPath([0])!.delta!.toPlainText(),
+        '$syntax$text',
+      );
+
+      editorState.undoManager.redo();
+
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'paragraph-id');
+      expect(editorState.getNodeAtPath([0])!.type, HeadingBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.delta!.toPlainText(), text);
+    });
+
+    test('convert numbered_list to heading flattens children', () async {
+      const syntax = '#';
+      const text = 'Welcome to AppFlowy Editor 🔥!';
+      await testFormatCharacterShortcut(
+        formatSignToHeading,
+        syntax,
+        syntax.length,
+        (result, before, after, editorState) {
+          expect(result, true);
+          expect(after.delta!.toPlainText(), text);
+          expect(after.type, HeadingBlockKeys.type);
+          expect(after.attributes[HeadingBlockKeys.level], 1);
+          expect(after.children.isEmpty, true);
+          expect(after.next!.delta!.toPlainText(), '1 $text');
+          expect(after.next!.type, NumberedListBlockKeys.type);
+          expect(after.next!.next!.delta!.toPlainText(), '2 $text');
+          expect(after.next!.next!.type, NumberedListBlockKeys.type);
+        },
+        node: numberedListNode(
+          delta: Delta()..insert('$syntax$text'),
+          children: [
+            numberedListNode(delta: Delta()..insert('1 $text')),
+            numberedListNode(delta: Delta()..insert('2 $text')),
+          ],
+        ),
+      );
+    });
+
+    test('undo and redo numbered_list to heading child flattening', () async {
+      const syntax = '#';
+      const text = 'Welcome to AppFlowy Editor 🔥!';
+      final child1 = numberedListNode(delta: Delta()..insert('1 $text'))
+        ..id = 'child-1';
+      final child2 = numberedListNode(delta: Delta()..insert('2 $text'))
+        ..id = 'child-2';
+      final node = numberedListNode(
+        delta: Delta()..insert('$syntax$text'),
+        children: [child1, child2],
+      )..id = 'parent';
+      final document = Document.blank()..insert([0], [node]);
+      final editorState = EditorState(document: document);
+      editorState.selection = Selection.collapsed(
+        Position(path: [0], offset: syntax.length),
+      );
+
+      final result = await formatSignToHeading.execute(editorState);
+
+      expect(result, true);
+      expect(editorState.document.root.children.length, 3);
+      expect(editorState.getNodeAtPath([0])!.type, HeadingBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children, isEmpty);
+      expect(editorState.getNodeAtPath([1])!.type, NumberedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([2])!.type, NumberedListBlockKeys.type);
+
+      editorState.undoManager.undo();
+
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'parent');
+      expect(editorState.getNodeAtPath([0])!.type, NumberedListBlockKeys.type);
+      expect(
+          editorState.getNodeAtPath([0])!.delta!.toPlainText(), '$syntax$text');
+      expect(editorState.getNodeAtPath([0])!.children.length, 2);
+      expect(editorState.getNodeAtPath([0, 0])!.id, 'child-1');
+      expect(editorState.getNodeAtPath([0, 1])!.id, 'child-2');
+
+      editorState.undoManager.redo();
+
+      expect(editorState.document.root.children.length, 3);
+      expect(editorState.getNodeAtPath([0])!.type, HeadingBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children, isEmpty);
+      expect(editorState.getNodeAtPath([1])!.type, NumberedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([1])!.delta!.toPlainText(), '1 $text');
+      expect(editorState.getNodeAtPath([2])!.type, NumberedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([2])!.delta!.toPlainText(), '2 $text');
+    });
   });
 }

--- a/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
+++ b/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
@@ -253,7 +253,9 @@ void main() async {
       expect(editorState.getNodeAtPath([0])!.id, 'parent');
       expect(editorState.getNodeAtPath([0])!.type, NumberedListBlockKeys.type);
       expect(
-          editorState.getNodeAtPath([0])!.delta!.toPlainText(), '$syntax$text');
+        editorState.getNodeAtPath([0])!.delta!.toPlainText(),
+        '$syntax$text',
+      );
       expect(editorState.getNodeAtPath([0])!.children.length, 2);
       expect(editorState.getNodeAtPath([0, 0])!.id, 'child-1');
       expect(editorState.getNodeAtPath([0, 1])!.id, 'child-2');

--- a/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
+++ b/test/new/block_component/heading_block_component/heading_character_shortcut_test.dart
@@ -150,6 +150,8 @@ void main() async {
     });
 
     test('paragraph to heading preserves id through undo and redo', () async {
+      // No children: this is the safe in-place path. The markdown shortcut
+      // should change the type to heading without replacing the node id.
       const syntax = '#';
       const text = 'Welcome to AppFlowy Editor 🔥!';
       final node = paragraphNode(text: '$syntax$text')..id = 'paragraph-id';
@@ -186,6 +188,9 @@ void main() async {
     });
 
     test('convert numbered_list to heading flattens children', () async {
+      // Historical AppFlowy PR #6516 covered this corner case: heading blocks
+      // cannot contain children, so nested list children must be flattened into
+      // siblings instead of being preserved inside the converted heading.
       const syntax = '#';
       const text = 'Welcome to AppFlowy Editor 🔥!';
       await testFormatCharacterShortcut(
@@ -214,6 +219,9 @@ void main() async {
     });
 
     test('undo and redo numbered_list to heading child flattening', () async {
+      // The same historical report also called out undo risk. The fallback
+      // insert/delete path must undo back to one nested list and redo back to a
+      // childless heading followed by flattened list siblings.
       const syntax = '#';
       const text = 'Welcome to AppFlowy Editor 🔥!';
       final child1 = numberedListNode(delta: Delta()..insert('1 $text'))

--- a/test/new/block_component/numbered_list_block_component/numbered_list_character_shortcut_test.dart
+++ b/test/new/block_component/numbered_list_block_component/numbered_list_character_shortcut_test.dart
@@ -204,6 +204,55 @@ void main() async {
       );
     });
 
+    test(
+        'nested todo_list to numbered_list preserves ids through undo and redo',
+        () async {
+      const syntax = '1.';
+      const text = 'Welcome to AppFlowy Editor 🔥!';
+      final child1 = todoListNode(text: '1 $text', checked: false)
+        ..id = 'child-1';
+      final child2 = todoListNode(text: '2 $text', checked: false)
+        ..id = 'child-2';
+      final node = todoListNode(
+        text: '$syntax$text',
+        checked: false,
+        children: [child1, child2],
+      )..id = 'parent';
+      final document = Document.blank()..insert([0], [node]);
+      final editorState = EditorState(document: document);
+      editorState.selection = Selection.collapsed(
+        Position(path: [0], offset: syntax.length),
+      );
+
+      final result = await formatNumberToNumberedList.execute(editorState);
+
+      expect(result, true);
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'parent');
+      expect(editorState.getNodeAtPath([0])!.type, NumberedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children.length, 2);
+      expect(editorState.getNodeAtPath([0, 0])!.id, 'child-1');
+      expect(editorState.getNodeAtPath([0, 1])!.id, 'child-2');
+
+      editorState.undoManager.undo();
+
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'parent');
+      expect(editorState.getNodeAtPath([0])!.type, TodoListBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children.length, 2);
+      expect(editorState.getNodeAtPath([0, 0])!.id, 'child-1');
+      expect(editorState.getNodeAtPath([0, 1])!.id, 'child-2');
+
+      editorState.undoManager.redo();
+
+      expect(editorState.document.root.children.length, 1);
+      expect(editorState.getNodeAtPath([0])!.id, 'parent');
+      expect(editorState.getNodeAtPath([0])!.type, NumberedListBlockKeys.type);
+      expect(editorState.getNodeAtPath([0])!.children.length, 2);
+      expect(editorState.getNodeAtPath([0, 0])!.id, 'child-1');
+      expect(editorState.getNodeAtPath([0, 1])!.id, 'child-2');
+    });
+
     test('nothing will happen when converting heading to numbered list',
         () async {
       const syntax = '1.';

--- a/test/new/block_component/numbered_list_block_component/numbered_list_character_shortcut_test.dart
+++ b/test/new/block_component/numbered_list_block_component/numbered_list_character_shortcut_test.dart
@@ -207,6 +207,9 @@ void main() async {
     test(
         'nested todo_list to numbered_list preserves ids through undo and redo',
         () async {
+      // Unlike heading, numbered lists can keep the same child shape. This
+      // covers the safe in-place path for nested blocks and verifies undo/redo
+      // does not regenerate parent or child ids.
       const syntax = '1.';
       const text = 'Welcome to AppFlowy Editor 🔥!';
       final child1 = todoListNode(text: '1 $text', checked: false)


### PR DESCRIPTION
## Summary

Small editor-only change to preserve node identity during safe block type conversions.

Scope is intentionally limited to `appflowy-editor`:
- Add `UpdateNodeTypeOperation` for same-node type/data updates.
- Add `Transaction.updateNodeType` and `Document.updateNodeType`.
- Allow `Node.copyWith` to preserve ids only when explicitly requested.
- Use in-place type updates for markdown shortcut conversions when descendant shape/content is unchanged.
- Emit and apply same-id type diffs from `diffDocuments` / `EditorState`.
- Resolve same-id type updates by stable node id when the operation path is stale.

## Related GitHub Issues

- AppFlowy-IO/AppFlowy#8704 - document fails to open after toggle lists and images; reports `Failed to apply update: block parent ... Type: 8`.
- AppFlowy-IO/AppFlowy#8649 - same `Type: 8` document-open failure on Linux.
- AppFlowy-IO/AppFlowy#8427 - same failure around the 0.11.0 migration boundary.
- AppFlowy-IO/AppFlowy#8124 - earlier multi-platform document corruption report repaired manually, without a code fix.
- AppFlowy-IO/AppFlowy#8414 - adjacent grid/database update error included in the investigation notes.

## Why

The old markdown conversion path replaced a block with insert+delete even when only the block type changed. That regenerated node ids and made downstream clients treat a type conversion as a structural replacement. Desktop/web integration can use this operation to preserve block identity instead.

The user-reported historical context from AppFlowy PR #6516 was also checked before adding coverage. That earlier fix showed two important constraints:
- Conversions into childless block types, such as heading, must flatten nested children instead of keeping them inside the converted block.
- Undo/redo must be verified for both same-id conversions and flattening conversions.

## Test Coverage

Core operation/document coverage:
- `UpdateNodeTypeOperation` serialization, inversion, copy, equality, and hash consistency.
- `Document.updateNodeType` / `Transaction.updateNodeType` preserve node id, children, external values, and metadata.
- `diffDocuments` emits `UpdateNodeTypeOperation` for same-id type changes.
- Remote/local apply handles `UpdateNodeTypeOperation`.
- Stale-path type updates resolve by `nodeId` instead of mutating the wrong path.
- Missing `nodeId` targets are skipped instead of applying to a stale path.
- Undo/redo for `UpdateNodeTypeOperation` preserves parent and child ids.

Markdown conversion coverage:
- Safe no-child conversion: `paragraph -> heading` preserves node id through undo/redo.
- Safe same-shape nested conversion: nested `todo_list -> numbered_list` preserves parent and child ids through undo/redo.
- Childless target conversion: nested `numbered_list -> heading` flattens children into siblings.
- Flattening undo/redo: undo restores the original nested numbered list, redo reapplies the heading plus flattened sibling list items.
- Existing nested `bulleted_list -> heading` flattening behavior remains covered.

## Diff Size

- 13 files changed
- 606 insertions
- 13 deletions
- No desktop, Rust, web, vendored dependency, generated, or lockfile changes

## Verification

- `dart format --output=none --set-exit-if-changed ...`
- `git diff --check`
- `flutter test test/core/transform/operation_test.dart test/core/transform/transaction_test.dart test/new/block_component/heading_block_component/heading_character_shortcut_test.dart test/new/block_component/numbered_list_block_component/numbered_list_character_shortcut_test.dart`