### PR TITLE
fix: implement TextInputClient.onFocusReceived for Flutter 3.44 compat

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_service.dart
@@ -19,6 +19,12 @@ class DeltaTextInputService extends TextInputService with DeltaTextInputClient {
   @override
   bool get attached => _textInputConnection?.attached ?? false;
 
+  // Added in Flutter 3.44 (TextInputClient.onFocusReceived).
+  // Returning `attached` signals that focus was handled whenever an IME
+  // connection is active. Default implementation returns false.
+  @override
+  bool onFocusReceived() => attached;
+
   @override
   AutofillScope? get currentAutofillScope => throw UnimplementedError();
 

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -26,6 +26,12 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
   @override
   bool get attached => _textInputConnection?.attached ?? false;
 
+  // Added in Flutter 3.44 (TextInputClient.onFocusReceived).
+  // Returning `attached` signals that focus was handled whenever an IME
+  // connection is active. Default implementation returns false.
+  @override
+  bool onFocusReceived() => attached;
+
   @override
   AutofillScope? get currentAutofillScope => throw UnimplementedError();
 


### PR DESCRIPTION
Flutter 3.44 added a new required onFocusReceived method to TextInputClient (flutter/flutter#text_input.dart). Without an implementation, every project on Flutter 3.44+ fails to compile with:

  Error: The non-abstract class '<DeltaTextInputService|NonDeltaTextInputService>'
  is missing implementations for these members:
   - TextInputClient.onFocusReceived

This adds the override in both TextInputService subclasses (delta and non-delta), returning the existing 'attached' state so focus is acknowledged whenever an IME connection is held.

Closes #1204