### PR TITLE
Fix numbered list markers in markdown export

### DIFF
--- a/lib/src/plugins/markdown/encoder/document_markdown_encoder.dart
+++ b/lib/src/plugins/markdown/encoder/document_markdown_encoder.dart
@@ -11,11 +11,39 @@ class DocumentMarkdownEncoder extends Converter<Document, String> {
 
   final List<NodeParser> parsers;
   final String lineBreak;
+  final Map<String, int> _numberedListNumbers = {};
+
+  int? numberedListNumberFor(Node node) => _numberedListNumbers[node.id];
+
+  int _numberedListStartFor(Node node, int fallback) {
+    final number = node.attributes[NumberedListBlockKeys.number];
+    if (number is int) {
+      return number;
+    }
+    if (number is String) {
+      return int.tryParse(number) ?? fallback;
+    }
+    return fallback;
+  }
 
   @override
   String convert(Document input) {
     final buffer = StringBuffer();
+    var nextNumberedListNumber = 1;
+    var previousWasNumberedList = false;
     for (final node in input.root.children) {
+      if (node.type == NumberedListBlockKeys.type) {
+        final number = previousWasNumberedList
+            ? nextNumberedListNumber
+            : _numberedListStartFor(node, 1);
+        _numberedListNumbers[node.id] = number;
+        nextNumberedListNumber = number + 1;
+        previousWasNumberedList = true;
+      } else {
+        nextNumberedListNumber = 1;
+        previousWasNumberedList = false;
+      }
+
       NodeParser? parser = parsers.firstWhereOrNull(
         (element) => element.id == node.type,
       );
@@ -25,6 +53,7 @@ class DocumentMarkdownEncoder extends Converter<Document, String> {
           buffer.write(lineBreak);
         }
       }
+      _numberedListNumbers.remove(node.id);
     }
 
     return buffer.toString();

--- a/lib/src/plugins/markdown/encoder/parser/numbered_list_node_parser.dart
+++ b/lib/src/plugins/markdown/encoder/parser/numbered_list_node_parser.dart
@@ -10,7 +10,9 @@ class NumberedListNodeParser extends NodeParser {
   String transform(Node node, DocumentMarkdownEncoder? encoder) {
     final delta = node.delta ?? Delta()
       ..insert('');
-    final number = node.attributes[NumberedListBlockKeys.number] ?? '1';
+    final number = encoder?.numberedListNumberFor(node) ??
+        node.attributes[NumberedListBlockKeys.number] ??
+        1;
     final children = encoder?.convertNodes(node.children, withIndent: true);
     String markdown = '$number. ${DeltaMarkdownEncoder().convert(delta)}\n';
     if (children != null && children.isNotEmpty) {

--- a/test/plugins/markdown/document_markdown_test.dart
+++ b/test/plugins/markdown/document_markdown_test.dart
@@ -27,6 +27,46 @@ void main() {
       expect(markdown, markdownDocumentEncoded);
     });
 
+    test('documentToMarkdown() preserves sequential numbered list markers', () {
+      final document = Document(
+        root: pageNode(
+          children: [
+            numberedListNode(text: 'get up'),
+            numberedListNode(text: 'brush teeth'),
+            numberedListNode(text: 'go to school'),
+          ],
+        ),
+      );
+
+      final markdown = documentToMarkdown(document);
+
+      expect(markdown, '''
+1. get up
+2. brush teeth
+3. go to school
+''');
+    });
+
+    test('documentToMarkdown() preserves numbered list start marker', () {
+      final document = Document(
+        root: pageNode(
+          children: [
+            numberedListNode(text: 'get up', number: 3),
+            numberedListNode(text: 'brush teeth'),
+            numberedListNode(text: 'go to school'),
+          ],
+        ),
+      );
+
+      final markdown = documentToMarkdown(document);
+
+      expect(markdown, '''
+3. get up
+4. brush teeth
+5. go to school
+''');
+    });
+
     test('paragraph + image with single \n', () {
       const markdown = '''This is the first line
 ![image](https://example.com/image.png)''';


### PR DESCRIPTION
## Summary

Fixes `documentToMarkdown` so consecutive numbered list nodes export as sequential Markdown markers instead of every item using `1.`. The encoder now tracks the displayed numbered-list marker for each contiguous list block and passes it to the numbered-list node parser.

This also preserves an explicit starting marker, such as exporting `3, 4, 5` when the first item starts at `3`.

Fixes #1206.

## Validation

- Added regression coverage for sequential numbered list export.
- Added regression coverage for an explicit numbered-list start marker.
- I could not run the Flutter/Dart test suite locally because this machine does not have `dart` or `flutter` installed.
