### PR TITLE
fix: prevent infinite table row-height relayout loop on sub-pixel jitter

### DIFF
--- a/lib/src/editor/block_component/table_block_component/table_node.dart
+++ b/lib/src/editor/block_component/table_block_component/table_node.dart
@@ -3,6 +3,33 @@ import 'dart:math';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/editor/block_component/table_block_component/table_config.dart';
 
+/// Minimum height delta (in logical pixels) that counts as a real change
+/// when reconciling a table row's stored height against its measured
+/// height.
+///
+/// Layout reports `rect.height` with sub-pixel jitter between frames
+/// (device-pixel rounding, or a focus/selection-dependent measurement on
+/// mobile). Comparing with exact `!=` treated that jitter as a genuine
+/// change, so [TableNode.updateRowHeight] emitted a height transaction
+/// every frame -> apply -> rebuild -> re-measure: an unbounded relayout
+/// loop that pinned the UI isolate (a hang, not a crash) when a table was
+/// edited and then defocused. One logical pixel is imperceptible but
+/// safely above the jitter, so the height converges and the loop ends.
+const double _tableRowHeightTolerance = 1.0;
+
+/// Whether [measured] differs from the [stored] height attribute by at
+/// least [_tableRowHeightTolerance]. Also absorbs the old `!isNaN` guard:
+/// a NaN measurement is never treated as a change. Returns `true` when
+/// nothing is stored yet (or it can't be parsed) so the first real
+/// measurement is always written.
+bool _tableRowHeightChanged(Object? stored, double measured) {
+  if (measured.isNaN) return false;
+  final current =
+      stored is num ? stored.toDouble() : double.tryParse('${stored ?? ''}');
+  if (current == null) return true;
+  return (current - measured).abs() >= _tableRowHeightTolerance;
+}
+
 class TableNode {
   final TableConfig _config;
 
@@ -197,11 +224,13 @@ class TableNode {
         .map<double>((c) => c[row].children.first.rect.height + 8)
         .reduce(max);
 
-    if (_cells[0][row].attributes[TableCellBlockKeys.height] != maxHeight &&
-        !maxHeight.isNaN) {
+    if (_tableRowHeightChanged(
+      _cells[0][row].attributes[TableCellBlockKeys.height],
+      maxHeight,
+    )) {
       for (int i = 0; i < colsLen; i++) {
         final currHeight = _cells[i][row].attributes[TableCellBlockKeys.height];
-        if (currHeight == maxHeight) {
+        if (!_tableRowHeightChanged(currHeight, maxHeight)) {
           continue;
         }
 
@@ -218,8 +247,10 @@ class TableNode {
       }
     }
 
-    if (node.attributes[TableBlockKeys.colsHeight] != colsHeight &&
-        !colsHeight.isNaN) {
+    if (_tableRowHeightChanged(
+      node.attributes[TableBlockKeys.colsHeight],
+      colsHeight,
+    )) {
       if (transaction != null) {
         transaction.updateNode(node, {TableBlockKeys.colsHeight: colsHeight});
         if (editorState != null && editorState.editable != true) {

--- a/test/new/block_component/table_block_component/table_node_test.dart
+++ b/test/new/block_component/table_block_component/table_node_test.dart
@@ -5,6 +5,12 @@ import 'package:appflowy_editor/src/editor/block_component/table_block_component
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // Some tests below call `updateRowHeight`, which reads `Node.rect` ->
+  // `renderBox` -> `GlobalKey.currentContext`; that needs an initialized
+  // binding. With no widget tree mounted, `currentContext` is null and
+  // `rect` falls back to `Rect.zero`.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('table_node.dart', () {
     test('fromJson', () {
       final tableNode = TableNode.fromJson({
@@ -337,6 +343,60 @@ void main() {
         tableNode.colsHeight,
         tableNode.config.rowDefaultHeight * 2 +
             tableNode.config.borderWidth * 3,
+      );
+    });
+
+    test('updateRowHeight ignores sub-pixel jitter (no relayout loop)', () {
+      // Regression test for the mobile table freeze. Layout reports
+      // `rect.height` with sub-pixel jitter between frames, so the old
+      // exact `!=` comparison made updateRowHeight emit a height
+      // transaction every frame -> apply -> rebuild -> re-measure
+      // forever, hanging the UI isolate. Detached nodes report
+      // `rect == Rect.zero`, so the measured row height here is the
+      // paragraph padding only (0 + 8 = 8.0).
+      final tableNode = TableNode.fromList([
+        ['1', '2'],
+        ['3', '4'],
+      ]);
+
+      // A stored height within 1px of the measured 8.0 must be left
+      // untouched so the height converges instead of oscillating.
+      tableNode.getCell(0, 0).updateAttributes(
+        {TableCellBlockKeys.height: 8.4},
+      );
+      tableNode.getCell(1, 0).updateAttributes(
+        {TableCellBlockKeys.height: 8.4},
+      );
+
+      tableNode.updateRowHeight(0);
+
+      expect(
+        tableNode.getCell(0, 0).attributes[TableCellBlockKeys.height],
+        8.4,
+      );
+      expect(
+        tableNode.getCell(1, 0).attributes[TableCellBlockKeys.height],
+        8.4,
+      );
+
+      // A change larger than the tolerance is still applied, so genuine
+      // content resizes keep working.
+      tableNode.getCell(0, 1).updateAttributes(
+        {TableCellBlockKeys.height: 50.0},
+      );
+      tableNode.getCell(1, 1).updateAttributes(
+        {TableCellBlockKeys.height: 50.0},
+      );
+
+      tableNode.updateRowHeight(1);
+
+      expect(
+        tableNode.getCell(0, 1).attributes[TableCellBlockKeys.height],
+        8.0,
+      );
+      expect(
+        tableNode.getCell(1, 1).attributes[TableCellBlockKeys.height],
+        8.0,
       );
     });
   });


### PR DESCRIPTION
## Summary

Fixes #1213.

Editing a table cell and then defocusing it froze the app on mobile via an unbounded row-height relayout loop. Because it's a UI-thread hang (no exception is thrown), it was invisible to every Dart error handler.

## Root cause

`TableCol._buildCells` schedules `updateRowHeightCallback` in a post-frame callback on every build. That calls `TableNode.updateRowHeight`, which reconciles the stored row/cols height against the measured `children.first.rect.height` using an **exact `!=` comparison**. Layout reports sub-pixel-different heights between frames (device-pixel rounding, and a focus/selection-dependent measurement on mobile), so a height transaction is emitted every frame → `apply` → rebuild → re-measure → loop forever.

## Fix

Compare heights with a 1px tolerance (`_tableRowHeightChanged`) so reconciliation stops once the stored height is within a logical pixel of the measurement. This is imperceptible visually, safely above the jitter, and guarantees convergence. The previous `!isNaN` guard is folded into the helper. Genuine (supra-pixel) content resizes still apply, so no behavioral regression on desktop where heights were already stable.

## Tests

Added a unit test to `test/new/block_component/table_block_component/table_node_test.dart` that:

- asserts a **sub-pixel** stored/measured delta is left untouched (the convergence guarantee), and
- asserts a **supra-pixel** delta is still applied (resize still works).

The test fails on `main` (`Expected: <8.4> / Actual: <8.0>`) and passes with this change. `dart format` and `flutter analyze` are clean.

## Checklist

- [x] Conventional commit title (`fix:`)
- [x] Regression test added
- [x] `flutter analyze` / `dart format` clean
- [x] DCO sign-off on the commit
- [x] CLA signed (will sign via the bot comment)
