### PR TITLE
fix: prevent mobile auto-scroll feedback loops

### DIFF
--- a/lib/src/editor/editor_component/service/scroll/auto_scroller.dart
+++ b/lib/src/editor/editor_component/service/scroll/auto_scroller.dart
@@ -7,6 +7,7 @@ abstract class AutoScrollerService {
     double edgeOffset = 200,
     AxisDirection? direction,
     Duration? duration,
+    bool repeat = true,
   });
 
   void stopAutoScroll();
@@ -38,6 +39,7 @@ class AutoScroller extends EdgeDraggingAutoScroller
     double edgeOffset = 200,
     AxisDirection? direction,
     Duration? duration,
+    bool repeat = true,
   }) {
     lastOffset = offset;
     lastDuration = duration;
@@ -47,6 +49,7 @@ class AutoScroller extends EdgeDraggingAutoScroller
       return startAutoScrollIfNecessary(
         Rect.fromLTWH(offset.dx, offset.dy - edgeOffset, 1, edgeOffset),
         duration: duration,
+        repeat: repeat,
       );
     }
 
@@ -54,6 +57,7 @@ class AutoScroller extends EdgeDraggingAutoScroller
       return startAutoScrollIfNecessary(
         Rect.fromLTWH(offset.dx, offset.dy, 1, edgeOffset),
         duration: duration,
+        repeat: repeat,
       );
     }
 
@@ -66,6 +70,7 @@ class AutoScroller extends EdgeDraggingAutoScroller
     startAutoScrollIfNecessary(
       dragTarget,
       duration: duration,
+      repeat: repeat,
     );
   }
 

--- a/lib/src/editor/editor_component/service/scroll/desktop_scroll_service.dart
+++ b/lib/src/editor/editor_component/service/scroll/desktop_scroll_service.dart
@@ -104,6 +104,7 @@ class _DesktopScrollServiceState extends State<DesktopScrollService>
     double edgeOffset = 200,
     AxisDirection? direction,
     Duration? duration,
+    bool repeat = true,
   }) {
     if (editorState.disableAutoScroll) {
       return;
@@ -114,6 +115,7 @@ class _DesktopScrollServiceState extends State<DesktopScrollService>
       edgeOffset: edgeOffset,
       direction: direction,
       duration: duration ?? _kDesktopAutoScrollTickDuration,
+      repeat: repeat,
     );
   }
 

--- a/lib/src/editor/editor_component/service/scroll/mobile_scroll_service.dart
+++ b/lib/src/editor/editor_component/service/scroll/mobile_scroll_service.dart
@@ -98,12 +98,14 @@ class _MobileScrollServiceState extends State<MobileScrollService>
     double edgeOffset = 200,
     AxisDirection? direction,
     Duration? duration,
+    bool repeat = true,
   }) {
     autoScroller?.startAutoScroll(
       offset,
       edgeOffset: edgeOffset,
       direction: direction,
       duration: duration,
+      repeat: repeat,
     );
   }
 

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -192,6 +192,7 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
           edgeOffset: editorState.autoScrollEdgeOffset,
           direction: direction,
           duration: Duration.zero,
+          repeat: false,
         );
       }
     });

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -180,6 +180,7 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
             edgeOffset: editorState.autoScrollEdgeOffset,
             direction: direction,
             duration: scrollDuration,
+            repeat: isDragOperation,
           );
         });
       } else {
@@ -243,12 +244,14 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
     double edgeOffset = 100,
     AxisDirection? direction,
     Duration? duration,
+    bool repeat = true,
   }) {
     forward.startAutoScroll(
       offset,
       edgeOffset: edgeOffset,
       direction: direction,
       duration: duration,
+      repeat: repeat,
     );
   }
 

--- a/lib/src/flutter/scrollable_helpers.dart
+++ b/lib/src/flutter/scrollable_helpers.dart
@@ -365,6 +365,7 @@ class EdgeDraggingAutoScroller {
           return;
         }
       }
+      final double pixelsBeforeMove = scrollable.position.pixels;
       await scrollable.position.moveTo(
         newOffset,
         duration: _currentDuration ?? _animationDuration,
@@ -372,6 +373,22 @@ class EdgeDraggingAutoScroller {
         // clamp: true,
       );
       onScrollViewScrolled?.call();
+      // Termination guard against an unbounded auto-scroll loop.
+      //
+      // `_scroll` re-invokes itself via `await _scroll()` as long as
+      // `_scrolling` is true. `moveTo` can complete synchronously when the
+      // position cannot actually advance (already at min/maxScrollExtent, a
+      // zero scroll range, or a pinned position), in which case the
+      // self-recursion degenerates into a tight microtask loop that pins the
+      // platform/UI thread with no frames produced — observed as an ANR on
+      // mobile when leaving a table cell. Requiring real forward progress
+      // bounds the loop: each tick must move the scroll offset by at least
+      // the precision tolerance, and the scroll extent is finite.
+      if ((scrollable.position.pixels - pixelsBeforeMove).abs() <=
+          precisionErrorTolerance) {
+        _scrolling = false;
+        return;
+      }
       if (_scrolling) {
         await _scroll();
       }

--- a/lib/src/flutter/scrollable_helpers.dart
+++ b/lib/src/flutter/scrollable_helpers.dart
@@ -10,6 +10,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 export 'package:flutter/physics.dart' show Tolerance;
 
@@ -188,12 +189,14 @@ class EdgeDraggingAutoScroller {
   final Duration _animationDuration;
   Duration? _currentDuration;
   double? _previousScrollDelta;
+  bool _repeatScroll = true;
 
   late Rect _dragTargetRelatedToScrollOrigin;
 
   /// Whether the auto scroll is in progress.
   bool get scrolling => _scrolling;
   bool _scrolling = false;
+  bool _scrollScheduled = false;
 
   double _offsetExtent(Offset offset, Axis scrollDirection) {
     return switch (scrollDirection) {
@@ -220,28 +223,54 @@ class EdgeDraggingAutoScroller {
   ///
   /// If the scrollable is already scrolling, calling this method updates the
   /// previous dragTarget to the new value and continues scrolling if necessary.
-  void startAutoScrollIfNecessary(Rect dragTarget, {Duration? duration}) {
+  void startAutoScrollIfNecessary(
+    Rect dragTarget, {
+    Duration? duration,
+    bool repeat = true,
+  }) {
     final Offset deltaToOrigin = scrollable.deltaToScrollOrigin;
     _dragTargetRelatedToScrollOrigin =
         dragTarget.translate(deltaToOrigin.dx, deltaToOrigin.dy);
     _currentDuration = duration;
+    _repeatScroll = repeat;
     if (_scrolling) {
       // The change will be picked up in the next scroll.
       return;
     }
     assert(!_scrolling);
-    _scroll();
+    _scrolling = true;
+    _scheduleScroll();
   }
 
   /// Stop any ongoing auto scrolling.
   void stopAutoScroll() {
     _scrolling = false;
+    _scrollScheduled = false;
     _previousScrollDelta = null;
     _currentDuration = null;
+    _repeatScroll = true;
+  }
+
+  void _scheduleScroll() {
+    if (!_scrolling || _scrollScheduled) {
+      return;
+    }
+    _scrollScheduled = true;
+    SchedulerBinding.instance.scheduleFrameCallback((_) {
+      _scrollScheduled = false;
+      if (!_scrolling) {
+        return;
+      }
+      unawaited(_scroll());
+    });
+    SchedulerBinding.instance.ensureVisualUpdate();
   }
 
   Future<void> _scroll() async {
     try {
+      if (!_scrolling) {
+        return;
+      }
       final RenderBox scrollRenderBox =
           scrollable.context.findRenderObject()! as RenderBox;
       final Matrix4 transform = scrollRenderBox.getTransformTo(null);
@@ -266,7 +295,6 @@ class EdgeDraggingAutoScroller {
         // do nothing.
       }
 
-      _scrolling = true;
       double? newOffset;
       const double overDragMax = 20.0;
 
@@ -340,14 +368,14 @@ class EdgeDraggingAutoScroller {
       final double currentPixels = scrollable.position.pixels;
       if (newOffset == null) {
         // Drag should not trigger scroll.
-        _scrolling = false;
+        stopAutoScroll();
 
         return;
       }
       double delta = newOffset - currentPixels;
       if (delta.abs() < _minimumAutoScrollDelta) {
         if (delta.abs() <= precisionErrorTolerance) {
-          _scrolling = false;
+          stopAutoScroll();
 
           return;
         }
@@ -360,7 +388,7 @@ class EdgeDraggingAutoScroller {
         newOffset = target.toDouble();
         delta = newOffset - currentPixels;
         if (delta.abs() <= precisionErrorTolerance) {
-          _scrolling = false;
+          stopAutoScroll();
 
           return;
         }
@@ -386,16 +414,17 @@ class EdgeDraggingAutoScroller {
       // the precision tolerance, and the scroll extent is finite.
       if ((scrollable.position.pixels - pixelsBeforeMove).abs() <=
           precisionErrorTolerance) {
-        _scrolling = false;
+        stopAutoScroll();
         return;
       }
-      if (_scrolling) {
-        await _scroll();
+      if (_repeatScroll) {
+        _scheduleScroll();
+      } else {
+        stopAutoScroll();
       }
     } catch (e) {
       debugPrint(e.toString());
-    } finally {
-      _scrolling = false;
+      stopAutoScroll();
     }
   }
 

--- a/test/editor/editor_component/service/auto_scroller_test.dart
+++ b/test/editor/editor_component/service/auto_scroller_test.dart
@@ -10,7 +10,11 @@ class _CapturingAutoScroller extends AutoScroller {
   Rect? capturedRect;
 
   @override
-  void startAutoScrollIfNecessary(Rect dragTarget, {Duration? duration}) {
+  void startAutoScrollIfNecessary(
+    Rect dragTarget, {
+    Duration? duration,
+    bool repeat = true,
+  }) {
     capturedRect = dragTarget;
     // intentionally do not call super — we only want the rect
   }


### PR DESCRIPTION
## Summary

Fixes #1215.

This fixes a mobile editor auto-scroll feedback loop that remained after the table row-height relayout fix in #1214. On a physical Android device, table focus/defocus could still ANR the app; after moving repeat work off microtasks, the remaining issue surfaced as visible content vibration during table selection.

## Root cause

`EdgeDraggingAutoScroller._scroll` recursively awaited itself while `_scrolling` was true. `ScrollPosition.moveTo` can complete synchronously when the scroll position cannot make meaningful progress, so the recursion can become a tight microtask chain that starves frames/input.

Separately, mobile selection changes were starting repeating auto-scroll for ordinary caret/table focus updates. Those updates need at most a one-shot keep-visible nudge; continuous repeat should be reserved for active drag selection.

## Fix

- Schedule repeated auto-scroll ticks with `SchedulerBinding.scheduleFrameCallback` instead of recursive `await _scroll()`.
- Preserve the no-progress guard so auto-scroll stops if the scroll offset does not advance.
- Add a `repeat` flag to the auto-scroll service.
- Use `repeat: true` only for mobile drag modes (`leftSelectionHandle`, `rightSelectionHandle`, `cursor`); ordinary selection/caret updates use one-shot auto-scroll.
- Update the auto-scroller test helper override for the new optional parameter.

## Verification

- `dart format --set-exit-if-changed` on touched Dart files
- `flutter analyze`
- Manual release-APK verification on Galaxy S23+ / Android 16: the table tap-out/tap-in interaction no longer ANRs, no new Android Dropbox ANR was written, post-focus screenshots were stable, and manual drag-select around the table looked stable.


Made with [Cursor](https://cursor.com)