### PR TITLE
fix: don't leak HTML comment content into pasted paragraph text

### DIFF
--- a/lib/src/plugins/html/html_document_decoder.dart
+++ b/lib/src/plugins/html/html_document_decoder.dart
@@ -470,9 +470,11 @@ class DocumentHTMLDecoder extends Converter<String, Document> {
             );
           }
         }
-      } else {
-        delta.insert(child.text?.replaceAll(RegExp(r'\n+$'), '') ?? '');
+      } else if (child is dom.Text) {
+        delta.insert(child.text.replaceAll(RegExp(r'\n+$'), ''));
       }
+      // other node types (e.g. dom.Comment) carry no visible content and
+      // are intentionally skipped, mirroring _parseElement's handling.
     }
 
     return (delta, nodes);

--- a/test/customer/html_document_test.dart
+++ b/test/customer/html_document_test.dart
@@ -41,5 +41,21 @@ void main() {
         isTrue,
       );
     });
+
+    test('paste text with an inline HTML comment does not leak comment text',
+        () {
+      // Some sites (e.g. Google Search AI Overview) inject an HTML comment
+      // into copied content as an internal marker. It must not surface as
+      // visible text, regardless of what the comment contains.
+      const html = '''
+<p>First answer<!--TgQPHd||[]--></p>
+<p>Second answer<!-- some other internal marker --></p>
+''';
+      final document = htmlToDocument(html);
+      final children = document.root.children;
+
+      expect(children[0].delta!.toPlainText(), 'First answer');
+      expect(children[1].delta!.toPlainText(), 'Second answer');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- `_parseDeltaElement`'s fallback branch called `child.text` on any non-`Element` DOM node, including `dom.Comment` (whose `.text` getter aliases its raw `data`). A real HTML comment embedded inline in pasted content — e.g. the internal tracking marker Google's Search AI Overview panel injects when you copy its answer text — would surface as visible garbage text in the editor instead of being silently dropped.
- Fix mirrors the pattern `_parseElement` already uses one level up: only extract text from `dom.Text` nodes; other node types (comments, processing instructions, etc.) carry no visible content and are skipped.
- Added a regression test using a comment payload that is *not* the specific marker seen in the wild, to confirm the fix is general (any HTML comment) rather than tied to one vendor's marker string.

## Test plan
- [x] `flutter test test/customer/html_document_test.dart` — new regression test passes
- [x] `flutter test` (full suite) — 920/920 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nps55LWFpd6VBJkPX5cap