### PR TITLE
fix: replace universal_html with package:web to support wasm compilation

### DIFF
--- a/lib/src/editor/util/navigator_platform_stub.dart
+++ b/lib/src/editor/util/navigator_platform_stub.dart
@@ -1,0 +1,4 @@
+/// Stub used on non-web platforms, where `window.navigator` doesn't exist.
+///
+/// The web implementation lives in `navigator_platform_web.dart`.
+String get navigatorPlatform => '';

--- a/lib/src/editor/util/navigator_platform_web.dart
+++ b/lib/src/editor/util/navigator_platform_web.dart
@@ -1,0 +1,7 @@
+import 'package:web/web.dart' as web;
+
+/// The value of `window.navigator.platform`, lowercased.
+///
+/// Uses `package:web` so that the library can compile to WebAssembly —
+/// `dart:html`-based packages like `universal_html` cannot.
+String get navigatorPlatform => web.window.navigator.platform.toLowerCase();

--- a/lib/src/editor/util/platform_extension.dart
+++ b/lib/src/editor/util/platform_extension.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:universal_html/html.dart' show window;
 import 'package:universal_platform/universal_platform.dart';
+
+import 'navigator_platform_stub.dart'
+    if (dart.library.js_interop) 'navigator_platform_web.dart';
 
 // TODO(Xazin): Refactor to honor `Theme.platform`
 extension PlatformExtension on Platform {
-  static String get _webPlatform =>
-      window.navigator.platform?.toLowerCase() ?? '';
+  static String get _webPlatform => navigatorPlatform;
 
   /// Returns true if the operating system is macOS and not running on Web platform.
   static bool get isMacOS => UniversalPlatform.isMacOS;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,9 +31,9 @@ dependencies:
   provider: "^6.0.5"
   scroll_to_index: "^3.0.1"
   string_validator: "^1.0.0"
-  universal_html: "^2.2.4"
   universal_platform: ^1.1.0
   url_launcher: "^6.1.11"
+  web: ^1.0.0
 
 dev_dependencies:
   awesome_lints:


### PR DESCRIPTION
## What this fixes

`appflowy_editor` currently cannot be used in apps built with `flutter build web --wasm`: `universal_html` imports `dart:html`, which dart2wasm does not support, so any consumer app fails the wasm compatibility check with:

```
package:universal_html/src/_sdk/html.dart 32:1 - dart:html unsupported
package:universal_html/src/_sdk_html_additions.dart 16:1 - dart:html unsupported
```

The library's only use of `universal_html` is reading `window.navigator.platform` in `platform_extension.dart` for the `isWebOnMacOS`/`isWebOnWindows`/`isWebOnLinux` getters (Cmd vs Ctrl shortcut selection).

## The change

- Replace `universal_html` with `package:web` behind a conditional import (`dart.library.js_interop`), with a no-op stub on native platforms — where the existing `kIsWeb` guards already prevented the value from being read. Behavior on all platforms is unchanged.
- Drop the `universal_html` dependency; add `web: ^1.0.0`.

## Testing

- `flutter analyze`, `dart format`, `dart run custom_lint`, `flutter test` (920 passing) — all clean.
- Verified in a real production Flutter app: `flutter build web --wasm-dry-run` no longer reports any findings from `appflowy_editor`, and a full `flutter build web --wasm` compiles and runs.
- Manual smoke test of the editor running on the dart2wasm build in Chrome on macOS: typing, selection, toolbar formatting, and **Cmd+B** (i.e. `isWebOnMacOS` resolving correctly through the new code path) all work.

Note: the example app still uses `universal_html` in its own pubspec for file export; that doesn't affect library consumers, but I'm happy to migrate it in a follow-up if wanted.

Closes #811, closes #1019, closes #1131, closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
