### PR TITLE
test: reproduce find/replace overlay while typing (AppFlowy#8802)

### DIFF
--- a/test/new/find_replace_menu/find_replace_menu_repro_test.dart
+++ b/test/new/find_replace_menu/find_replace_menu_repro_test.dart
@@ -1,0 +1,84 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/editor/find_replace_menu/find_replace_widget.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../infra/testable_editor.dart';
+import 'find_replace_menu_utils.dart';
+
+// Reproduction for https://github.com/AppFlowy-IO/AppFlowy/issues/8802
+// "[Bug] can not search with Ctrl-F" - the find/replace overlay disappears
+// as soon as the user starts typing a search term.
+void main() async {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  group('find_replace_menu.dart findMenu stays open while typing', () {
+    testWidgets('menu remains mounted after typing each character',
+        (tester) async {
+      final editor = tester.editor;
+      editor.addParagraphs(3, initialText: text);
+
+      await editor.startTesting();
+      await editor.updateSelection(Selection.single(path: [0], startOffset: 0));
+
+      await pressFindAndReplaceCommand(editor);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FindAndReplaceMenuWidget), findsOneWidget);
+
+      // Type into the find field one character at a time, the way a real
+      // user would, and check the overlay survives every keystroke.
+      const pattern = 'Welcome';
+      final findField = find.byKey(const Key('findTextField'));
+      String typed = '';
+      for (final char in pattern.split('')) {
+        typed += char;
+        await tester.enterText(findField, typed);
+        await tester.pump();
+
+        expect(
+          find.byType(FindAndReplaceMenuWidget),
+          findsOneWidget,
+          reason:
+              'find menu disappeared after typing "$typed" (pattern so far)',
+        );
+      }
+
+      await tester.pumpAndSettle();
+      expect(find.byType(FindAndReplaceMenuWidget), findsOneWidget);
+
+      await editor.dispose();
+    });
+
+    testWidgets(
+        'menu remains mounted after typing a character with no matches',
+        (tester) async {
+      final editor = tester.editor;
+      editor.addParagraphs(3, initialText: text);
+
+      await editor.startTesting();
+      await editor.updateSelection(Selection.single(path: [0], startOffset: 0));
+
+      await pressFindAndReplaceCommand(editor);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FindAndReplaceMenuWidget), findsOneWidget);
+
+      // 'z' does not appear anywhere in `text`, so this exercises the
+      // zero-match branch of SearchServiceV3._findAndHighlight.
+      final findField = find.byKey(const Key('findTextField'));
+      await tester.enterText(findField, 'z');
+      await tester.pump();
+
+      expect(
+        find.byType(FindAndReplaceMenuWidget),
+        findsOneWidget,
+        reason: 'find menu disappeared after typing a non-matching character',
+      );
+
+      await editor.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds regression coverage for the find/replace overlay while the user is actively typing a search term, prompted by AppFlowy-IO/AppFlowy#8802 ("[Bug] can not search with Ctrl-F" — search box disappears while typing).
- These tests type into the find field character-by-character (including a no-match case) and assert `FindAndReplaceMenuWidget` stays mounted after every keystroke.

## Context
Investigating #8802, I could **not** reproduce the disappearance through this package's own simulated-typing harness (`tester.enterText` + `pump()`) — both new tests pass cleanly against `470c4e7`. That's a useful negative result: it rules out the two most likely internal mechanisms:
- `FindReplaceMenu._onSelectionChange` — dead code today; it's declared but never wired up via `addListener` in `show()`, so it can't be dismissing the overlay.
- A focus-steal race in `KeyboardServiceWidgetState._onSelectionChanged` — guarded correctly: every search-triggered selection update (`SearchServiceV3._findAndHighlight`) sets `selectionExtraInfoDoNotAttachTextService: true`, which makes `_onSelectionChanged` return early before it can call `focusNode.requestFocus()`.

Since `tester.enterText` bypasses the real hardware-key/IME event pipeline, my best guess is #8802 is a platform-specific (Linux) keyboard/IME timing issue rather than a pure-Dart selection/focus bug — outside what this harness can exercise. Leaving these tests in place as regression coverage and as a documented starting point for whoever picks up the platform-level investigation.

## Separate finding (not fixed here)
While tracing this, I noticed `FindReplaceMenu.show()` (`lib/src/editor/find_replace_menu/find_menu_service.dart`) never calls `editorState.service.keyboardService?.disable()` / `scrollService?.disable()`, even though `dismiss()` calls the matching `.enable()` on both. The analogous `SelectionMenuService.show()` (slash command menu) does call `.disable()` symmetrically. I don't have evidence this causes #8802 specifically, so I'm not bundling a behavior change into this PR — flagging it separately in case it's worth a follow-up.

## Test plan
- [x] `flutter test test/new/find_replace_menu/find_replace_menu_repro_test.dart` — 2/2 passing
- [x] `flutter test test/new/find_replace_menu/` — existing 10 tests still passing
