### PR TITLE
fix: detach shrink-wrapped editor listeners on dispose

### DIFF
--- a/lib/src/editor/editor_component/service/scroll/editor_scroll_controller.dart
+++ b/lib/src/editor/editor_component/service/scroll/editor_scroll_controller.dart
@@ -24,22 +24,13 @@ class EditorScrollController {
     // if shrinkWrap is true, we will render the document with Column layout.
     // otherwise, we will render the document with ScrollablePositionedList.
     if (shrinkWrap) {
-      void updateVisibleRange() {
-        visibleRangeNotifier.value = (
-          0,
-          editorState.document.root.children.length - 1,
-        );
-      }
-
-      updateVisibleRange();
-      editorState.document.root.addListener(updateVisibleRange);
+      _updateVisibleRange();
+      editorState.document.root.addListener(_updateVisibleRange);
 
       shouldDisposeScrollController = scrollController == null;
       this.scrollController = scrollController ?? ScrollController();
       // listen to the scroll offset
-      this.scrollController.addListener(
-            () => offsetNotifier.value = this.scrollController.offset,
-          );
+      this.scrollController.addListener(_updateScrollOffset);
     } else {
       // listen to the scroll offset
       _scrollOffsetSubscription = _scrollOffsetListener.changes.listen((value) {
@@ -141,18 +132,32 @@ class EditorScrollController {
 
   late final StreamSubscription<double> _scrollOffsetSubscription;
 
+  void _updateVisibleRange() {
+    visibleRangeNotifier.value = (
+      0,
+      editorState.document.root.children.length - 1,
+    );
+  }
+
+  void _updateScrollOffset() {
+    offsetNotifier.value = scrollController.offset;
+  }
+
   // dispose the subscription
   void dispose() {
-    if (shouldDisposeScrollController) {
-      scrollController.dispose();
-    }
-
-    if (!shrinkWrap) {
+    if (shrinkWrap) {
+      editorState.document.root.removeListener(_updateVisibleRange);
+      scrollController.removeListener(_updateScrollOffset);
+    } else {
       _scrollOffsetSubscription.cancel();
       _itemPositionsListener.itemPositions.removeListener(_listenItemPositions);
       (_itemPositionsListener as ItemPositionsNotifier?)
           ?.itemPositions
           .dispose();
+    }
+
+    if (shouldDisposeScrollController) {
+      scrollController.dispose();
     }
 
     offsetNotifier.dispose();

--- a/test/editor/editor_component/service/scroll/editor_scroll_controller_test.dart
+++ b/test/editor/editor_component/service/scroll/editor_scroll_controller_test.dart
@@ -1,0 +1,60 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'disposing a shrink-wrapped controller detaches document listeners',
+    (tester) async {
+      final editorState = EditorState.blank(withInitialText: false);
+      addTearDown(editorState.dispose);
+      final scrollController = EditorScrollController(
+        editorState: editorState,
+        shrinkWrap: true,
+      );
+
+      scrollController.dispose();
+      editorState.document.insert([0], [paragraphNode()]);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'disposing a shrink-wrapped controller detaches external scroll listeners',
+    (tester) async {
+      final editorState = EditorState.blank(withInitialText: false);
+      final externalScrollController = _TestScrollController();
+      addTearDown(editorState.dispose);
+      addTearDown(externalScrollController.dispose);
+      final scrollController = EditorScrollController(
+        editorState: editorState,
+        shrinkWrap: true,
+        scrollController: externalScrollController,
+      );
+
+      expect(externalScrollController.listenerCount, 1);
+      scrollController.dispose();
+
+      expect(externalScrollController.listenerCount, 0);
+    },
+  );
+}
+
+class _TestScrollController extends ScrollController {
+  final Set<VoidCallback> _listeners = {};
+
+  int get listenerCount => _listeners.length;
+
+  @override
+  void addListener(VoidCallback listener) {
+    _listeners.add(listener);
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _listeners.remove(listener);
+    super.removeListener(listener);
+  }
+}


### PR DESCRIPTION
## Summary

- detach the document-root visible-range listener when a shrink-wrapped editor scroll controller is disposed
- detach the offset listener from externally owned scroll controllers
- add regression coverage for both listener lifecycles

## Root cause

A shrink-wrapped controller registered callbacks on the document root and scroll controller, but disposed its notifiers without unregistering those callbacks. If the editor presentation unmounted while the EditorState remained alive, the next document mutation invoked the stale callback and wrote to a disposed ValueNotifier.

## Tests

- `flutter test test/editor/editor_component/service/scroll/editor_scroll_controller_test.dart`
- `flutter analyze`