### PR TITLE
fix: implement TextInputClient.onFocusReceived for Flutter >= 3.44 compatibility

### DIFF
--- a/lib/src/editor/editor_component/service/ime/delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/delta_input_service.dart
@@ -25,6 +25,12 @@ class DeltaTextInputService extends TextInputService with DeltaTextInputClient {
   @override
   TextEditingValue? currentTextEditingValue;
 
+  // Flutter >= 3.44 added TextInputClient.onFocusReceived with a concrete
+  // default; DeltaTextInputClient only *implements* TextInputClient, so the
+  // default body does not carry over and the member must be provided here.
+  @override
+  bool onFocusReceived() => false;
+
   TextInputConnection? _textInputConnection;
 
   @override


### PR DESCRIPTION
## Problem

On Flutter **3.44+**, `appflowy_editor` fails to compile with:

```
Missing concrete implementation of 'TextInputClient.onFocusReceived'.
```

Flutter 3.44 added `TextInputClient.onFocusReceived()` — a concrete member with a `=> false` default on the `TextInputClient` mixin (`packages/flutter/lib/src/services/text_input.dart`). `DeltaTextInputService` mixes in `DeltaTextInputClient`, which only **implements** `TextInputClient`; the framework's default body does not carry over to an `implements` relationship, so the concrete class no longer satisfies the interface.

## Fix

Add the `onFocusReceived` override to `DeltaTextInputService`, matching the framework default (`=> false`). It is a no-op on older Flutter versions where the member is unused, and restores compilation on 3.44+.

```dart
@override
bool onFocusReceived() => false;
```

## Notes

- Verified against Flutter 3.44.6 (stable).
- Single-file, backward-compatible change; no behavior change on Flutter < 3.44.