### PR TITLE
docs: fix customizing component link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Please refer to our documentation on customizing AppFlowy for a detailed discuss
 
 ### Customizing Block Components
 
-Please refer to our documentation on customizing AppFlowy for a detailed discussion about [customizing components](https://github.com/AppFlowy-IO/appflowy-editor/blob/main/documentation/customizing.md#customize-a-component).
+Please refer to our documentation on customizing AppFlowy for a detailed discussion about [customizing editor features](https://github.com/AppFlowy-IO/appflowy-editor/blob/main/documentation/customizing.md).
 
 Below are some examples of component customizations:
 


### PR DESCRIPTION
## Summary
- update the README link under "Customizing Block Components" to point to the actual customization guide entrypoint
- avoid sending readers to a missing anchor inside `documentation/customizing.md`

## Why
Addresses #420. The previous README link pointed to a non-existent `#customize-a-component` anchor.

## Testing
- not run (docs-only change)