### PR TITLE
fix: preserve mobile IME composing range and unstick hardware key handling

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -305,6 +305,14 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
   void _updateComposing(TextEditingDelta delta) {
     if (delta is TextEditingDeltaNonTextUpdate) {
       composingTextRange = delta.composing;
+    } else if (PlatformExtension.isMobile) {
+      // Mobile IMEs (including composing languages such as Korean) report the
+      // authoritative composing range on every delta. Merging it with the
+      // previous range corrupts the range at syllable boundaries (e.g. 반+ㄱ
+      // becomes (0,2) instead of (1,2)), which makes attach() push a
+      // mismatched editing state and restart the IME mid-composition.
+      // Trust the platform value verbatim.
+      composingTextRange = delta.composing;
     } else {
       composingTextRange = composingTextRange != null &&
               composingTextRange!.start != -1 &&

--- a/lib/src/editor/editor_component/service/keyboard_service_widget.dart
+++ b/lib/src/editor/editor_component/service/keyboard_service_widget.dart
@@ -169,6 +169,17 @@ class KeyboardServiceWidgetState extends State<KeyboardServiceWidget>
       return KeyEventResult.ignored;
     }
 
+    // The IME reports the end of a composition (e.g. Android composition
+    // timeout) with a TextEditingDeltaNonTextUpdate, which doesn't change
+    // the selection, so enableIMEShortcuts can be left stale-false and
+    // hardware key events (e.g. backspace) would be swallowed below.
+    // Re-sync the flag with the actual composing state before gating.
+    if (!enableIMEShortcuts &&
+        (textInputService.composingTextRange ?? TextRange.empty) ==
+            TextRange.empty) {
+      enableIMEShortcuts = true;
+    }
+
     if ((event is! KeyDownEvent && event is! KeyRepeatEvent) ||
         !enableIMEShortcuts) {
       if (textInputService.composingTextRange != TextRange.empty) {


### PR DESCRIPTION
## Problem

Two related mobile IME bugs make CJK (Korean/Chinese/Japanese) typing unusable on Android.

**1. Composition is split at syllable boundaries.**
`_updateComposing` merges the previous composing range with the incoming delta's range. On mobile this corrupts the range at syllable boundaries — e.g. typing `ㄱ` after `반` yields `(0, 2)` instead of the keyboard-reported `(1, 2)`. `attach()` then sees a mismatched editing state, calls `setEditingState`, and the framework restarts the input method mid-composition, splitting the jamo apart.

**2. Backspace stops responding after a composition timeout.**
The IME signals the end of a composition (Android's composition timeout) with a `TextEditingDeltaNonTextUpdate`, which doesn't change the selection. `enableIMEShortcuts` is only refreshed on attach/selection changes, so it stays stale-`false` and `_onKeyEvent` swallows subsequent hardware key events. Backspace does nothing until the user taps the editor again.

### Steps to reproduce (Android)

1. Open the editor with a Korean keyboard.
2. Type `반`, then `ㄱ` — the composition splits instead of forming `방`.
3. Stop typing until the composition times out, then press backspace on a hardware keyboard — nothing happens until you tap the editor.

## Fix

- **`non_delta_input_service.dart`** — on mobile, trust the platform's composing range verbatim instead of merging it with the previous range. Mobile IMEs report the authoritative composing range on every delta. Desktop keeps the existing merge behaviour, so the macOS Chinese IME workaround is untouched.
- **`keyboard_service_widget.dart`** — re-sync `enableIMEShortcuts` with the actual composing state before gating key events, so a composition that ended via `TextEditingDeltaNonTextUpdate` no longer leaves the flag stale.

The second fix depends on the composing range being accurate on mobile, which the first one guarantees.

## Testing

Verified on a physical Android device: zero input-method restarts during composition, correct syllable composition, and backspace responsive after a composition timeout. Desktop behaviour is unchanged — the merge path is only skipped when `PlatformExtension.isMobile`.

## Scope

+19 lines across 2 files, no public API change.
