### PR TITLE
fix: vertical cursor navigation issues across multiline nodes, line boundaries, and nested child blocks in `moveVertical`

### DIFF
--- a/lib/src/extensions/position_extension.dart
+++ b/lib/src/extensions/position_extension.dart
@@ -406,19 +406,45 @@ extension PositionExtension on Position {
     // In this case, we can manually get the previous/next node position.
     int offset = editorSelection.end.offset;
     final Path nodePath = editorSelection.end.path;
-    Path neighbourPath = upwards ? nodePath.previous : nodePath.next;
-    if (neighbourPath.equals(nodePath)) {
-      final last = neighbourPath.removeLast();
-      neighbourPath = upwards ? neighbourPath : (neighbourPath..add(last + 1));
-    }
-    if (neighbourPath.isNotEmpty && !neighbourPath.equals(nodePath)) {
-      var neighbour = editorState.document.nodeAtPath(neighbourPath);
-      if (upwards && neighbour != null) {
-        while (neighbour!.children.isNotEmpty) {
-          neighbour = neighbour.children.last;
+    Path? neighbourPath;
+    if (upwards) {
+      if (nodePath.last > 0) {
+        final siblingPath = nodePath.previous;
+        var siblingNode = editorState.document.nodeAtPath(siblingPath);
+        if (siblingNode != null) {
+          while (siblingNode!.children.isNotEmpty) {
+            siblingNode = siblingNode.children.last;
+          }
+          neighbourPath = siblingNode.path;
+        } else {
+          neighbourPath = siblingPath;
         }
-        neighbourPath = neighbour.path;
+      } else if (nodePath.length > 1) {
+        neighbourPath = Path.from(nodePath)..removeLast();
+      } else if (nodePath.first > 0) {
+        final prevRootPath = Path.from([nodePath.first - 1]);
+        var prevRootNode = editorState.document.nodeAtPath(prevRootPath);
+        if (prevRootNode != null) {
+          while (prevRootNode!.children.isNotEmpty) {
+            prevRootNode = prevRootNode.children.last;
+          }
+          neighbourPath = prevRootNode.path;
+        } else {
+          neighbourPath = prevRootPath;
+        }
       }
+    } else {
+      neighbourPath = nodePath.next;
+      if (neighbourPath.equals(nodePath)) {
+        final last = neighbourPath.removeLast();
+        neighbourPath = neighbourPath..add(last + 1);
+      }
+    }
+
+    if (neighbourPath != null &&
+        neighbourPath.isNotEmpty &&
+        !neighbourPath.equals(nodePath)) {
+      final neighbour = editorState.document.nodeAtPath(neighbourPath);
       final selectable = neighbour?.selectable;
       if (selectable != null) {
         offset = offset.clamp(

--- a/lib/src/extensions/position_extension.dart
+++ b/lib/src/extensions/position_extension.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 enum SelectionRange {
   character,
@@ -139,18 +140,218 @@ extension PositionExtension on Position {
     //      scenario the position will be found in 10/12 ms instead of 1/2 ms)
     // - If the current node is not multiline: the cycle will be completely
     //   skipped because `remainingMultilineHeight` would be 0.
+    Position adjustCrossNodePosition(Position targetPosition) {
+      if (targetPosition.path.equals(path)) {
+        return targetPosition;
+      }
+      final targetNode = editorState.document.nodeAtPath(targetPosition.path);
+      final selectable = targetNode?.selectable;
+      if (selectable is State) {
+        final context = (selectable as State).context;
+        RenderParagraph? renderParagraph;
+
+        void findParagraph(RenderObject? renderObject) {
+          if (renderObject is RenderParagraph) {
+            final textLen = renderObject.text.toPlainText().length;
+            if (renderParagraph == null ||
+                textLen > renderParagraph!.text.toPlainText().length) {
+              renderParagraph = renderObject;
+            }
+          }
+          renderObject?.visitChildren(findParagraph);
+        }
+
+        findParagraph(context.findRenderObject());
+        if (renderParagraph != null) {
+          final localCaretX = renderParagraph!.globalToLocal(caretOffset).dx;
+          final maxOffset = targetNode?.delta?.toPlainText().length ?? 0;
+
+          if (!upwards) {
+            // Moving DOWN into targetNode. Ensure position lands on the FIRST visual line of targetNode.
+            final firstLineDy = renderParagraph!
+                .getOffsetForCaret(
+                  const TextPosition(offset: 0),
+                  Rect.zero,
+                )
+                .dy;
+            final checkCaretDy = renderParagraph!
+                .getOffsetForCaret(
+                  TextPosition(offset: targetPosition.offset),
+                  Rect.zero,
+                )
+                .dy;
+            if (checkCaretDy > firstLineDy + 4.0) {
+              var adjustedOffset = targetPosition.offset;
+              while (adjustedOffset > 0) {
+                adjustedOffset--;
+                final caretDy = renderParagraph!
+                    .getOffsetForCaret(
+                      TextPosition(offset: adjustedOffset),
+                      Rect.zero,
+                    )
+                    .dy;
+                if (caretDy <= firstLineDy + 4.0) {
+                  return Position(
+                    path: targetPosition.path,
+                    offset: adjustedOffset,
+                  );
+                }
+                int bestOffset = 0;
+                double bestDiff = double.infinity;
+
+                for (int offset = 0; offset <= maxOffset; offset++) {
+                  final caret = renderParagraph!.getOffsetForCaret(
+                    TextPosition(
+                      offset: offset,
+                      affinity: offset == 0
+                          ? TextAffinity.downstream
+                          : TextAffinity.upstream,
+                    ),
+                    Rect.zero,
+                  );
+                  // Only consider offsets on the first visual line
+                  if (caret.dy > firstLineDy + 4.0) {
+                    break;
+                  }
+                  final diff = (caret.dx - localCaretX).abs();
+                  if (diff <= bestDiff) {
+                    bestDiff = diff;
+                    bestOffset = offset;
+                  }
+                }
+
+                return Position(path: targetPosition.path, offset: bestOffset);
+              }
+            }
+          } else {
+            // Moving UP into targetNode. Ensure position lands on the LAST visual line of targetNode.
+            final lastLineDy = renderParagraph!
+                .getOffsetForCaret(
+                  TextPosition(
+                    offset: maxOffset,
+                    affinity: TextAffinity.upstream,
+                  ),
+                  Rect.zero,
+                )
+                .dy;
+
+            int bestOffset = maxOffset;
+            double bestDiff = double.infinity;
+
+            for (int offset = maxOffset; offset >= 0; offset--) {
+              final caret = renderParagraph!.getOffsetForCaret(
+                TextPosition(
+                  offset: offset,
+                  affinity: TextAffinity.upstream,
+                ),
+                Rect.zero,
+              );
+              // Only consider offsets on the last visual line
+              if (caret.dy < lastLineDy - 4.0) {
+                break;
+              }
+              final diff = (caret.dx - localCaretX).abs();
+              if (diff <= bestDiff) {
+                bestDiff = diff;
+                bestOffset = offset;
+              }
+            }
+            return Position(path: targetPosition.path, offset: bestOffset);
+          }
+        }
+      }
+      return targetPosition;
+    }
+
     Offset newOffset = caretOffset;
     Position? newPosition;
     for (double y = minFontSize;
         y < remainingMultilineHeight + minFontSize;
         y += minFontSize) {
       newOffset = caretOffset.translate(0, upwards ? -y : y);
-
       newPosition =
           editorState.service.selectionService.getPositionInOffset(newOffset);
-
-      // If a position different from the current one is found, return it.
       if (newPosition != null && newPosition != this) {
+        // If the position moved to a different node, accept it directly.
+        if (!newPosition.path.equals(path)) {
+          return adjustCrossNodePosition(newPosition);
+        }
+
+        // If in the same node, check if the offset returned really belongs to a new visual line.
+        final node = editorState.document.nodeAtPath(newPosition.path);
+        final selectable = node?.selectable;
+
+        if (selectable is State) {
+          final context = (selectable as State).context;
+          RenderParagraph? renderParagraph;
+
+          void findParagraph(RenderObject? renderObject) {
+            if (renderObject is RenderParagraph) {
+              final textLen = renderObject.text.toPlainText().length;
+              if (renderParagraph == null ||
+                  textLen > renderParagraph!.text.toPlainText().length) {
+                renderParagraph = renderObject;
+              }
+            }
+            renderObject?.visitChildren(findParagraph);
+          }
+
+          findParagraph(context.findRenderObject());
+          if (renderParagraph != null) {
+            final oldCaretDy =
+                renderParagraph!.globalToLocal(caretRect.center).dy;
+            final newCaretDy = renderParagraph!
+                .getOffsetForCaret(
+                  TextPosition(offset: newPosition.offset),
+                  Rect.zero,
+                )
+                .dy;
+
+            final isNewVisualLine = upwards
+                ? newCaretDy < oldCaretDy - 2.0
+                : newCaretDy > oldCaretDy + 2.0;
+
+            if (isNewVisualLine) {
+              // If newPosition lands on a soft-wrap line boundary where getOffsetForCaret
+              // projects the caret onto the start of the next line, adjust back 1 character
+              // so the caret visually stays at the end of the target line.
+              if (!upwards && newPosition.offset > 0) {
+                final targetLineDy = oldCaretDy + caretRect.height;
+                if (newCaretDy > targetLineDy + 4.0) {
+                  final prevCaret = renderParagraph!.getOffsetForCaret(
+                    TextPosition(offset: newPosition.offset - 1),
+                    Rect.zero,
+                  );
+                  if (prevCaret.dy <= targetLineDy + 4.0) {
+                    newPosition = Position(
+                      path: newPosition.path,
+                      offset: newPosition.offset - 1,
+                    );
+                  }
+                }
+              } else if (upwards && newPosition.offset > 0) {
+                final targetLineDy = oldCaretDy - caretRect.height;
+                if (newCaretDy > targetLineDy + 4.0) {
+                  final prevCaret = renderParagraph!.getOffsetForCaret(
+                    TextPosition(offset: newPosition.offset - 1),
+                    Rect.zero,
+                  );
+                  if (prevCaret.dy <= targetLineDy + 4.0) {
+                    newPosition = Position(
+                      path: newPosition.path,
+                      offset: newPosition.offset - 1,
+                    );
+                  }
+                }
+              }
+
+              return newPosition;
+            }
+            // Same visual line in the same node; keep searching.
+            continue;
+          }
+        }
+
         return newPosition;
       }
     }
@@ -186,16 +387,18 @@ extension PositionExtension on Position {
     final nodeHeightOffset = nodeRenderBox.localToGlobal(Offset(0, nodeHeight));
 
     // Clamp the new offset to the node's bounds.
-    newOffset = Offset(
-      newOffset.dx,
-      math.min(newOffset.dy, nodeHeightOffset.dy),
-    );
+    if (upwards) {
+      newOffset = Offset(
+        newOffset.dx,
+        math.min(newOffset.dy, nodeHeightOffset.dy),
+      );
+    }
 
     newPosition =
         editorState.service.selectionService.getPositionInOffset(newOffset);
 
     if (newPosition != null && newPosition != this) {
-      return newPosition;
+      return adjustCrossNodePosition(newPosition);
     }
 
     // If a new position has not been found, it means that the current node
@@ -209,7 +412,13 @@ extension PositionExtension on Position {
       neighbourPath = upwards ? neighbourPath : (neighbourPath..add(last + 1));
     }
     if (neighbourPath.isNotEmpty && !neighbourPath.equals(nodePath)) {
-      final neighbour = editorState.document.nodeAtPath(neighbourPath);
+      var neighbour = editorState.document.nodeAtPath(neighbourPath);
+      if (upwards && neighbour != null) {
+        while (neighbour!.children.isNotEmpty) {
+          neighbour = neighbour.children.last;
+        }
+        neighbourPath = neighbour.path;
+      }
       final selectable = neighbour?.selectable;
       if (selectable != null) {
         offset = offset.clamp(
@@ -217,7 +426,8 @@ extension PositionExtension on Position {
           selectable.end().offset,
         );
 
-        return Position(path: neighbourPath, offset: offset);
+        final targetPos = Position(path: neighbourPath, offset: offset);
+        return upwards ? adjustCrossNodePosition(targetPos) : targetPos;
       }
     }
 


### PR DESCRIPTION
# Fix vertical cursor navigation issues across multiline nodes, line boundaries, and nested child blocks in `moveVertical`

## Description

Fixes several vertical caret movement issues (`Up` and `Down` arrow navigation) in `PositionExtension.moveVertical` when dealing with multiline blocks, line-wrapped soft boundaries, cross-node transitions, and nested child block structures.


https://github.com/user-attachments/assets/6449883c-49da-44ed-a2ee-7e65c7d92923


---

## Problem Statement & Bug Scenarios

### 1. **Cross-Node Upward Jump to First Line of Multiline Paragraphs**
* **Bug:** When moving `Up` from a single-line or multiline block into an adjacent multiline block located above it, if the caret was positioned near or at the end of the current line (where the horizontal coordinate $X$ exceeded the right edge of the target line above), Flutter's `RenderParagraph.getPositionForOffset` fell back to offset `0`. As a result, the caret jumped to the **first line** of the target block instead of landing on its **last visual line**.
* **Impact:** Unexpected cursor movement to the top of a paragraph when navigating upwards.

### 2. **Cross-Node Upward Navigation Skipping Nested Child Blocks**
* **Bug:** When moving `Up` from a block located beneath a parent block containing nested child nodes (e.g., bulleted lists inside a parent paragraph), fallback neighbor resolution (`nodePath.previous`) selected the parent node `[0]` instead of traversing down to its deepest last child node `[0, N]`.
* **Impact:** The cursor skipped all nested bullet list items and jumped straight to the parent paragraph header text above.

### 3. **Line Boundary Caret Projection on Soft-Wrapped Lines (Same-Node & Cross-Node)**
* **Bug:** On line-wrapped text, when caret horizontal coordinate $X$ exceeded the end of a line above/below, `getOffsetForCaret` returned an offset pointing to the soft-wrap boundary character at offset index 0 of the adjacent line, projecting the caret visually onto the wrong visual line.
* **Impact:** Caret jumped to the beginning of the current line or skipped intermediate lines during vertical arrow navigation.

### 4. **TextAffinity Downstream Defaulting on Paragraph End Offsets**
* **Bug:** When querying `getOffsetForCaret` at `maxOffset` (end of node text), Flutter defaults to `TextAffinity.downstream`, resolving the caret vertical coordinate `dy` to `0.0` (top line of paragraph) instead of the bottom line's `dy`.
* **Impact:** Cross-node target line calculations evaluated `lastLineDy` as `0.0`, routing the caret to line 1 of the target paragraph.

---

## Key Changes & Solution

### A. Symmetrical Cross-Node Line Constraint (`adjustCrossNodePosition`)
* **Upward Navigation (`upwards == true`):** Computes `lastLineDy` using `TextAffinity.upstream` at `maxOffset` to accurately pinpoint the bottom-most visual line of the target node. Iterates backwards through all offsets belonging to that last visual line to find the offset with the minimum horizontal distance `|caret.dx - localCaretX|`.
* **Downward Navigation (`upwards == false`):** Restricts caret placement strictly to characters belonging to the top-most visual line (`firstLineDy`) of the target node, ensuring the caret lands on line 1 of the next paragraph.

### B. Nested Child Node Resolution (`neighbourPath`)
* When resolving neighbor nodes during fallback cross-node upward navigation, if `upwards == true` and the target node contains children (`neighbour.children.isNotEmpty`), the algorithm recursively traverses to the last leaf child node (`neighbour.children.last`) before applying `adjustCrossNodePosition`.

### C. Soft-Wrap Boundary Offset Compensation
* When moving `Up` or `Down` on wrapped text, if `newCaretDy` crosses beyond the target line boundary height, the algorithm steps back 1 character index (`newPosition.offset - 1`) to ensure the caret visually stays at the end of the intended visual line.

---

## Test Cases & Verification

### Scenario 1: Cross-Node Upward Navigation into Multiline Block
* **Document:** 
  - Block 1 (7 lines): `"Davi, porém insistiu: ... 1 Samuel 17:34-36"`
  - Block 2 (1 line): `"Então veja: Ser pastor de ovelhas, não era uma coisa fácil."`
* **Action:** Place caret at the end of Block 2 and press `Up`.
* **Expected Result:** Caret moves to the end of the last line of Block 1 (`"...1 Samuel 17:34-36|"`).
* **Before Fix:** Caret jumped to Line 1 of Block 1 (`"Davi, porém insistiu: |"`).

### Scenario 2: Cross-Node Upward Navigation into Parent with Nested Children
* **Document:**
  - Node `[0]` (Parent Paragraph): `"Eu dei enfaze no 'se'..."`
    - Node `[0, 0]` (Bullet 1): `"Se não estamos..."`
    - Node `[0, 1]` (Bullet 2): `"Seguiremos aquele..."`
    - Node `[0, 2]` (Bullet 3): `"Na verdade o ouviremos, mas não o reconheceremos..."`
  - Node `[1]` (Paragraph): `"Como ovelhas do rebanho de Jesus..."`
* **Action:** Place caret at the end of Node `[1]` and press `Up`.
* **Expected Result:** Caret moves to the end of Node `[0, 2]` (`"...não teremos escolha.|"`).
* **Before Fix:** Caret jumped past all bullets to Node `[0]` (`"...sequestrado pelo inimigo.|"`).

### Automated Tests
- Ran `flutter test test/extensions/` — all **42/42 tests passed** cleanly.


