### PR TITLE
fix: move horizontal

### DIFF
--- a/lib/src/editor/editor_component/service/shortcuts/command/arrow_left_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/arrow_left_command.dart
@@ -109,8 +109,16 @@ CommandShortcutEventHandler _moveCursorToLeftWordCommandHandler =
       selectionRange: SelectionRange.word,
     );
     if (startOfWord == null) {
+      editorState.moveCursorForward(SelectionMoveRange.word);
       return KeyEventResult.handled;
     }
+
+    // if 0, it means we are at the beginning of the line, move to the previous node
+    if (selection.end.offset <= 0) {
+      editorState.moveCursorForward(SelectionMoveRange.word);
+      return KeyEventResult.handled;
+    }
+
     final selectedWord = delta.toPlainText().substring(
           startOfWord.offset,
           selection.end.offset,

--- a/lib/src/editor/editor_component/service/shortcuts/command/arrow_right_command.dart
+++ b/lib/src/editor/editor_component/service/shortcuts/command/arrow_right_command.dart
@@ -112,6 +112,12 @@ CommandShortcutEventHandler _moveCursorToRightWordCommandHandler =
       selectionRange: SelectionRange.word,
     );
     if (endOfWord == null) {
+      editorState.moveCursorBackward(SelectionMoveRange.line);
+      return KeyEventResult.handled;
+    }
+    // if the end of the word is less than or equal to 0, it means we are at the end of the line, move to the next node
+    if (endOfWord.offset <= 0) {
+      editorState.moveCursorBackward(SelectionMoveRange.line);
       return KeyEventResult.handled;
     }
     final selectedLine = delta.toPlainText();

--- a/lib/src/extensions/node_extensions.dart
+++ b/lib/src/extensions/node_extensions.dart
@@ -49,16 +49,20 @@ extension NodeExtensions on Node {
       }
     }
 
-    var next = this.next;
-    while (next != null) {
-      final nextDescendentMatch = next._thisOrDescendantMatching(test);
-      if (nextDescendentMatch != null) {
-        return nextDescendentMatch;
+    Node? current = this;
+    while (current != null) {
+      var next = current.next;
+      while (next != null) {
+        final nextDescendentMatch = next._thisOrDescendantMatching(test);
+        if (nextDescendentMatch != null) {
+          return nextDescendentMatch;
+        }
+        next = next.next;
       }
-      next = next.next;
+      current = current.parent;
     }
 
-    return parent?.next?._thisOrDescendantMatching(test);
+    return null;
   }
 
   Node? _thisOrDescendantMatching(bool Function(Node element) test) {


### PR DESCRIPTION
When ctrl+left and in the begin of the node, was not moving to the previous node
When ctrl+right and in the end of the node, was not moving to the next node

Need to fix the nextNodeWhere to recursively find the ancestor to move correct.
 * There was a problem when bullet has many levels


https://github.com/user-attachments/assets/b4048107-bfb5-4c5d-af19-bab0eec5e623



Fix the command ctrl+left and ctrl+right and the stuck cursor on the final paragraph when has bullet and many levels.