### PR TITLE
fix input method composing rect position

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -172,7 +172,7 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
     _textInputConnection
       ?..setEditableSizeAndTransform(size, transform)
       ..setCaretRect(rect)
-      ..setComposingRect(rect.translate(0, rect.height));
+      ..setComposingRect(rect);
   }
 
   @override


### PR DESCRIPTION
IME composition window is placed lower than expected.

This is current state (tested on win & mac):

<img width="486" height="230" alt="img_v3_02154_bcf34356-5397-46aa-b7e4-3ead768904bg" src="https://github.com/user-attachments/assets/a97a1127-d9f7-4bd4-b94c-4e98519f71e1" />

This is after patch (verified on win):

<img width="494" height="237" alt="img_v3_02154_45e539f6-107d-4679-9b36-23c50114126g" src="https://github.com/user-attachments/assets/0441e2af-d9fa-41cf-a1be-e0c70969d0b0" />