### PR TITLE
fix: build under dart2wasm by replacing universal_html with package:web

### DIFF
--- a/lib/src/editor/util/platform_extension.dart
+++ b/lib/src/editor/util/platform_extension.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:universal_html/html.dart' show window;
+import 'package:appflowy_editor/src/editor/util/web_platform_stub.dart'
+    if (dart.library.js_interop) 'package:appflowy_editor/src/editor/util/web_platform_web.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 extension PlatformExtension on Platform {
-  static String get _webPlatform =>
-      window.navigator.platform?.toLowerCase() ?? '';
+  static String get _webPlatform => webPlatformName;
 
   /// Returns true if the operating system is macOS and not running on Web platform.
   static bool get isMacOS => UniversalPlatform.isMacOS;

--- a/lib/src/editor/util/web_platform_stub.dart
+++ b/lib/src/editor/util/web_platform_stub.dart
@@ -1,0 +1,6 @@
+/// The value of `window.navigator.platform` on the web.
+///
+/// This is the non-web implementation: off the web there is no `window` to
+/// ask, and every caller is already behind a `kIsWeb` check, so the empty
+/// string is never actually consulted.
+String get webPlatformName => '';

--- a/lib/src/editor/util/web_platform_web.dart
+++ b/lib/src/editor/util/web_platform_web.dart
@@ -1,0 +1,8 @@
+import 'package:web/web.dart' show window;
+
+/// The value of `window.navigator.platform` on the web.
+///
+/// `package:web` is used rather than `universal_html` because the latter
+/// re-exports `dart:html`, which dart2wasm does not provide — see
+/// `web_platform_stub.dart` for the non-web half of this pair.
+String get webPlatformName => window.navigator.platform.toLowerCase();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   provider: "^6.0.5"
   scroll_to_index: "^3.0.1"
   string_validator: "^1.0.0"
-  universal_html: "^2.2.4"
+  web: ^1.1.0
   universal_platform: ^1.1.0
   url_launcher: "^6.1.11"
 


### PR DESCRIPTION
## Problem

`appflowy_editor` cannot be compiled with `flutter build web --wasm`. Any app that depends on it fails:

```
Error: Dart library 'dart:html' is not available on this platform.
export 'dart:html';
^
Context: The unavailable library 'dart:html' is imported through these packages:
    <app> => package:appflowy_editor => package:universal_html => dart:html
```

`universal_html` re-exports `dart:html`, which dart2wasm does not provide. This makes the package unusable for anyone shipping a WasmGC web build.

## Change

The dependency is used in exactly one place — `PlatformExtension._webPlatform` reads `window.navigator.platform` to distinguish web-on-macOS from web-on-Windows/Linux. `package:web` exposes the same value and compiles to both JS and wasm, so the import is swapped and `universal_html` dropped from the library's dependencies.

`navigator.platform` is non-nullable in `package:web`, so the `?? ''` fallback becomes a `kIsWeb` guard — off the web `window` must not be touched at all. Every caller of `_webPlatform` (`isWebOnMacOS`, `isWebOnWindows`, `isWebOnLinux`) is already behind a `kIsWeb` check, so behaviour is unchanged on every platform.

## Verification

Flutter 3.44.6 / Dart 3.12.2, on a minimal app rendering an `AppFlowyEditor`:

| | `flutter build web --wasm` |
| --- | --- |
| `main` | fails — `dart:html` not available |
| this branch | ✓ builds |

The JS build is unaffected, and `example/` still uses `universal_html` — it is out of the published package and left alone.