### PR TITLE
fix: scope the transaction compose map to its transaction

### DIFF
--- a/lib/src/core/transform/transaction.dart
+++ b/lib/src/core/transform/transaction.dart
@@ -16,6 +16,12 @@ class Transaction {
   /// The operations to be applied.
   final List<Operation> _operations = [];
 
+  /// The text deltas waiting to be composed into [_operations], keyed by the
+  /// node they apply to. Owned by this transaction: a transaction that is
+  /// never applied (an `EditorState` refusing it, or an error while
+  /// composing) must not leak its pending deltas into the next one.
+  final Map<Node, List<Delta>> _composeMap = {};
+
   List<Operation> get operations {
     if (markNeedsComposing) {
       // compose the delta operations
@@ -212,11 +218,10 @@ class Transaction {
 }
 
 extension TextTransaction on Transaction {
-  /// We use this map to cache the delta waiting to be composed.
-  ///
-  /// This is for make calling the below function as chained.
-  /// For example, transaction..deleteText(..)..insertText(..);
-  static final Map<Node, List<Delta>> _composeMap = {};
+  /// The delta cache lives on the transaction itself (`Transaction._composeMap`)
+  /// so chained calls compose together — transaction..deleteText(..)..insertText(..) —
+  /// while a transaction that is dropped or refused takes its pending deltas
+  /// with it instead of handing them to whichever transaction composes next.
 
   /// Inserts the [text] at the given [index].
   ///
@@ -448,23 +453,28 @@ extension TextTransaction on Transaction {
 
       return;
     }
-    for (final entry in _composeMap.entries) {
-      final node = entry.key;
-      if (node.delta == null) {
-        continue;
+    try {
+      for (final entry in _composeMap.entries) {
+        final node = entry.key;
+        if (node.delta == null) {
+          continue;
+        }
+        final deltaQueue = entry.value;
+        final composed = deltaQueue.fold<Delta>(
+          node.delta!,
+          (p, e) => p.compose(e),
+        );
+        assert(composed.every((element) => element is TextInsert));
+        updateNode(node, {
+          blockComponentDelta: composed.toJson(),
+        });
       }
-      final deltaQueue = entry.value;
-      final composed = deltaQueue.fold<Delta>(
-        node.delta!,
-        (p, e) => p.compose(e),
-      );
-      assert(composed.every((element) => element is TextInsert));
-      updateNode(node, {
-        blockComponentDelta: composed.toJson(),
-      });
+    } finally {
+      // Cleared whether or not the loop finished: a delta that failed to
+      // compose is discarded with its transaction, never retried by the next.
+      markNeedsComposing = false;
+      _composeMap.clear();
     }
-    markNeedsComposing = false;
-    _composeMap.clear();
   }
 
   void addDeltaToComposeMap(Node node, Delta delta) {

--- a/test/core/transform/transaction_test.dart
+++ b/test/core/transform/transaction_test.dart
@@ -739,4 +739,55 @@ void main() async {
       ),
     );
   });
+
+  group('compose map is scoped to its transaction', () {
+    test('a refused text transaction does not leak into the next one',
+        () async {
+      // A transaction built while the editor is read-only is refused by
+      // apply() before it is ever composed. Its pending text delta must be
+      // discarded with it, not re-composed by the next transaction that
+      // touches the same node.
+      final document = Document.blank().addParagraphs(
+        1,
+        initialText: 'hello',
+      );
+      final editorState = EditorState(document: document)..editable = false;
+      final node = editorState.getNodeAtPath([0])!;
+
+      final refused = editorState.transaction..insertText(node, 5, ' world');
+      await editorState.apply(refused);
+      expect(node.delta?.toPlainText(), 'hello');
+
+      editorState.editable = true;
+      final next = editorState.transaction..insertText(node, 0, 'A');
+      expect(next.operations.length, 1);
+      await editorState.apply(next);
+
+      expect(editorState.getNodeAtPath([0])?.delta?.toPlainText(), 'Ahello');
+    });
+
+    test('refused deletes on the same node do not poison later transactions',
+        () async {
+      // Two refused deletes of the whole text queued against one node used to
+      // compose past the end of its delta, tripping the inserts-only
+      // assertion in compose() on every later transaction in the process.
+      final document = Document.blank().addParagraphs(
+        1,
+        initialText: 'hello',
+      );
+      final editorState = EditorState(document: document)..editable = false;
+      final node = editorState.getNodeAtPath([0])!;
+
+      await editorState.apply(editorState.transaction..deleteText(node, 0, 5));
+      await editorState.apply(editorState.transaction..deleteText(node, 0, 5));
+      expect(node.delta?.toPlainText(), 'hello');
+
+      editorState.editable = true;
+      final next = editorState.transaction..insertText(node, 5, '!');
+      expect(() => next.operations, returnsNormally);
+      await editorState.apply(next);
+
+      expect(editorState.getNodeAtPath([0])?.delta?.toPlainText(), 'hello!');
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- move the pending-delta cache of `TextTransaction` (`_composeMap`) from a static on the extension onto the `Transaction` instance, so a transaction that is never applied cannot hand its deltas to the next one
- clear that cache in a `finally` inside `compose()`, so a delta that fails to compose is discarded with its transaction instead of being retried by every later one
- add two regression tests in `test/core/transform/transaction_test.dart` that fail on `main` and pass with the fix

Fixes: https://github.com/AppFlowy-IO/AppFlowy/issues/4763

## Root cause

`TextTransaction` (`lib/src/core/transform/transaction.dart`) queues the deltas built by `insertText`, `deleteText`, `mergeText`, `formatText`, and `replaceText` in `static final Map<Node, List<Delta>> _composeMap`, one map shared by every `Transaction` in the process. `compose()` folds each queued delta over its node's current delta, asserts the result contains only `TextInsert`s, and clears the map only after the whole loop has succeeded.

`EditorState.apply` returns before it reads `transaction.operations` when the editor is disposed or not editable. A text transaction refused that way is never composed, so its deltas stay queued, and every later transaction on any node re-composes them as if they were its own:

- a format or insert refused while the editor was read-only is applied by the next transaction that composes, typically the next keystroke, on whatever node it targeted;
- once a leftover no longer fits its node (a refused delete retried, or a range a later edit already removed), `Delta.compose` runs past the end of the delta and emits a `TextDelete`, the inserts-only assertion throws inside `compose()`, and because the map is never cleared on that path the same assertion fires on every subsequent transaction in the process. Typing stops landing in every document until the app restarts. The stack in #4763 (`Delta.compose` → `TextTransaction.compose` → `Transaction.operations`) is this path.

Host apps reach it through their own toolbars and menus, which call `toggleAttribute` / `formatDelta` or build text transactions directly against an editor that is read-only or was just disposed. The package's own floating toolbar and character shortcuts are gated on `editable`, and `deleteSelection` reads `transaction.operations` for its debug log before `apply`, so the built-in UI does not trigger it on its own.

The cache was static because an extension cannot hold state; the transaction is its natural owner, and chained calls (`transaction..deleteText(..)..insertText(..)`) compose together exactly as before. No public API changes.

## Tests

- `flutter test test/core/transform/` — 38 passing. The two new cases fail on `main`: the refused `' world'` insert composes in and the text reads `Ahello world` instead of `Ahello`; two refused whole-text deletes make `operations` throw `'composed.every((element) => element is TextInsert)': is not true`.
- `flutter analyze` — no diagnostics introduced by this change.
- `dart format --set-exit-if-changed .` and `dart run custom_lint` — clean.

## Manual reproduction (example app)

The **Fixed Toolbar** page (`example/lib/pages/fixed_toolbar_editor.dart`) calls `editorState.toggleAttribute` from an external toolbar without checking `editable`, which is the host-app shape. It has no read-only switch, so temporarily make the unused `Icons.code` case in `_FixedToolbar` run `editorState.editable = !editorState.editable;`.

A refused format lands later:

1. Open **Fixed Toolbar**, select a word, press `</>` (editor is now read-only; typing does nothing).
2. With the word still selected, press **Bold**. Nothing changes in either state.
3. Press `</>` again, click at the end of a different paragraph, type one character.
   - `main`: the character appears **and** the word from step 1 turns bold at the same moment.
   - this branch: only the character appears.

A refused delete leaves the editor stuck:

Also route the unused `Icons.format_quote` case through a host-style delete of the selection:

```dart
final selection = editorState.selection;
if (selection == null || selection.isCollapsed) return;
final node = editorState.getNodeAtPath(selection.start.path)!;
editorState.apply(
  editorState.transaction
    ..deleteText(node, selection.startIndex, selection.length),
);
```

1. Select the whole text of a one-line paragraph, press `</>`.
2. Press the **quote** button twice. The text stays in either state.
3. Press `</>` again, click anywhere, type one character.
   - `main` (debug build): nothing lands, the console shows the `TextInsert` assertion from `TextTransaction.compose`, and typing anywhere else fails the same way until restart.
   - this branch: the character appears and the editor keeps working.
