### PR TITLE
fix: re-show the mobile keyboard when tapping the existing caret

### DIFF
--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -86,8 +86,7 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
       return;
     }
 
-    if (!formattedValue.isValid() ||
-        currentTextEditingValue == formattedValue) {
+    if (!formattedValue.isValid()) {
       return;
     }
 
@@ -101,11 +100,16 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
 
     Debounce.cancel(debounceKey);
 
-    _textInputConnection!
-      ..setEditingState(formattedValue)
-      ..show();
+    // Dismissing the soft keyboard often leaves the connection attached with
+    // the same editing value. Skip setEditingState in that case (it can
+    // disrupt IME composition) but still call show() so a same-caret tap
+    // brings the keyboard back.
+    if (currentTextEditingValue != formattedValue) {
+      _textInputConnection!.setEditingState(formattedValue);
+      currentTextEditingValue = formattedValue;
+    }
 
-    currentTextEditingValue = formattedValue;
+    _textInputConnection!.show();
 
     AppFlowyEditorLog.input.debug(
       'attach text editing value: $textEditingValue',

--- a/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
+++ b/lib/src/editor/editor_component/service/ime/non_delta_input_service.dart
@@ -90,8 +90,9 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
       return;
     }
 
-    if (_textInputConnection == null ||
-        _textInputConnection!.attached == false) {
+    final needsNewConnection = _textInputConnection == null ||
+        _textInputConnection!.attached == false;
+    if (needsNewConnection) {
       _textInputConnection = TextInput.attach(
         this,
         configuration,
@@ -100,11 +101,11 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
 
     Debounce.cancel(debounceKey);
 
-    // Dismissing the soft keyboard often leaves the connection attached with
-    // the same editing value. Skip setEditingState in that case (it can
-    // disrupt IME composition) but still call show() so a same-caret tap
-    // brings the keyboard back.
-    if (currentTextEditingValue != formattedValue) {
+    // A replacement connection (another client stole the IME) must receive
+    // the current value. An already-attached connection can skip an
+    // identical setEditingState, which would disrupt composition, but still
+    // needs show() so a same-caret tap brings the keyboard back.
+    if (needsNewConnection || currentTextEditingValue != formattedValue) {
       _textInputConnection!.setEditingState(formattedValue);
       currentTextEditingValue = formattedValue;
     }
@@ -321,7 +322,7 @@ class NonDeltaTextInputService extends TextInputService with TextInputClient {
     }
 
     // solve the issue where the Chinese IME doesn't continue deleting after the input content has been deleted.
-    if (PlatformExtension.isMacOS &&
+    if ((PlatformExtension.isMacOS || PlatformExtension.isIOS) &&
         (composingTextRange?.isCollapsed ?? false)) {
       composingTextRange = TextRange.empty;
     }

--- a/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
+++ b/lib/src/editor/editor_component/service/selection/mobile_selection_service.dart
@@ -634,6 +634,13 @@ class _MobileSelectionServiceWidgetState
     // if the tap happens on a selection area, don't change the selection
     if (_isClickOnSelectionArea(offset)) {
       appFlowyEditorOnTapSelectionArea.add(0);
+      final selection = editorState.selection;
+      if (selection != null) {
+        // The caret did not move, so selection listeners will not re-attach
+        // the IME. Request it explicitly in case the user dismissed the
+        // keyboard and tapped the same cursor position.
+        editorState.service.keyboardService?.enableKeyBoard(selection);
+      }
 
       return;
     }

--- a/test/editor/editor_component/ime/non_delta_input_service_test.dart
+++ b/test/editor/editor_component/ime/non_delta_input_service_test.dart
@@ -216,4 +216,33 @@ void main() {
     final currentSelection = inputService.currentTextEditingValue?.selection;
     assert(currentSelection?.baseOffset == 100);
   });
+
+  testWidgets('reattach same value still shows the IME', (tester) async {
+    final inputService = NonDeltaTextInputService(
+      onInsert: (_) async => true,
+      onDelete: (_) async => true,
+      onReplace: (_) async => true,
+      onNonTextUpdate: (_) async => true,
+      onPerformAction: (_) async {},
+    );
+    addTearDown(inputService.close);
+
+    const value = TextEditingValue(
+      text: 'hello',
+      selection: TextSelection.collapsed(offset: 5),
+    );
+    inputService.attach(value, const TextInputConfiguration());
+    await tester.pump();
+    expect(inputService.attached, isTrue);
+    expect(tester.testTextInput.hasAnyClients, isTrue);
+
+    tester.testTextInput.hide();
+    await tester.pump();
+
+    // Same caret / same editing value: the IME must still be requested.
+    inputService.attach(value, const TextInputConfiguration());
+    await tester.pump();
+    expect(inputService.attached, isTrue);
+    expect(tester.testTextInput.hasAnyClients, isTrue);
+  });
 }

--- a/test/editor/editor_component/ime/non_delta_input_service_test.dart
+++ b/test/editor/editor_component/ime/non_delta_input_service_test.dart
@@ -244,5 +244,52 @@ void main() {
     await tester.pump();
     expect(inputService.attached, isTrue);
     expect(tester.testTextInput.hasAnyClients, isTrue);
+    expect(tester.testTextInput.isVisible, isTrue);
+  });
+
+  testWidgets('new connection receives editing state even at same caret',
+      (tester) async {
+    final inputService = NonDeltaTextInputService(
+      onInsert: (_) async => true,
+      onDelete: (_) async => true,
+      onReplace: (_) async => true,
+      onNonTextUpdate: (_) async => true,
+      onPerformAction: (_) async {},
+    );
+    addTearDown(inputService.close);
+
+    const value = TextEditingValue(
+      text: 'hello',
+      selection: TextSelection.collapsed(offset: 5),
+    );
+    inputService.attach(value, const TextInputConfiguration());
+    await tester.pump();
+
+    final other = NonDeltaTextInputService(
+      onInsert: (_) async => true,
+      onDelete: (_) async => true,
+      onReplace: (_) async => true,
+      onNonTextUpdate: (_) async => true,
+      onPerformAction: (_) async {},
+    );
+    addTearDown(other.close);
+    other.attach(
+      const TextEditingValue(
+        text: 'other',
+        selection: TextSelection.collapsed(offset: 5),
+      ),
+      const TextInputConfiguration(),
+    );
+    await tester.pump();
+    expect(inputService.attached, isFalse);
+
+    tester.testTextInput.log.clear();
+    inputService.attach(value, const TextInputConfiguration());
+    await tester.pump();
+    expect(inputService.attached, isTrue);
+    expect(
+      tester.testTextInput.log.map((call) => call.method),
+      contains('TextInput.setEditingState'),
+    );
   });
 }


### PR DESCRIPTION
Hello,

This PR does re-show the software keyboard when the user taps the existing caret after dismissing it.

It was slightly annoying behavior and I thought standard was to behave like in other editors.

Note: PR was AI-Assisted

Best regards
Saif