### PR TITLE
fix: keep the mobile caret visible after the keyboard resizes the editor

### DIFF
--- a/lib/src/editor/editor_component/entry/page_block_component.dart
+++ b/lib/src/editor/editor_component/entry/page_block_component.dart
@@ -149,11 +149,20 @@ class PageBlockComponent extends BlockComponentStatelessWidget {
   }
 
   Widget _keyboardClearance(BuildContext context, EditorState editorState) {
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
+    final viewport = editorState.renderBox;
     return IgnoreEditorSelectionGesture(
       child: SizedBox(
         height: keyboardBottomScrollClearance(
           edgeOffset: editorState.autoScrollEdgeOffset,
-          keyboardInset: MediaQuery.viewInsetsOf(context).bottom,
+          keyboardInset: keyboardInset,
+          keyboardOverlap: viewport == null
+              ? 0
+              : keyboardViewportOverlap(
+                  viewport: viewport,
+                  screenSize: MediaQuery.sizeOf(context),
+                  keyboardInset: keyboardInset,
+                ),
         ),
       ),
     );

--- a/lib/src/editor/editor_component/entry/page_block_component.dart
+++ b/lib/src/editor/editor_component/entry/page_block_component.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/editor/block_component/base_component/widget/ignore_parent_gesture.dart';
+import 'package:appflowy_editor/src/editor/util/platform_extension.dart';
 import 'package:appflowy_editor/src/flutter/scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -85,28 +86,36 @@ class PageBlockComponent extends BlockComponentStatelessWidget {
                   },
                 ),
                 if (footer != null) footer!,
+                if (PlatformExtension.isMobile)
+                  _keyboardClearance(context, editorState),
               ],
             );
           },
         ),
       );
     } else {
-      int extentCount = 0;
-      if (header != null) extentCount++;
-      if (footer != null) extentCount++;
+      final hasHeader = header != null;
+      final hasFooter = footer != null;
+      final hasClearance = PlatformExtension.isMobile;
+      final extentCount =
+          (hasHeader ? 1 : 0) + (hasFooter ? 1 : 0) + (hasClearance ? 1 : 0);
 
       return ScrollablePositionedList.builder(
         shrinkWrap: scrollController.shrinkWrap,
         itemCount: items.length + extentCount,
         itemBuilder: (context, index) {
           editorState.updateAutoScroller(Scrollable.of(context));
-          if (header != null && index == 0) {
+          if (hasHeader && index == 0) {
             return IgnoreEditorSelectionGesture(
               child: header!,
             );
           }
 
-          if (footer != null && index == (items.length - 1) + extentCount) {
+          final lastIndex = items.length + extentCount - 1;
+          if (hasClearance && index == lastIndex) {
+            return _keyboardClearance(context, editorState);
+          }
+          if (hasFooter && index == lastIndex - (hasClearance ? 1 : 0)) {
             return IgnoreEditorSelectionGesture(
               child: footer!,
             );
@@ -137,5 +146,16 @@ class PageBlockComponent extends BlockComponentStatelessWidget {
         scrollOffsetListener: scrollController.scrollOffsetListener,
       );
     }
+  }
+
+  Widget _keyboardClearance(BuildContext context, EditorState editorState) {
+    return IgnoreEditorSelectionGesture(
+      child: SizedBox(
+        height: keyboardBottomScrollClearance(
+          edgeOffset: editorState.autoScrollEdgeOffset,
+          keyboardInset: MediaQuery.viewInsetsOf(context).bottom,
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/editor/editor_component/service/scroll/editor_scroll_controller.dart
+++ b/lib/src/editor/editor_component/service/scroll/editor_scroll_controller.dart
@@ -274,6 +274,12 @@ class EditorScrollController {
       max--;
     }
 
+    // Keyboard clearance (and any other trailing extent) is not content.
+    final lastContent = editorState.document.root.children.length - 1;
+    if (max > lastContent) {
+      max = lastContent;
+    }
+
     // notify the listeners
 
     visibleRangeNotifier.value = (min, max);

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -317,10 +317,14 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
     final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
     final edge = editorState.autoScrollEdgeOffset;
     final bottomEdge = keyboardBottomScrollClearance(
-          edgeOffset: edge,
-          keyboardInset: keyboardInset,
-        ) +
-        _obscuredBottom(scrollBox);
+      edgeOffset: edge,
+      keyboardInset: keyboardInset,
+      keyboardOverlap: keyboardViewportOverlap(
+        viewport: scrollBox,
+        screenSize: MediaQuery.sizeOf(context),
+        keyboardInset: keyboardInset,
+      ),
+    );
     final delta = computeSelectionVisibleScrollDelta(
       localSelection: localSelection,
       viewportSize: scrollBox.size,
@@ -348,19 +352,6 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
         _ensureSelectionVisible(attempt: 1);
       });
     }
-  }
-
-  /// How much of [scrollBox] sits under the software keyboard, in local px.
-  double _obscuredBottom(RenderBox scrollBox) {
-    final insets = MediaQuery.viewInsetsOf(context).bottom;
-    if (insets <= 0) {
-      return 0;
-    }
-    final boxBottom =
-        scrollBox.localToGlobal(Offset(0, scrollBox.size.height)).dy;
-    final keyboardTop = MediaQuery.sizeOf(context).height - insets;
-    final covered = boxBottom - keyboardTop;
-    return covered > 0 ? covered : 0;
   }
 
   Future<void> _scrollBy(double delta, {required bool animate}) {
@@ -399,15 +390,35 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
 /// Extra list extent below the last line while the IME is visible.
 const double appFlowyEditorKeyboardCaretGap = 32.0;
 
+/// How much of [viewport] sits under the software keyboard, in local px.
+double keyboardViewportOverlap({
+  required RenderBox viewport,
+  required Size screenSize,
+  required double keyboardInset,
+}) {
+  if (keyboardInset <= 0 || !viewport.hasSize) {
+    return 0;
+  }
+  final boxBottom =
+      viewport.localToGlobal(Offset(0, viewport.size.height)).dy;
+  final keyboardTop = screenSize.height - keyboardInset;
+  final covered = boxBottom - keyboardTop;
+  return covered > 0 ? covered : 0;
+}
+
 /// Real bottom spacer height so the last line can sit above the keyboard.
+///
+/// Includes [keyboardOverlap] when the editor viewport is not fully resized
+/// above the IME; a fixed pad cannot substitute for that measured amount.
 double keyboardBottomScrollClearance({
   required double edgeOffset,
   required double keyboardInset,
+  double keyboardOverlap = 0,
 }) {
   if (keyboardInset <= 0) {
     return 0;
   }
-  return edgeOffset + appFlowyEditorKeyboardCaretGap;
+  return edgeOffset + appFlowyEditorKeyboardCaretGap + keyboardOverlap;
 }
 
 /// How far to scroll so [localSelection] stays inside the viewport.

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -22,6 +22,7 @@ class ScrollServiceWidget extends StatefulWidget {
 }
 
 class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
+    with WidgetsBindingObserver
     implements AppFlowyScrollService {
   final _forwardKey =
       GlobalKey(debugLabel: 'forward_to_platform_scroll_service');
@@ -34,18 +35,39 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
   late ScrollController scrollController = ScrollController();
 
   Selection? lastSelection;
+  double _lastViewInsetsBottom = 0;
 
   @override
   void initState() {
     super.initState();
     editorState.selectionNotifier.addListener(_onSelectionChanged);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     scrollController.dispose();
     editorState.selectionNotifier.removeListener(_onSelectionChanged);
     super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    if (!PlatformExtension.isMobile) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+      final keyboardGrew = bottomInset > _lastViewInsetsBottom + 1.0;
+      _lastViewInsetsBottom = bottomInset;
+      if (keyboardGrew) {
+        _ensureSelectionVisible();
+      }
+    });
   }
 
   @override
@@ -176,14 +198,22 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
           if (_forwardKey.currentContext == null) {
             return;
           }
-          // Mobile needs to continuously update scroll position/direction during drag
-          // Don't skip even if already scrolling, because direction may have changed
-          startAutoScroll(
-            endTouchPoint,
-            edgeOffset: editorState.autoScrollEdgeOffset,
-            direction: direction,
-            duration: scrollDuration,
-          );
+          if (isDragOperation) {
+            // Mobile needs to continuously update scroll position/direction
+            // during drag. Don't skip even if already scrolling, because
+            // direction may have changed.
+            startAutoScroll(
+              endTouchPoint,
+              edgeOffset: editorState.autoScrollEdgeOffset,
+              direction: direction,
+              duration: scrollDuration,
+            );
+            return;
+          }
+          // Edge-dragging only nudges a few pixels per tick and does not
+          // continue after a tap. After the soft keyboard resizes the
+          // viewport, jump the caret fully back into view.
+          _ensureSelectionVisible();
         });
       } else {
         if (_forwardKey.currentContext == null) {
@@ -260,4 +290,66 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
 
   @override
   void goBallistic(double velocity) => forward.goBallistic(velocity);
+
+  void _ensureSelectionVisible() {
+    if (editorState.disableAutoScroll) {
+      return;
+    }
+    final selectionRects = editorState.selectionRects();
+    if (selectionRects.isEmpty) {
+      return;
+    }
+    final scrollBox = editorState.renderBox;
+    if (scrollBox == null || !scrollBox.hasSize) {
+      return;
+    }
+
+    final targetRect = selectionRects.last;
+    final localSelection = Rect.fromPoints(
+      scrollBox.globalToLocal(targetRect.topLeft),
+      scrollBox.globalToLocal(targetRect.bottomRight),
+    );
+    final delta = computeSelectionVisibleScrollDelta(
+      localSelection: localSelection,
+      viewportSize: scrollBox.size,
+      edgeOffset: editorState.autoScrollEdgeOffset,
+    );
+    if (delta == null || delta == 0) {
+      return;
+    }
+
+    final targetOffset =
+        widget.editorScrollController.offsetNotifier.value + delta;
+    widget.editorScrollController.animateTo(
+      offset: targetOffset,
+      duration: Duration.zero,
+    );
+  }
+}
+
+/// How far to scroll so [localSelection] stays inside the viewport.
+///
+/// [localSelection] is in the scrollable viewport's local coordinates.
+/// Positive scrolls down; negative scrolls up. Returns null if already visible.
+double? computeSelectionVisibleScrollDelta({
+  required Rect localSelection,
+  required Size viewportSize,
+  double edgeOffset = 0,
+}) {
+  if (viewportSize.height <= 0) {
+    return null;
+  }
+
+  final visibleTop = edgeOffset;
+  final visibleBottom = viewportSize.height - edgeOffset;
+  if (visibleBottom <= visibleTop) {
+    return localSelection.center.dy - viewportSize.height / 2;
+  }
+  if (localSelection.bottom > visibleBottom) {
+    return localSelection.bottom - visibleBottom;
+  }
+  if (localSelection.top < visibleTop) {
+    return localSelection.top - visibleTop;
+  }
+  return null;
 }

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -320,10 +320,25 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
 
     final targetOffset =
         widget.editorScrollController.offsetNotifier.value + delta;
-    widget.editorScrollController.animateTo(
-      offset: targetOffset,
-      duration: Duration.zero,
-    );
+    _jumpToOffset(targetOffset);
+  }
+
+  void _jumpToOffset(double offset) {
+    final controller = widget.editorScrollController;
+    final clamped = offset < 0 ? 0.0 : offset;
+    // animateTo(duration: Duration.zero) asserts in Flutter.
+    if (controller.shrinkWrap) {
+      if (controller.scrollController.hasClients) {
+        controller.scrollController.jumpTo(
+          clamped.clamp(
+            controller.scrollController.position.minScrollExtent,
+            controller.scrollController.position.maxScrollExtent,
+          ),
+        );
+      }
+      return;
+    }
+    controller.scrollOffsetController.jumpTo(offset: clamped);
   }
 }
 

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -379,8 +379,20 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
         curve: Curves.easeOut,
       );
     }
+    final position = editorState.scrollableState?.position;
+    var clampedDelta = delta;
+    if (position != null) {
+      final target = (position.pixels + delta).clamp(
+        position.minScrollExtent,
+        position.maxScrollExtent,
+      );
+      clampedDelta = target - position.pixels;
+      if (clampedDelta.abs() < 0.5) {
+        return Future.value();
+      }
+    }
     return controller.scrollOffsetController.animateScroll(
-      offset: delta,
+      offset: clampedDelta,
       duration: animate ? duration : const Duration(milliseconds: 1),
       curve: Curves.easeOut,
     );

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -36,6 +36,7 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
 
   Selection? lastSelection;
   double _lastViewInsetsBottom = 0;
+  int _ensureGeneration = 0;
 
   @override
   void initState() {
@@ -295,6 +296,10 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
     if (editorState.disableAutoScroll) {
       return;
     }
+    if (attempt == 0) {
+      _ensureGeneration++;
+    }
+    final generation = _ensureGeneration;
     final selectionRects = editorState.selectionRects();
     if (selectionRects.isEmpty) {
       return;
@@ -311,33 +316,36 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
     );
     final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
     final edge = editorState.autoScrollEdgeOffset;
-    // Android often leaves the editor box overlapping the IME even with
-    // adjustResize. Subtract that overlap and keep extra padding so the
-    // caret is not flush against the keyboard.
-    final bottomEdge = edge + _obscuredBottom(scrollBox) + (keyboardInset > 0 ? 32.0 : 0.0);
+    final bottomEdge = keyboardBottomScrollClearance(
+          edgeOffset: edge,
+          keyboardInset: keyboardInset,
+        ) +
+        _obscuredBottom(scrollBox);
     final delta = computeSelectionVisibleScrollDelta(
       localSelection: localSelection,
       viewportSize: scrollBox.size,
       edgeOffset: edge,
-      bottomEdgeOffset: bottomEdge,
+      bottomEdgeOffset: bottomEdge > 0 ? bottomEdge : edge,
     );
     if (delta != null && delta.abs() > 0.5) {
-      _scrollBy(delta);
+      final future = _scrollBy(delta, animate: attempt == 0);
       if (attempt < 2) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            _ensureSelectionVisible(attempt: attempt + 1);
+        future.then((_) {
+          if (!mounted || generation != _ensureGeneration) {
+            return;
           }
+          _ensureSelectionVisible(attempt: attempt + 1);
         });
       }
       return;
     }
-    // Scroll extent can lag the keyboard inset by a frame.
+    // Scroll extent can lag the keyboard inset / footer layout by a frame.
     if (attempt == 0 && keyboardInset > 0) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _ensureSelectionVisible(attempt: 1);
+        if (!mounted || generation != _ensureGeneration) {
+          return;
         }
+        _ensureSelectionVisible(attempt: 1);
       });
     }
   }
@@ -355,7 +363,7 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
     return covered > 0 ? covered : 0;
   }
 
-  void _scrollBy(double delta) {
+  Future<void> _scrollBy(double delta, {required bool animate}) {
     final controller = widget.editorScrollController;
     // Relative to the live scroll position. offsetNotifier can desync after
     // a keyboard hide/show; jumping to (staleNotifier + delta) looks like a
@@ -363,26 +371,43 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
     const duration = Duration(milliseconds: 100);
     if (controller.shrinkWrap) {
       if (!controller.scrollController.hasClients) {
-        return;
+        return Future.value();
       }
       final position = controller.scrollController.position;
       final target = (position.pixels + delta).clamp(
         position.minScrollExtent,
         position.maxScrollExtent,
       );
-      controller.scrollController.animateTo(
+      if (!animate) {
+        controller.scrollController.jumpTo(target);
+        return Future.value();
+      }
+      return controller.scrollController.animateTo(
         target,
         duration: duration,
         curve: Curves.easeOut,
       );
-      return;
     }
-    controller.scrollOffsetController.animateScroll(
+    return controller.scrollOffsetController.animateScroll(
       offset: delta,
-      duration: duration,
+      duration: animate ? duration : const Duration(milliseconds: 1),
       curve: Curves.easeOut,
     );
   }
+}
+
+/// Extra list extent below the last line while the IME is visible.
+const double appFlowyEditorKeyboardCaretGap = 32.0;
+
+/// Real bottom spacer height so the last line can sit above the keyboard.
+double keyboardBottomScrollClearance({
+  required double edgeOffset,
+  required double keyboardInset,
+}) {
+  if (keyboardInset <= 0) {
+    return 0;
+  }
+  return edgeOffset + appFlowyEditorKeyboardCaretGap;
 }
 
 /// How far to scroll so [localSelection] stays inside the viewport.

--- a/lib/src/editor/editor_component/service/scroll_service_widget.dart
+++ b/lib/src/editor/editor_component/service/scroll_service_widget.dart
@@ -291,7 +291,7 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
   @override
   void goBallistic(double velocity) => forward.goBallistic(velocity);
 
-  void _ensureSelectionVisible() {
+  void _ensureSelectionVisible({int attempt = 0}) {
     if (editorState.disableAutoScroll) {
       return;
     }
@@ -309,36 +309,79 @@ class _ScrollServiceWidgetState extends State<ScrollServiceWidget>
       scrollBox.globalToLocal(targetRect.topLeft),
       scrollBox.globalToLocal(targetRect.bottomRight),
     );
+    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
+    final edge = editorState.autoScrollEdgeOffset;
+    // Android often leaves the editor box overlapping the IME even with
+    // adjustResize. Subtract that overlap and keep extra padding so the
+    // caret is not flush against the keyboard.
+    final bottomEdge = edge + _obscuredBottom(scrollBox) + (keyboardInset > 0 ? 32.0 : 0.0);
     final delta = computeSelectionVisibleScrollDelta(
       localSelection: localSelection,
       viewportSize: scrollBox.size,
-      edgeOffset: editorState.autoScrollEdgeOffset,
+      edgeOffset: edge,
+      bottomEdgeOffset: bottomEdge,
     );
-    if (delta == null || delta == 0) {
-      return;
-    }
-
-    final targetOffset =
-        widget.editorScrollController.offsetNotifier.value + delta;
-    _jumpToOffset(targetOffset);
-  }
-
-  void _jumpToOffset(double offset) {
-    final controller = widget.editorScrollController;
-    final clamped = offset < 0 ? 0.0 : offset;
-    // animateTo(duration: Duration.zero) asserts in Flutter.
-    if (controller.shrinkWrap) {
-      if (controller.scrollController.hasClients) {
-        controller.scrollController.jumpTo(
-          clamped.clamp(
-            controller.scrollController.position.minScrollExtent,
-            controller.scrollController.position.maxScrollExtent,
-          ),
-        );
+    if (delta != null && delta.abs() > 0.5) {
+      _scrollBy(delta);
+      if (attempt < 2) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            _ensureSelectionVisible(attempt: attempt + 1);
+          }
+        });
       }
       return;
     }
-    controller.scrollOffsetController.jumpTo(offset: clamped);
+    // Scroll extent can lag the keyboard inset by a frame.
+    if (attempt == 0 && keyboardInset > 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _ensureSelectionVisible(attempt: 1);
+        }
+      });
+    }
+  }
+
+  /// How much of [scrollBox] sits under the software keyboard, in local px.
+  double _obscuredBottom(RenderBox scrollBox) {
+    final insets = MediaQuery.viewInsetsOf(context).bottom;
+    if (insets <= 0) {
+      return 0;
+    }
+    final boxBottom =
+        scrollBox.localToGlobal(Offset(0, scrollBox.size.height)).dy;
+    final keyboardTop = MediaQuery.sizeOf(context).height - insets;
+    final covered = boxBottom - keyboardTop;
+    return covered > 0 ? covered : 0;
+  }
+
+  void _scrollBy(double delta) {
+    final controller = widget.editorScrollController;
+    // Relative to the live scroll position. offsetNotifier can desync after
+    // a keyboard hide/show; jumping to (staleNotifier + delta) looks like a
+    // reset-to-top followed by a second scroll.
+    const duration = Duration(milliseconds: 100);
+    if (controller.shrinkWrap) {
+      if (!controller.scrollController.hasClients) {
+        return;
+      }
+      final position = controller.scrollController.position;
+      final target = (position.pixels + delta).clamp(
+        position.minScrollExtent,
+        position.maxScrollExtent,
+      );
+      controller.scrollController.animateTo(
+        target,
+        duration: duration,
+        curve: Curves.easeOut,
+      );
+      return;
+    }
+    controller.scrollOffsetController.animateScroll(
+      offset: delta,
+      duration: duration,
+      curve: Curves.easeOut,
+    );
   }
 }
 
@@ -350,13 +393,14 @@ double? computeSelectionVisibleScrollDelta({
   required Rect localSelection,
   required Size viewportSize,
   double edgeOffset = 0,
+  double? bottomEdgeOffset,
 }) {
   if (viewportSize.height <= 0) {
     return null;
   }
 
   final visibleTop = edgeOffset;
-  final visibleBottom = viewportSize.height - edgeOffset;
+  final visibleBottom = viewportSize.height - (bottomEdgeOffset ?? edgeOffset);
   if (visibleBottom <= visibleTop) {
     return localSelection.center.dy - viewportSize.height / 2;
   }

--- a/lib/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart
+++ b/lib/src/flutter/scrollable_positioned_list/src/scrollable_positioned_list.dart
@@ -281,10 +281,22 @@ class ScrollOffsetController {
     required Duration duration,
     Curve curve = Curves.linear,
   }) async {
-    final currentPosition =
-        _scrollableListState!.primary.scrollController.offset;
-    final newPosition = currentPosition + offset;
-    await _scrollableListState!.primary.scrollController.animateTo(
+    final controller = _scrollableListState?.primary.scrollController;
+    if (controller == null || !controller.hasClients) {
+      return;
+    }
+    final position = controller.position;
+    // animateTo past the extents rubber-bands with BouncingScrollPhysics
+    // and then springs back — the caret-visible path used to do this
+    // when the last line needed more padding than remaining extent.
+    final newPosition = (position.pixels + offset).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    if ((newPosition - position.pixels).abs() < 0.5) {
+      return;
+    }
+    await controller.animateTo(
       newPosition,
       duration: duration,
       curve: curve,
@@ -296,15 +308,35 @@ class ScrollOffsetController {
     required Duration duration,
     Curve curve = Curves.linear,
   }) async {
-    await _scrollableListState!.primary.scrollController.animateTo(
-      offset,
+    final controller = _scrollableListState?.primary.scrollController;
+    if (controller == null || !controller.hasClients) {
+      return;
+    }
+    final position = controller.position;
+    final newPosition = offset.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    if ((newPosition - position.pixels).abs() < 0.5) {
+      return;
+    }
+    await controller.animateTo(
+      newPosition,
       duration: duration,
       curve: curve,
     );
   }
 
-  void jumpTo({required double offset}) =>
-      _scrollableListState!.primary.scrollController.jumpTo(offset);
+  void jumpTo({required double offset}) {
+    final controller = _scrollableListState?.primary.scrollController;
+    if (controller == null || !controller.hasClients) {
+      return;
+    }
+    final position = controller.position;
+    controller.jumpTo(
+      offset.clamp(position.minScrollExtent, position.maxScrollExtent),
+    );
+  }
 
   _ScrollablePositionedListState? _scrollableListState;
 

--- a/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
+++ b/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
@@ -1,0 +1,56 @@
+import 'package:appflowy_editor/src/editor/editor_component/service/scroll_service_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('computeSelectionVisibleScrollDelta', () {
+    const viewport = Size(400, 600);
+
+    test('returns null when the caret is already inside the padded viewport',
+        () {
+      const caret = Rect.fromLTWH(16, 200, 2, 20);
+      expect(
+        computeSelectionVisibleScrollDelta(
+          localSelection: caret,
+          viewportSize: viewport,
+          edgeOffset: 20,
+        ),
+        isNull,
+      );
+    });
+
+    test('scrolls down when the caret sits below the visible area', () {
+      const caret = Rect.fromLTWH(16, 590, 2, 20);
+      expect(
+        computeSelectionVisibleScrollDelta(
+          localSelection: caret,
+          viewportSize: viewport,
+          edgeOffset: 20,
+        ),
+        caret.bottom - (viewport.height - 20),
+      );
+    });
+
+    test('scrolls up when the caret sits above the visible area', () {
+      const caret = Rect.fromLTWH(16, 4, 2, 20);
+      expect(
+        computeSelectionVisibleScrollDelta(
+          localSelection: caret,
+          viewportSize: viewport,
+          edgeOffset: 20,
+        ),
+        caret.top - 20,
+      );
+    });
+
+    test('returns null for an empty viewport', () {
+      expect(
+        computeSelectionVisibleScrollDelta(
+          localSelection: const Rect.fromLTWH(0, 0, 2, 20),
+          viewportSize: Size.zero,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
+++ b/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
@@ -253,6 +253,47 @@ void main() {
     );
   });
 
+  testWidgets('animateScroll does not overshoot max extent', (tester) async {
+    final items = ItemScrollController();
+    final offsets = ScrollOffsetController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 200,
+          child: ScrollablePositionedList.builder(
+            itemScrollController: items,
+            scrollOffsetController: offsets,
+            itemCount: 8,
+            itemBuilder: (_, index) => SizedBox(
+              height: 40,
+              child: Text('$index'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    items.jumpTo(index: 7);
+    await tester.pump();
+
+    final position =
+        tester.state<ScrollableState>(find.byType(Scrollable)).position;
+    expect(position.pixels, closeTo(position.maxScrollExtent, 1));
+
+    offsets.animateScroll(
+      offset: 200,
+      duration: const Duration(milliseconds: 100),
+    );
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(position.pixels, lessThanOrEqualTo(position.maxScrollExtent + 0.5));
+    expect(
+      position.pixels,
+      greaterThanOrEqualTo(position.minScrollExtent - 0.5),
+    );
+  });
+
   testWidgets('keyboardViewportOverlap is the covered portion of the viewport',
       (tester) async {
     const viewportKey = ValueKey('viewport');

--- a/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
+++ b/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy_editor/src/editor/editor_component/service/scroll_service_widget.dart';
+import 'package:appflowy_editor/src/flutter/scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -65,5 +66,96 @@ void main() {
         caret.bottom - (viewport.height - 120),
       );
     });
+
+    test('keyboard clearance is real extent only while the IME is visible', () {
+      expect(
+        keyboardBottomScrollClearance(edgeOffset: 20, keyboardInset: 0),
+        0,
+      );
+      expect(
+        keyboardBottomScrollClearance(edgeOffset: 20, keyboardInset: 300),
+        20 + appFlowyEditorKeyboardCaretGap,
+      );
+    });
+  });
+
+  testWidgets('last line reaches requested keyboard clearance', (tester) async {
+    final items = ItemScrollController();
+    final offsets = ScrollOffsetController();
+    const viewportKey = ValueKey('viewport');
+    const caretKey = ValueKey('caret');
+    const edgeOffset = 20.0;
+    final clearance = keyboardBottomScrollClearance(
+      edgeOffset: edgeOffset,
+      keyboardInset: 300,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              key: viewportKey,
+              width: 400,
+              height: 300,
+              child: ScrollablePositionedList.builder(
+                itemScrollController: items,
+                scrollOffsetController: offsets,
+                itemCount: 31,
+                itemBuilder: (_, index) {
+                  if (index == 30) {
+                    return SizedBox(height: clearance);
+                  }
+                  return SizedBox(
+                    height: 40,
+                    child: Align(
+                      alignment: Alignment.bottomLeft,
+                      child: SizedBox(
+                        key: index == 29 ? caretKey : null,
+                        width: 2,
+                        height: 20,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    items.jumpTo(index: 29);
+    await tester.pump();
+
+    double? delta() {
+      final box = tester.getRect(find.byKey(viewportKey));
+      final caret = tester.getRect(find.byKey(caretKey)).shift(-box.topLeft);
+      return computeSelectionVisibleScrollDelta(
+        localSelection: caret,
+        viewportSize: box.size,
+        edgeOffset: edgeOffset,
+        bottomEdgeOffset: clearance,
+      );
+    }
+
+    for (var attempt = 0; attempt < 3; attempt++) {
+      final distance = delta();
+      if (distance == null) {
+        break;
+      }
+      offsets.animateScroll(
+        offset: distance,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeOut,
+      );
+      await tester.pump(const Duration(milliseconds: 120));
+    }
+    expect(
+      delta(),
+      isNull,
+      reason: 'The requested ${clearance}px clearance must be reachable '
+          'at the end of the document',
+    );
   });
 }

--- a/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
+++ b/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
@@ -77,6 +77,17 @@ void main() {
         20 + appFlowyEditorKeyboardCaretGap,
       );
     });
+
+    test('keyboard clearance includes measured keyboard overlap', () {
+      expect(
+        keyboardBottomScrollClearance(
+          edgeOffset: 20,
+          keyboardInset: 300,
+          keyboardOverlap: 100,
+        ),
+        20 + appFlowyEditorKeyboardCaretGap + 100,
+      );
+    });
   });
 
   testWidgets('last line reaches requested keyboard clearance', (tester) async {
@@ -156,6 +167,126 @@ void main() {
       isNull,
       reason: 'The requested ${clearance}px clearance must be reachable '
           'at the end of the document',
+    );
+  });
+
+  testWidgets('last line reaches clearance with keyboard overlap',
+      (tester) async {
+    final items = ItemScrollController();
+    final offsets = ScrollOffsetController();
+    const viewportKey = ValueKey('viewport');
+    const caretKey = ValueKey('caret');
+    const edgeOffset = 20.0;
+    const overlap = 100.0;
+    final clearance = keyboardBottomScrollClearance(
+      edgeOffset: edgeOffset,
+      keyboardInset: 300,
+      keyboardOverlap: overlap,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              key: viewportKey,
+              width: 400,
+              height: 300,
+              child: ScrollablePositionedList.builder(
+                itemScrollController: items,
+                scrollOffsetController: offsets,
+                itemCount: 31,
+                itemBuilder: (_, index) {
+                  if (index == 30) {
+                    return SizedBox(height: clearance);
+                  }
+                  return SizedBox(
+                    height: 40,
+                    child: Align(
+                      alignment: Alignment.bottomLeft,
+                      child: SizedBox(
+                        key: index == 29 ? caretKey : null,
+                        width: 2,
+                        height: 20,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    items.jumpTo(index: 29);
+    await tester.pump();
+
+    double? delta() {
+      final box = tester.getRect(find.byKey(viewportKey));
+      final caret = tester.getRect(find.byKey(caretKey)).shift(-box.topLeft);
+      return computeSelectionVisibleScrollDelta(
+        localSelection: caret,
+        viewportSize: box.size,
+        edgeOffset: edgeOffset,
+        bottomEdgeOffset: clearance,
+      );
+    }
+
+    for (var attempt = 0; attempt < 3; attempt++) {
+      final distance = delta();
+      if (distance == null) {
+        break;
+      }
+      offsets.animateScroll(
+        offset: distance,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeOut,
+      );
+      await tester.pump(const Duration(milliseconds: 120));
+    }
+    expect(
+      delta(),
+      isNull,
+      reason: 'The requested gap plus ${overlap}px overlap must be reachable '
+          'at the end of the document',
+    );
+  });
+
+  testWidgets('keyboardViewportOverlap is the covered portion of the viewport',
+      (tester) async {
+    const viewportKey = ValueKey('viewport');
+    const screenSize = Size(800, 600);
+    tester.view.physicalSize = screenSize;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(key: viewportKey, width: 400, height: 300),
+        ),
+      ),
+    );
+    final box = tester.renderObject<RenderBox>(find.byKey(viewportKey));
+    expect(
+      keyboardViewportOverlap(
+        viewport: box,
+        screenSize: screenSize,
+        keyboardInset: 200,
+      ),
+      200,
+    );
+    expect(
+      keyboardViewportOverlap(
+        viewport: box,
+        screenSize: screenSize,
+        keyboardInset: 0,
+      ),
+      0,
     );
   });
 }

--- a/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
+++ b/test/editor/editor_component/service/selection_visible_scroll_delta_test.dart
@@ -52,5 +52,18 @@ void main() {
         isNull,
       );
     });
+
+    test('uses a larger bottom edge when the keyboard overlaps the viewport', () {
+      const caret = Rect.fromLTWH(16, 500, 2, 20);
+      expect(
+        computeSelectionVisibleScrollDelta(
+          localSelection: caret,
+          viewportSize: viewport,
+          edgeOffset: 20,
+          bottomEdgeOffset: 120,
+        ),
+        caret.bottom - (viewport.height - 120),
+      );
+    });
   });
 }


### PR DESCRIPTION
Hello,

This PR does Auto-scroll the caret back into view when the soft keyboard shrinks the editor viewport.

Essentially, the keyboard on screen was covering the text towards the bottom of the editor and required manual scrolling again.

Note: This PR was AI-Assisted

Best regards
Saif